### PR TITLE
feat: add Live TV exclusion setting

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -45,6 +45,8 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public int LoginNagThreshold { get; set; } = 5;
 
+    public bool ExcludeLiveTv { get; set; } = false;
+
     public string LoginNagTimeWindow { get; set; } = "Week";
 
     public string LoginNagMessage { get; set; } = "You've transcoded {{transcodes}} videos in the last {{timewindow}} due to unsupported formats. Consider switching to mpv, VLC, or Jellyfin Media Player to improve quality and reduce server load!";

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -35,6 +35,14 @@
                         <div class="fieldDescription checkboxFieldDescription">Log when nag messages are sent (helpful for debugging).</div>
                     </div>
 
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input type="checkbox" is="emby-checkbox" id="chkExcludeLiveTv" name="chkExcludeLiveTv" />
+                            <span>Exclude Live TV</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">Do not nag Live TV channel playback or count it toward login nags.</div>
+                    </div>
+
                     <h2>Playback Trigger Reasons</h2>
                     <div class="fieldDescription" style="margin-bottom: 12px;">
                         Select which transcoding reasons should trigger nag events. These choices apply to both playback nags and login nag history.
@@ -447,6 +455,7 @@
                 excludedUserMap: {},
                 includedClientPatterns: [],
                 excludedClientPatterns: [],
+                excludeLiveTv: false,
 
                 init: function() {
                     if (this.initialized) {
@@ -517,6 +526,23 @@
                     this.excludedClientPatterns = Array.isArray(config.ExcludedClientPatterns)
                         ? ClientPatternEditor.splitPatterns(config.ExcludedClientPatterns.join('\n'))
                         : [];
+                    this.excludeLiveTv = config.ExcludeLiveTv === true;
+                },
+
+                isLiveTvItem: function(item) {
+                    if (!item) {
+                        return false;
+                    }
+
+                    if (item.IsLive === true || item.isLive === true) {
+                        return true;
+                    }
+
+                    var itemType = String(item.Type || item.type || '').toLowerCase();
+                    return itemType === 'tvchannel'
+                        || itemType === 'tvprogram'
+                        || itemType === 'livetvchannel'
+                        || itemType === 'livetvprogram';
                 },
 
                 parseReasonNames: function(rawReasons) {
@@ -611,6 +637,10 @@
                     }
 
                     if (session.TranscodingInfo.IsVideoDirect === true) {
+                        return false;
+                    }
+
+                    if (this.excludeLiveTv && this.isLiveTvItem(session.NowPlayingItem)) {
                         return false;
                     }
 
@@ -727,6 +757,7 @@
                     document.getElementById('txtDelaySeconds').value = config.DelaySeconds || 5;
                     document.getElementById('txtMessageTimeout').value = config.MessageTimeoutMs || 10000;
                     document.getElementById('chkEnableLogging').checked = config.EnableLogging || false;
+                    document.getElementById('chkExcludeLiveTv').checked = config.ExcludeLiveTv === true;
                     document.getElementById('txtIncludedClientPatterns').value = ClientPatternEditor.formatPatterns(config.IncludedClientPatterns);
                     document.getElementById('txtExcludedClientPatterns').value = ClientPatternEditor.formatPatterns(config.ExcludedClientPatterns);
                     document.getElementById('chkEnableLoginNag').checked = config.EnableLoginNag !== false;
@@ -749,6 +780,7 @@
                     config.DelaySeconds = parseInt(document.getElementById('txtDelaySeconds').value);
                     config.MessageTimeoutMs = parseInt(document.getElementById('txtMessageTimeout').value);
                     config.EnableLogging = document.getElementById('chkEnableLogging').checked;
+                    config.ExcludeLiveTv = document.getElementById('chkExcludeLiveTv').checked;
                     config.IncludedClientPatterns = ClientPatternEditor.splitPatterns(document.getElementById('txtIncludedClientPatterns').value);
                     config.ExcludedClientPatterns = ClientPatternEditor.splitPatterns(document.getElementById('txtExcludedClientPatterns').value);
                     config.EnableLoginNag = document.getElementById('chkEnableLoginNag').checked;

--- a/Models/TranscodeEvent.cs
+++ b/Models/TranscodeEvent.cs
@@ -19,6 +19,8 @@ public class TranscodeEvent
 
     public string Client { get; set; } = string.Empty;
 
+    public bool IsLiveTv { get; set; }
+
     /// <summary>
     /// What kind of event this is.
     /// </summary>

--- a/PlaybackMonitor.cs
+++ b/PlaybackMonitor.cs
@@ -189,6 +189,12 @@ public class PlaybackMonitor : IHostedService
 
             var playbackKey = $"{session.Id}_{session.NowPlayingItem.Id}";
 
+            if (!IsItemAllowed(session, config, "playback nag"))
+            {
+                _naggedPlaybacks.Remove(playbackKey);
+                return;
+            }
+
             if (!IsClientAllowed(session, config, "playback nag"))
             {
                 _naggedPlaybacks.Remove(playbackKey);
@@ -250,6 +256,26 @@ public class PlaybackMonitor : IHostedService
 
         var userIdString = userId.Value.ToString("N");
         return Array.IndexOf(config.ExcludedUserIds, userIdString) >= 0;
+    }
+
+    private bool IsItemAllowed(SessionInfo session, Configuration.PluginConfiguration config, string context)
+    {
+        if (TranscodeNagRules.IsItemAllowed(session.NowPlayingItem, config))
+        {
+            return true;
+        }
+
+        if (config.EnableLogging)
+        {
+            _logger.LogInformation(
+                "Skipping {Context} for excluded Live TV item {ItemName} ({ItemId}) on session {SessionId}",
+                context,
+                session.NowPlayingItem?.Name ?? "Unknown",
+                session.NowPlayingItem?.Id.ToString() ?? "Unknown",
+                session.Id ?? "Unknown");
+        }
+
+        return false;
     }
 
     private bool IsClientAllowed(SessionInfo session, Configuration.PluginConfiguration config, string context)
@@ -486,6 +512,7 @@ public class PlaybackMonitor : IHostedService
             Timestamp = DateTime.UtcNow,
             Reasons = transcodeInfo.TranscodeReasons,
             Client = session.Client ?? "Unknown",
+            IsLiveTv = TranscodeNagRules.IsLiveTvItem(session.NowPlayingItem),
             Kind = NagEventKind.BadTranscode
         };
 
@@ -509,7 +536,7 @@ public class PlaybackMonitor : IHostedService
                 var status = await _eventStore.GetUserNagStatusAsync(
                     session.UserId.ToString(),
                     30,
-                    e => TranscodeNagRules.IsClientAllowed(e.Client, config)).ConfigureAwait(false);
+                    e => TranscodeNagRules.IsStoredEventAllowed(e, config)).ConfigureAwait(false);
 
                 if (!status.LastBadTranscodeUtc.HasValue)
                 {
@@ -531,6 +558,7 @@ public class PlaybackMonitor : IHostedService
                     Timestamp = DateTime.UtcNow,
                     Reasons = 0,
                     Client = session.Client ?? "Unknown",
+                    IsLiveTv = TranscodeNagRules.IsLiveTvItem(session.NowPlayingItem),
                     Kind = NagEventKind.ImprovementCredit
                 };
 
@@ -618,7 +646,7 @@ public class PlaybackMonitor : IHostedService
         var status = await _eventStore.GetUserNagStatusAsync(
             userId,
             days,
-            e => TranscodeNagRules.IsClientAllowed(e.Client, config)).ConfigureAwait(false);
+            e => TranscodeNagRules.IsStoredEventAllowed(e, config)).ConfigureAwait(false);
 
         // Rate limit: only once per configured period.
         if (status.NaggedRecently)

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A Jellyfin plugin that intelligently nags users when they're transcoding due to 
 
 - Sends a playback nag when Jellyfin reports selected `TranscodeReasons`.
 - Ignores bitrate-only transcodes, so users lowering quality for bandwidth do not get warned.
+- Can exclude Live TV channel streams from playback nags and login nag history.
 - Can send a login nag when a user keeps hitting bad transcodes over the last week or month.
 - Lets you exclude users from all nags.
 - Includes a live session monitor in the plugin settings page.
@@ -78,6 +79,7 @@ Open **Dashboard** → **Plugins** → **Transcode Nag**.
 
 - Choose which playback transcode reasons should trigger nags. Defaults focus on unsupported container, codec, subtitle, profile, level, resolution, bit depth, framerate, and related compatibility failures.
 - Set the playback message, delay, and timeout.
+- Enable **Exclude Live TV** if Live TV channel streams should not trigger playback nags or count toward login nags.
 - Optionally add client include/exclude filters using case-insensitive text matching. If the include list is empty, all clients are eligible; exclude matches always win.
 - If you want login nags, enable them and set the threshold, time window, and message. The login message supports `{{transcodes}}` and `{{timewindow}}`.
 - Use **Manage Excluded Users** to opt users out of both playback and login nags.

--- a/TranscodeNagRules.cs
+++ b/TranscodeNagRules.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Linq;
+using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.TranscodeNag.Configuration;
+using Jellyfin.Plugin.TranscodeNag.Models;
+using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Session;
 
 namespace Jellyfin.Plugin.TranscodeNag;
@@ -71,6 +74,40 @@ internal static class TranscodeNagRules
         }
 
         return MatchesConfiguredClientPatterns(clientName, config.IncludedClientPatterns);
+    }
+
+    internal static bool IsLiveTvItem(BaseItemDto? item)
+    {
+        if (item == null)
+        {
+            return false;
+        }
+
+        if (item.IsLive == true)
+        {
+            return true;
+        }
+
+        return item.Type == BaseItemKind.TvChannel
+            || item.Type == BaseItemKind.TvProgram
+            || item.Type == BaseItemKind.LiveTvChannel
+            || item.Type == BaseItemKind.LiveTvProgram;
+    }
+
+    internal static bool IsItemAllowed(BaseItemDto? item, PluginConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        return !config.ExcludeLiveTv || !IsLiveTvItem(item);
+    }
+
+    internal static bool IsStoredEventAllowed(TranscodeEvent transcodeEvent, PluginConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(transcodeEvent);
+        ArgumentNullException.ThrowIfNull(config);
+
+        return IsClientAllowed(transcodeEvent.Client, config)
+            && (!config.ExcludeLiveTv || !transcodeEvent.IsLiveTv);
     }
 
     internal static bool ShouldNagTranscode(TranscodingInfo transcodeInfo, PluginConfiguration config)

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/TranscodeEventStoreTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/TranscodeEventStoreTests.cs
@@ -106,7 +106,38 @@ public class TranscodeEventStoreTests
         Assert.Equal("web-bad", events[0].ItemId);
     }
 
-    private static TranscodeEvent CreateEvent(string userId, NagEventKind kind, DateTime timestampUtc, string itemId, string client = "xUnit")
+    [Fact]
+    public async Task GetUserNagStatusAsync_CanFilterHistoryByLiveTvSetting()
+    {
+        using var harness = new StoreHarness();
+        var userId = Guid.NewGuid().ToString();
+        var config = new PluginConfiguration
+        {
+            ExcludeLiveTv = true
+        };
+
+        await harness.AddEventAsync(CreateEvent(userId, NagEventKind.BadTranscode, DateTime.UtcNow.AddDays(-4), "live-bad", isLiveTv: true));
+        await harness.AddEventAsync(CreateEvent(userId, NagEventKind.BadTranscode, DateTime.UtcNow.AddDays(-3), "movie-bad"));
+        await harness.AddEventAsync(CreateEvent(userId, NagEventKind.ImprovementCredit, DateTime.UtcNow.AddDays(-2), "live-credit", isLiveTv: true));
+        await harness.AddEventAsync(CreateEvent(userId, NagEventKind.NagSent, DateTime.UtcNow.AddDays(-1), "live-nag", isLiveTv: true));
+
+        var status = await harness.Store.GetUserNagStatusAsync(
+            userId,
+            7,
+            e => TranscodeNagRules.IsStoredEventAllowed(e, config));
+        var events = await harness.Store.GetUserEventsAsync(
+            userId,
+            7,
+            e => TranscodeNagRules.IsStoredEventAllowed(e, config));
+
+        Assert.Equal(1, status.BadTranscodeCount);
+        Assert.False(status.HasImprovementCredit);
+        Assert.False(status.NaggedRecently);
+        Assert.Single(events);
+        Assert.Equal("movie-bad", events[0].ItemId);
+    }
+
+    private static TranscodeEvent CreateEvent(string userId, NagEventKind kind, DateTime timestampUtc, string itemId, string client = "xUnit", bool isLiveTv = false)
     {
         return new TranscodeEvent
         {
@@ -117,6 +148,7 @@ public class TranscodeEventStoreTests
             Timestamp = timestampUtc,
             Reasons = kind == NagEventKind.BadTranscode ? MediaBrowser.Model.Session.TranscodeReason.VideoCodecNotSupported : 0,
             Client = client,
+            IsLiveTv = isLiveTv,
             Kind = kind
         };
     }

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/TranscodeNagRulesTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/TranscodeNagRulesTests.cs
@@ -1,4 +1,7 @@
+using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.TranscodeNag.Configuration;
+using Jellyfin.Plugin.TranscodeNag.Models;
+using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Session;
 
 namespace Jellyfin.Plugin.TranscodeNag.Tests;
@@ -89,6 +92,51 @@ public class TranscodeNagRulesTests
         Assert.False(TranscodeNagRules.IsClientAllowed("Jellyfin Android TV", config));
         Assert.False(TranscodeNagRules.IsClientAllowed("Chrome Web", config));
         Assert.False(TranscodeNagRules.IsClientAllowed(null, config));
+    }
+
+    [Fact]
+    public void IsLiveTvItem_DetectsLiveAndLiveTvItemTypes()
+    {
+        Assert.True(TranscodeNagRules.IsLiveTvItem(new BaseItemDto { IsLive = true, Type = BaseItemKind.Movie }));
+        Assert.True(TranscodeNagRules.IsLiveTvItem(new BaseItemDto { Type = BaseItemKind.TvChannel }));
+        Assert.True(TranscodeNagRules.IsLiveTvItem(new BaseItemDto { Type = BaseItemKind.LiveTvProgram }));
+        Assert.True(TranscodeNagRules.IsLiveTvItem(new BaseItemDto { Type = BaseItemKind.TvProgram }));
+        Assert.False(TranscodeNagRules.IsLiveTvItem(new BaseItemDto { Type = BaseItemKind.Movie }));
+        Assert.False(TranscodeNagRules.IsLiveTvItem(null));
+    }
+
+    [Fact]
+    public void IsItemAllowed_UsesLiveTvExclusionSetting()
+    {
+        var liveTvItem = new BaseItemDto { Type = BaseItemKind.TvChannel };
+
+        Assert.True(TranscodeNagRules.IsItemAllowed(liveTvItem, new PluginConfiguration()));
+        Assert.False(TranscodeNagRules.IsItemAllowed(
+            liveTvItem,
+            new PluginConfiguration { ExcludeLiveTv = true }));
+        Assert.True(TranscodeNagRules.IsItemAllowed(
+            new BaseItemDto { Type = BaseItemKind.Movie },
+            new PluginConfiguration { ExcludeLiveTv = true }));
+    }
+
+    [Fact]
+    public void IsStoredEventAllowed_AppliesClientAndLiveTvFilters()
+    {
+        var config = new PluginConfiguration
+        {
+            ExcludeLiveTv = true,
+            ExcludedClientPatterns = new[] { "android tv" }
+        };
+
+        Assert.True(TranscodeNagRules.IsStoredEventAllowed(
+            new TranscodeEvent { Client = "Jellyfin Web" },
+            config));
+        Assert.False(TranscodeNagRules.IsStoredEventAllowed(
+            new TranscodeEvent { Client = "Jellyfin Web", IsLiveTv = true },
+            config));
+        Assert.False(TranscodeNagRules.IsStoredEventAllowed(
+            new TranscodeEvent { Client = "Jellyfin Android TV" },
+            config));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add an Exclude Live TV plugin setting and dashboard checkbox
- skip Live TV playback nags and mark playback history with Live TV metadata
- filter login nag history and live session monitor results when Live TV is excluded

## Tests
- dotnet build --configuration Release
- dotnet test tests/Jellyfin.Plugin.TranscodeNag.Tests/Jellyfin.Plugin.TranscodeNag.Tests.csproj --configuration Release -p:TargetFrameworks=net9.0 -p:TargetFramework=net9.0 --no-restore
- dotnet format whitespace --verify-no-changes
- dotnet format style --verify-no-changes --severity warn

Note: test target was temporarily overridden to net9.0 because this machine has Microsoft.AspNetCore.App 9.0 installed, but not the test project default 10.0 runtime.