### PR TITLE
Add client include/exclude filters for nags

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -51,5 +51,9 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public string[] AlertTranscodeReasons { get; set; } = GetDefaultAlertTranscodeReasons();
 
+    public string[] IncludedClientPatterns { get; set; } = Array.Empty<string>();
+
+    public string[] ExcludedClientPatterns { get; set; } = Array.Empty<string>();
+
     public string[] ExcludedUserIds { get; set; } = Array.Empty<string>();
 }

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -52,6 +52,23 @@
                     </div>
                     <div id="transcodeReasonList" style="margin-bottom: 20px;"></div>
 
+                    <h2>Client Filters</h2>
+                    <div class="fieldDescription" style="margin-bottom: 12px;">
+                        Match clients using case-insensitive text. If the include list is empty, all clients are eligible. Excluded matches always win.
+                    </div>
+
+                    <div class="selectContainer">
+                        <label class="inputLabel inputLabelUnfocused" for="txtIncludedClientPatterns">Only Include Matching Clients:</label>
+                        <textarea id="txtIncludedClientPatterns" name="txtIncludedClientPatterns" rows="3" class="emby-input"></textarea>
+                        <div class="fieldDescription">Optional. Enter one client match per line or comma, for example: Jellyfin Web, browser, moonfin.</div>
+                    </div>
+
+                    <div class="selectContainer">
+                        <label class="inputLabel inputLabelUnfocused" for="txtExcludedClientPatterns">Exclude Matching Clients:</label>
+                        <textarea id="txtExcludedClientPatterns" name="txtExcludedClientPatterns" rows="3" class="emby-input"></textarea>
+                        <div class="fieldDescription">Optional. Matching clients will never receive playback or login nags, and their history will not count toward login nags.</div>
+                    </div>
+
                     <h2>Login Nag Settings</h2>
 
                     <div class="checkboxContainer checkboxContainer-withDescription">
@@ -273,12 +290,80 @@
                 }
             };
 
+            var ClientPatternEditor = {
+                splitPatterns: function(value) {
+                    if (!value) {
+                        return [];
+                    }
+
+                    var seen = {};
+                    var patterns = [];
+
+                    String(value).split(/\r?\n|,/).forEach(function(part) {
+                        var pattern = String(part || '').trim();
+                        var key = pattern.toLowerCase();
+                        if (!pattern || seen[key]) {
+                            return;
+                        }
+
+                        seen[key] = true;
+                        patterns.push(pattern);
+                    });
+
+                    return patterns;
+                },
+
+                formatPatterns: function(patterns) {
+                    if (!Array.isArray(patterns)) {
+                        return '';
+                    }
+
+                    return this.splitPatterns(patterns.join('\n')).join('\n');
+                },
+
+                hasPatterns: function(patterns) {
+                    return Array.isArray(patterns) && patterns.some(function(pattern) {
+                        return String(pattern || '').trim().length > 0;
+                    });
+                },
+
+                matchesAny: function(clientName, patterns) {
+                    if (!clientName || !Array.isArray(patterns)) {
+                        return false;
+                    }
+
+                    var normalizedClient = String(clientName).toLowerCase();
+                    for (var i = 0; i < patterns.length; i++) {
+                        var pattern = String(patterns[i] || '').trim().toLowerCase();
+                        if (pattern && normalizedClient.indexOf(pattern) !== -1) {
+                            return true;
+                        }
+                    }
+
+                    return false;
+                },
+
+                isClientAllowed: function(clientName, includedPatterns, excludedPatterns) {
+                    if (this.matchesAny(clientName, excludedPatterns)) {
+                        return false;
+                    }
+
+                    if (!this.hasPatterns(includedPatterns)) {
+                        return true;
+                    }
+
+                    return this.matchesAny(clientName, includedPatterns);
+                }
+            };
+
             var LiveSessionMonitor = {
                 initialized: false,
                 refreshTimer: null,
                 selectedReasonNames: [],
                 selectedReasonMap: {},
                 excludedUserMap: {},
+                includedClientPatterns: [],
+                excludedClientPatterns: [],
 
                 init: function() {
                     if (this.initialized) {
@@ -342,6 +427,13 @@
                             LiveSessionMonitor.excludedUserMap[key] = true;
                         }
                     });
+
+                    this.includedClientPatterns = Array.isArray(config.IncludedClientPatterns)
+                        ? ClientPatternEditor.splitPatterns(config.IncludedClientPatterns.join('\n'))
+                        : [];
+                    this.excludedClientPatterns = Array.isArray(config.ExcludedClientPatterns)
+                        ? ClientPatternEditor.splitPatterns(config.ExcludedClientPatterns.join('\n'))
+                        : [];
                 },
 
                 parseReasonNames: function(rawReasons) {
@@ -441,6 +533,10 @@
 
                     var normalizedUserId = this.normalizeId(session.UserId);
                     if (normalizedUserId && this.excludedUserMap[normalizedUserId]) {
+                        return false;
+                    }
+
+                    if (!ClientPatternEditor.isClientAllowed(session.Client, this.includedClientPatterns, this.excludedClientPatterns)) {
                         return false;
                     }
 
@@ -548,6 +644,8 @@
                     document.getElementById('txtDelaySeconds').value = config.DelaySeconds || 5;
                     document.getElementById('txtMessageTimeout').value = config.MessageTimeoutMs || 10000;
                     document.getElementById('chkEnableLogging').checked = config.EnableLogging || false;
+                    document.getElementById('txtIncludedClientPatterns').value = ClientPatternEditor.formatPatterns(config.IncludedClientPatterns);
+                    document.getElementById('txtExcludedClientPatterns').value = ClientPatternEditor.formatPatterns(config.ExcludedClientPatterns);
                     document.getElementById('chkEnableLoginNag').checked = config.EnableLoginNag !== false;
                     document.getElementById('txtLoginNagThreshold').value = config.LoginNagThreshold || 5;
                     document.getElementById('selectLoginNagTimeWindow').value = config.LoginNagTimeWindow || 'Week';
@@ -568,6 +666,8 @@
                     config.DelaySeconds = parseInt(document.getElementById('txtDelaySeconds').value);
                     config.MessageTimeoutMs = parseInt(document.getElementById('txtMessageTimeout').value);
                     config.EnableLogging = document.getElementById('chkEnableLogging').checked;
+                    config.IncludedClientPatterns = ClientPatternEditor.splitPatterns(document.getElementById('txtIncludedClientPatterns').value);
+                    config.ExcludedClientPatterns = ClientPatternEditor.splitPatterns(document.getElementById('txtExcludedClientPatterns').value);
                     config.EnableLoginNag = document.getElementById('chkEnableLoginNag').checked;
                     config.LoginNagThreshold = parseInt(document.getElementById('txtLoginNagThreshold').value);
                     config.LoginNagTimeWindow = document.getElementById('selectLoginNagTimeWindow').value;

--- a/Data/TranscodeEventStore.cs
+++ b/Data/TranscodeEventStore.cs
@@ -88,7 +88,7 @@ public class TranscodeEventStore
     /// <summary>
     /// Get stats used for login/open nags.
     /// </summary>
-    public async System.Threading.Tasks.Task<UserNagStatus> GetUserNagStatusAsync(string userId, int days)
+    public async System.Threading.Tasks.Task<UserNagStatus> GetUserNagStatusAsync(string userId, int days, Func<TranscodeEvent, bool>? eventFilter = null)
     {
         await _lock.WaitAsync().ConfigureAwait(false);
         try
@@ -97,7 +97,9 @@ public class TranscodeEventStore
             var now = DateTime.UtcNow;
             var cutoff = now.AddDays(-days);
 
-            var userEvents = events.Where(e => e.UserId == userId).ToList();
+            var userEvents = events
+                .Where(e => e.UserId == userId && (eventFilter == null || eventFilter(e)))
+                .ToList();
             var recentUserEvents = userEvents.Where(e => e.Timestamp >= cutoff).ToList();
 
             var badCount = recentUserEvents.Count(e => e.Kind == NagEventKind.BadTranscode);
@@ -154,7 +156,7 @@ public class TranscodeEventStore
         }
     }
 
-    public async System.Threading.Tasks.Task<List<TranscodeEvent>> GetUserEventsAsync(string userId, int days)
+    public async System.Threading.Tasks.Task<List<TranscodeEvent>> GetUserEventsAsync(string userId, int days, Func<TranscodeEvent, bool>? eventFilter = null)
     {
         await _lock.WaitAsync().ConfigureAwait(false);
         try
@@ -163,7 +165,7 @@ public class TranscodeEventStore
             var cutoff = DateTime.UtcNow.AddDays(-days);
 
             return events
-                .Where(e => e.UserId == userId && e.Timestamp >= cutoff)
+                .Where(e => e.UserId == userId && e.Timestamp >= cutoff && (eventFilter == null || eventFilter(e)))
                 .OrderByDescending(e => e.Timestamp)
                 .ToList();
         }

--- a/PlaybackMonitor.cs
+++ b/PlaybackMonitor.cs
@@ -186,12 +186,18 @@ public class PlaybackMonitor : IHostedService
 
         var playbackKey = $"{session.Id}_{session.NowPlayingItem.Id}";
 
+        if (!IsClientAllowed(session, config, "playback nag"))
+        {
+            _naggedPlaybacks.Remove(playbackKey);
+            return;
+        }
+
         var transcodeInfo = session.TranscodingInfo;
         if (transcodeInfo == null || transcodeInfo.IsVideoDirect)
         {
             // Good playback (direct play / direct stream) - record a credit so users don't get dinged
             // on login/open nags until the next bad transcode.
-            RecordImprovementCreditIfNeeded(session);
+            RecordImprovementCreditIfNeeded(session, config);
 
             // Not transcoding - remove from nagged list if present
             _naggedPlaybacks.Remove(playbackKey);
@@ -236,6 +242,25 @@ public class PlaybackMonitor : IHostedService
 
         var userIdString = userId.Value.ToString("N");
         return Array.IndexOf(config.ExcludedUserIds, userIdString) >= 0;
+    }
+
+    private bool IsClientAllowed(SessionInfo session, Configuration.PluginConfiguration config, string context)
+    {
+        if (TranscodeNagRules.IsClientAllowed(session.Client, config))
+        {
+            return true;
+        }
+
+        if (config.EnableLogging)
+        {
+            _logger.LogInformation(
+                "Skipping {Context} for filtered client {Client} on session {SessionId}",
+                context,
+                session.Client ?? "Unknown",
+                session.Id ?? "Unknown");
+        }
+
+        return false;
     }
 
     private void SendNagMessage(SessionInfo session, Configuration.PluginConfiguration config)
@@ -318,7 +343,7 @@ public class PlaybackMonitor : IHostedService
         _eventStore.AddEvent(transcodeEvent);
     }
 
-    private void RecordImprovementCreditIfNeeded(SessionInfo session)
+    private void RecordImprovementCreditIfNeeded(SessionInfo session, Configuration.PluginConfiguration config)
     {
         if (session.UserId == Guid.Empty || session.NowPlayingItem == null)
         {
@@ -332,7 +357,10 @@ public class PlaybackMonitor : IHostedService
             // Fire-and-forget: GetUserNagStatusAsync takes a lock and reads the file.
             _ = Task.Run(async () =>
             {
-                var status = await _eventStore.GetUserNagStatusAsync(session.UserId.ToString(), 30).ConfigureAwait(false);
+                var status = await _eventStore.GetUserNagStatusAsync(
+                    session.UserId.ToString(),
+                    30,
+                    e => TranscodeNagRules.IsClientAllowed(e.Client, config)).ConfigureAwait(false);
 
                 if (!status.LastBadTranscodeUtc.HasValue)
                 {
@@ -429,11 +457,19 @@ public class PlaybackMonitor : IHostedService
             return;
         }
 
+        if (!IsClientAllowed(session, config, "login/open nag"))
+        {
+            return;
+        }
+
         var userId = session.UserId.ToString();
 
         var (days, timeWindowText) = TranscodeNagRules.ResolveLoginNagWindow(config.LoginNagTimeWindow);
 
-        var status = await _eventStore.GetUserNagStatusAsync(userId, days).ConfigureAwait(false);
+        var status = await _eventStore.GetUserNagStatusAsync(
+            userId,
+            days,
+            e => TranscodeNagRules.IsClientAllowed(e.Client, config)).ConfigureAwait(false);
 
         // Rate limit: only once per configured period.
         if (status.NaggedRecently)

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Open **Dashboard** → **Plugins** → **Transcode Nag**.
 
 - Choose which playback transcode reasons should trigger nags. Defaults focus on unsupported container, codec, subtitle, profile, level, resolution, bit depth, framerate, and related compatibility failures.
 - Set the playback message, delay, and timeout.
+- Optionally add client include/exclude filters using case-insensitive text matching. If the include list is empty, all clients are eligible; exclude matches always win.
 - If you want login nags, enable them and set the threshold, time window, and message. The login message supports `{{transcodes}}` and `{{timewindow}}`.
 - Use **Manage Excluded Users** to opt users out of both playback and login nags.
 - Use the built-in live session monitor to see which active sessions currently match your rules.

--- a/TranscodeNagRules.cs
+++ b/TranscodeNagRules.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Jellyfin.Plugin.TranscodeNag.Configuration;
 using MediaBrowser.Model.Session;
 
@@ -25,6 +26,51 @@ internal static class TranscodeNagRules
         }
 
         return reasonMask;
+    }
+
+    internal static bool HasConfiguredClientPatterns(string[]? configuredPatterns)
+    {
+        return configuredPatterns?.Any(pattern => !string.IsNullOrWhiteSpace(pattern)) == true;
+    }
+
+    internal static bool MatchesConfiguredClientPatterns(string? clientName, string[]? configuredPatterns)
+    {
+        if (string.IsNullOrWhiteSpace(clientName) || configuredPatterns == null)
+        {
+            return false;
+        }
+
+        foreach (var pattern in configuredPatterns)
+        {
+            if (string.IsNullOrWhiteSpace(pattern))
+            {
+                continue;
+            }
+
+            if (clientName.IndexOf(pattern.Trim(), StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    internal static bool IsClientAllowed(string? clientName, PluginConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (MatchesConfiguredClientPatterns(clientName, config.ExcludedClientPatterns))
+        {
+            return false;
+        }
+
+        if (!HasConfiguredClientPatterns(config.IncludedClientPatterns))
+        {
+            return true;
+        }
+
+        return MatchesConfiguredClientPatterns(clientName, config.IncludedClientPatterns);
     }
 
     internal static bool ShouldNagTranscode(TranscodingInfo transcodeInfo, PluginConfiguration config)

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/TranscodeEventStoreTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/TranscodeEventStoreTests.cs
@@ -1,4 +1,5 @@
 using Jellyfin.Plugin.TranscodeNag.Data;
+using Jellyfin.Plugin.TranscodeNag.Configuration;
 using Jellyfin.Plugin.TranscodeNag.Models;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -74,7 +75,38 @@ public class TranscodeEventStoreTests
         Assert.DoesNotContain(recentEvents, e => e.UserId == otherUserId);
     }
 
-    private static TranscodeEvent CreateEvent(string userId, NagEventKind kind, DateTime timestampUtc, string itemId)
+    [Fact]
+    public async Task GetUserNagStatusAsync_CanFilterHistoryByClientRules()
+    {
+        using var harness = new StoreHarness();
+        var userId = Guid.NewGuid().ToString();
+        var config = new PluginConfiguration
+        {
+            ExcludedClientPatterns = new[] { "android tv" }
+        };
+
+        await harness.AddEventAsync(CreateEvent(userId, NagEventKind.BadTranscode, DateTime.UtcNow.AddDays(-3), "android-bad", "Jellyfin Android TV"));
+        await harness.AddEventAsync(CreateEvent(userId, NagEventKind.BadTranscode, DateTime.UtcNow.AddDays(-2), "web-bad", "Jellyfin Web"));
+        await harness.AddEventAsync(CreateEvent(userId, NagEventKind.ImprovementCredit, DateTime.UtcNow.AddDays(-1), "android-credit", "Jellyfin Android TV"));
+        await harness.AddEventAsync(CreateEvent(userId, NagEventKind.NagSent, DateTime.UtcNow.AddHours(-12), "android-nag", "Jellyfin Android TV"));
+
+        var status = await harness.Store.GetUserNagStatusAsync(
+            userId,
+            7,
+            e => TranscodeNagRules.IsClientAllowed(e.Client, config));
+        var events = await harness.Store.GetUserEventsAsync(
+            userId,
+            7,
+            e => TranscodeNagRules.IsClientAllowed(e.Client, config));
+
+        Assert.Equal(1, status.BadTranscodeCount);
+        Assert.False(status.HasImprovementCredit);
+        Assert.False(status.NaggedRecently);
+        Assert.Single(events);
+        Assert.Equal("web-bad", events[0].ItemId);
+    }
+
+    private static TranscodeEvent CreateEvent(string userId, NagEventKind kind, DateTime timestampUtc, string itemId, string client = "xUnit")
     {
         return new TranscodeEvent
         {
@@ -84,7 +116,7 @@ public class TranscodeEventStoreTests
             ItemName = itemId,
             Timestamp = timestampUtc,
             Reasons = kind == NagEventKind.BadTranscode ? MediaBrowser.Model.Session.TranscodeReason.VideoCodecNotSupported : 0,
-            Client = "xUnit",
+            Client = client,
             Kind = kind
         };
     }

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/TranscodeNagRulesTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/TranscodeNagRulesTests.cs
@@ -64,6 +64,34 @@ public class TranscodeNagRulesTests
     }
 
     [Fact]
+    public void IsClientAllowed_AllowsAllClientsWhenIncludeListIsEmpty()
+    {
+        var config = new PluginConfiguration
+        {
+            ExcludedClientPatterns = new[] { "android tv" }
+        };
+
+        Assert.True(TranscodeNagRules.IsClientAllowed("Jellyfin Web", config));
+        Assert.False(TranscodeNagRules.IsClientAllowed("Jellyfin Android TV", config));
+    }
+
+    [Fact]
+    public void IsClientAllowed_RequiresIncludeMatchAndTreatsExcludeAsStronger()
+    {
+        var config = new PluginConfiguration
+        {
+            IncludedClientPatterns = new[] { " web ", "browser" },
+            ExcludedClientPatterns = new[] { "chrome" }
+        };
+
+        Assert.True(TranscodeNagRules.IsClientAllowed("Jellyfin Web", config));
+        Assert.True(TranscodeNagRules.IsClientAllowed("Firefox Browser", config));
+        Assert.False(TranscodeNagRules.IsClientAllowed("Jellyfin Android TV", config));
+        Assert.False(TranscodeNagRules.IsClientAllowed("Chrome Web", config));
+        Assert.False(TranscodeNagRules.IsClientAllowed(null, config));
+    }
+
+    [Fact]
     public void ResolveLoginNagWindow_MapsMonthAndFallsBackToWeek()
     {
         Assert.Equal((30, "month"), TranscodeNagRules.ResolveLoginNagWindow("Month"));


### PR DESCRIPTION
## Summary
- add configurable client include/exclude text matching to the plugin settings page
- apply the same client filter to playback nags, login nags, live-session matching, and stored history used for login nag counts
- add tests covering client filter rules and filtered history behavior

## Verification
- dotnet build --configuration Release
- dotnet format whitespace --verify-no-changes
- dotnet format style --verify-no-changes --severity warn
- /tmp/dotnet-sdk-10/dotnet test tests/Jellyfin.Plugin.TranscodeNag.Tests/Jellyfin.Plugin.TranscodeNag.Tests.csproj --configuration Release

Closes #10