### PR TITLE
feat: add Message of the Day

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -60,6 +60,16 @@ public class PluginConfiguration : BasePluginConfiguration
     public string[] ExcludedClientPatterns { get; set; } = Array.Empty<string>();
 
     public string[] ExcludedUserIds { get; set; } = Array.Empty<string>();
+
+    public bool EnableMotd { get; set; } = false;
+
+    public string MotdMessage { get; set; } = "Welcome back! Check the announcements channel for server news and planned maintenance.";
+
+    public string[] MotdExcludedUserIds { get; set; } = Array.Empty<string>();
+
+    public string[] MotdIncludedClientPatterns { get; set; } = Array.Empty<string>();
+
+    public string[] MotdExcludedClientPatterns { get; set; } = Array.Empty<string>();
 }
 
 public class ReasonMessageOverride

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -134,6 +134,49 @@
                     <div id="liveSettingsWarning" class="fieldDescription" style="margin-bottom: 12px;"></div>
                     <div id="liveSettingsSessionList" style="margin-bottom: 20px;"></div>
 
+                    <h2>Message of the Day</h2>
+                    <div class="fieldDescription" style="margin-bottom: 12px;">
+                        Send a message to everyone when they log in. This is independent of transcoding and has its own exclusions and client filters.
+                    </div>
+
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input type="checkbox" is="emby-checkbox" id="chkEnableMotd" name="chkEnableMotd" />
+                            <span>Enable Message of the Day</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">Off by default. When on, every matching user receives the MOTD once per session at login. Sessions that are already signed in do not get it until they sign in again.</div>
+                    </div>
+
+                    <div id="motdOptions" style="display: none;">
+                        <div class="selectContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtMotdMessage">MOTD Message:</label>
+                            <textarea id="txtMotdMessage" name="txtMotdMessage" rows="4" class="emby-input"></textarea>
+                            <div class="fieldDescription">Message shown at login. Uses the same message timeout as nag messages.</div>
+                        </div>
+
+                        <div class="fieldDescription" style="margin-bottom: 10px;">
+                            Exclude specific users from the MOTD. This list is separate from the nag exclusion list.
+                        </div>
+
+                        <div style="margin-bottom: 20px;">
+                            <button is="emby-button" type="button" id="btnManageMotdExclusions" class="raised block emby-button">
+                                <span>Manage Excluded Users (MOTD)</span>
+                            </button>
+                        </div>
+
+                        <div class="selectContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtMotdIncludedClientPatterns">Only Include Matching Clients (MOTD):</label>
+                            <textarea id="txtMotdIncludedClientPatterns" name="txtMotdIncludedClientPatterns" rows="3" class="emby-input"></textarea>
+                            <div class="fieldDescription">Optional. If empty, all clients receive the MOTD. Enter one client match per line or comma.</div>
+                        </div>
+
+                        <div class="selectContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtMotdExcludedClientPatterns">Exclude Matching Clients (MOTD):</label>
+                            <textarea id="txtMotdExcludedClientPatterns" name="txtMotdExcludedClientPatterns" rows="3" class="emby-input"></textarea>
+                            <div class="fieldDescription">Optional. Matching clients never receive the MOTD. Excluded matches always win over includes.</div>
+                        </div>
+                    </div>
+
                     <div>
                         <button is="emby-button" type="submit" class="raised button-submit block">
                             <span>Save</span>
@@ -168,6 +211,38 @@
                             <span>Save</span>
                         </button>
                         <button is="emby-button" type="button" id="btnCancelExclusions" class="raised">
+                            <span>Cancel</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- MOTD User Exclusion Modal -->
+            <div id="motdUserExclusionModal" style="display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.7); z-index: 1000; overflow-y: auto;">
+                <div style="background: var(--theme-background-content); margin: 50px auto; max-width: 600px; padding: 20px; border-radius: 4px;">
+                    <h2>Select Users to Exclude from MOTD</h2>
+                    <div class="fieldDescription" style="margin-bottom: 15px;">
+                        By default, all users receive the MOTD. Uncheck users to exclude them from the MOTD only.
+                    </div>
+                    <div style="display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 12px;">
+                        <button is="emby-button" type="button" id="btnMotdUsersSelectAll" class="raised">
+                            <span>Select All</span>
+                        </button>
+                        <button is="emby-button" type="button" id="btnMotdUsersResetDefaults" class="raised">
+                            <span>Reset Defaults</span>
+                        </button>
+                        <button is="emby-button" type="button" id="btnMotdUsersClearAll" class="raised">
+                            <span>Clear All</span>
+                        </button>
+                    </div>
+                    <div id="motdUserExclusionList" style="max-height: 400px; overflow-y: auto; margin-bottom: 20px;">
+                        <!-- User checkboxes will be populated here -->
+                    </div>
+                    <div style="display: flex; gap: 10px;">
+                        <button is="emby-button" type="button" id="btnSaveMotdExclusions" class="raised button-submit">
+                            <span>Save</span>
+                        </button>
+                        <button is="emby-button" type="button" id="btnCancelMotdExclusions" class="raised">
                             <span>Cancel</span>
                         </button>
                     </div>
@@ -444,6 +519,25 @@
                     }
 
                     return this.matchesAny(clientName, includedPatterns);
+                }
+            };
+
+            // Keeps the MOTD block collapsed unless the feature is switched on.
+            var MotdSection = {
+                initialized: false,
+
+                init: function() {
+                    if (this.initialized) {
+                        return;
+                    }
+
+                    document.getElementById('chkEnableMotd').addEventListener('change', this.updateVisibility);
+                    this.initialized = true;
+                },
+
+                updateVisibility: function() {
+                    var enabled = document.getElementById('chkEnableMotd').checked;
+                    document.getElementById('motdOptions').style.display = enabled ? 'block' : 'none';
                 }
             };
 
@@ -752,6 +846,8 @@
                 ReasonSelector.init();
                 LiveSessionMonitor.init();
                 UserExclusionManager.init();
+                MotdUserExclusionManager.init();
+                MotdSection.init();
                 ApiClient.getPluginConfiguration(TranscodeNagConfig.pluginId).then(function (config) {
                     document.getElementById('txtNagMessage').value = config.NagMessage || '';
                     document.getElementById('txtDelaySeconds').value = config.DelaySeconds || 5;
@@ -764,6 +860,11 @@
                     document.getElementById('txtLoginNagThreshold').value = config.LoginNagThreshold || 5;
                     document.getElementById('selectLoginNagTimeWindow').value = config.LoginNagTimeWindow || 'Week';
                     document.getElementById('txtLoginNagMessage').value = config.LoginNagMessage || '';
+                    document.getElementById('chkEnableMotd').checked = config.EnableMotd === true;
+                    document.getElementById('txtMotdMessage').value = config.MotdMessage || '';
+                    document.getElementById('txtMotdIncludedClientPatterns').value = ClientPatternEditor.formatPatterns(config.MotdIncludedClientPatterns);
+                    document.getElementById('txtMotdExcludedClientPatterns').value = ClientPatternEditor.formatPatterns(config.MotdExcludedClientPatterns);
+                    MotdSection.updateVisibility();
                     ReasonSelector.render(config.AlertTranscodeReasons, config.ReasonMessageOverrides);
                     LiveSessionMonitor.refresh(false, config);
                     LiveSessionMonitor.startRefreshTimer();
@@ -787,6 +888,10 @@
                     config.LoginNagThreshold = parseInt(document.getElementById('txtLoginNagThreshold').value);
                     config.LoginNagTimeWindow = document.getElementById('selectLoginNagTimeWindow').value;
                     config.LoginNagMessage = document.getElementById('txtLoginNagMessage').value;
+                    config.EnableMotd = document.getElementById('chkEnableMotd').checked;
+                    config.MotdMessage = document.getElementById('txtMotdMessage').value;
+                    config.MotdIncludedClientPatterns = ClientPatternEditor.splitPatterns(document.getElementById('txtMotdIncludedClientPatterns').value);
+                    config.MotdExcludedClientPatterns = ClientPatternEditor.splitPatterns(document.getElementById('txtMotdExcludedClientPatterns').value);
                     config.AlertTranscodeReasons = ReasonSelector.getSelectedReasonNames();
                     config.ReasonMessageOverrides = ReasonSelector.getReasonMessageOverrides();
 
@@ -798,120 +903,166 @@
                 return false;
             });
 
-            // User Exclusion Management
-            var UserExclusionManager = {
-                initialized: false,
-                allUsers: [],
-                excludedUserIds: [],
+            // User Exclusion Management.
+            // One instance per exclusion list (nag messages and MOTD keep separate lists).
+            function createUserExclusionManager(options) {
+                return {
+                    initialized: false,
+                    allUsers: [],
+                    excludedUserIds: [],
+                    options: options,
 
-                init: function() {
-                    if (this.initialized) {
-                        return;
-                    }
+                    init: function() {
+                        if (this.initialized) {
+                            return;
+                        }
 
-                    document.getElementById('btnManageExclusions').addEventListener('click', this.openModal.bind(this));
-                    document.getElementById('btnSaveExclusions').addEventListener('click', this.saveExclusions.bind(this));
-                    document.getElementById('btnCancelExclusions').addEventListener('click', this.closeModal.bind(this));
-                    document.getElementById('btnUsersSelectAll').addEventListener('click', this.selectAllUsers.bind(this));
-                    document.getElementById('btnUsersResetDefaults').addEventListener('click', this.resetUserDefaults.bind(this));
-                    document.getElementById('btnUsersClearAll').addEventListener('click', this.clearAllUsers.bind(this));
-                    this.initialized = true;
-                },
+                        document.getElementById(options.openButtonId).addEventListener('click', this.openModal.bind(this));
+                        document.getElementById(options.saveButtonId).addEventListener('click', this.saveExclusions.bind(this));
+                        document.getElementById(options.cancelButtonId).addEventListener('click', this.closeModal.bind(this));
+                        document.getElementById(options.selectAllButtonId).addEventListener('click', this.selectAllUsers.bind(this));
+                        document.getElementById(options.resetButtonId).addEventListener('click', this.resetUserDefaults.bind(this));
+                        document.getElementById(options.clearAllButtonId).addEventListener('click', this.clearAllUsers.bind(this));
+                        this.initialized = true;
+                    },
 
-                openModal: function() {
-                    Dashboard.showLoadingMsg();
+                    openModal: function() {
+                        var manager = this;
+                        Dashboard.showLoadingMsg();
 
-                    // Fetch current exclusion list from config
-                    ApiClient.getPluginConfiguration(TranscodeNagConfig.pluginId).then(function(config) {
-                        UserExclusionManager.excludedUserIds = config.ExcludedUserIds || [];
+                        // Fetch current exclusion list from config
+                        ApiClient.getPluginConfiguration(TranscodeNagConfig.pluginId).then(function(config) {
+                            manager.excludedUserIds = config[options.configProperty] || [];
 
-                        // Fetch all users from Jellyfin
-                        ApiClient.getUsers().then(function(users) {
-                            UserExclusionManager.allUsers = users;
-                            UserExclusionManager.renderUserList();
-                            document.getElementById('userExclusionModal').style.display = 'block';
+                            // Fetch all users from Jellyfin
+                            return ApiClient.getUsers();
+                        }).then(function(users) {
+                            manager.allUsers = users;
+                            manager.renderUserList();
+                            document.getElementById(options.modalId).style.display = 'block';
                             Dashboard.hideLoadingMsg();
                         }).catch(function(error) {
-                            console.error('Error fetching users:', error);
+                            console.error('Error loading user exclusions:', error);
                             Dashboard.alert('Failed to load users. Check console for details.');
                             Dashboard.hideLoadingMsg();
                         });
-                    });
-                },
+                    },
 
-                closeModal: function() {
-                    document.getElementById('userExclusionModal').style.display = 'none';
-                },
+                    closeModal: function() {
+                        document.getElementById(options.modalId).style.display = 'none';
+                    },
 
-                renderUserList: function() {
-                    var listHtml = '';
+                    renderUserList: function() {
+                        var listHtml = '';
+                        var excludedUserMap = {};
 
-                    this.allUsers.forEach(function(user) {
-                        var userId = user.Id;
-                        var userName = user.Name;
-                        var isIncluded = UserExclusionManager.excludedUserIds.indexOf(userId) === -1;
+                        this.excludedUserIds.forEach(function(userId) {
+                            var key = LiveSessionMonitor.normalizeId(userId);
+                            if (key) {
+                                excludedUserMap[key] = true;
+                            }
+                        });
 
-                        listHtml += '<div class="checkboxContainer" style="margin-bottom: 10px;">';
-                        listHtml += '<label>';
-                        listHtml += '<input type="checkbox" is="emby-checkbox" data-user-id="' + userId + '" ' + (isIncluded ? 'checked' : '') + ' />';
-                        listHtml += '<span>' + userName + '</span>';
-                        listHtml += '</label>';
-                        listHtml += '</div>';
-                    });
+                        this.allUsers.forEach(function(user) {
+                            var userId = user.Id;
+                            var userName = user.Name;
+                            var isIncluded = !excludedUserMap[LiveSessionMonitor.normalizeId(userId)];
 
-                    document.getElementById('userExclusionList').innerHTML = listHtml;
-                },
+                            listHtml += '<div class="checkboxContainer" style="margin-bottom: 10px;">';
+                            listHtml += '<label>';
+                            listHtml += '<input type="checkbox" is="emby-checkbox" data-user-id="' + escapeHtml(userId) + '" ' + (isIncluded ? 'checked' : '') + ' />';
+                            listHtml += '<span>' + escapeHtml(userName) + '</span>';
+                            listHtml += '</label>';
+                            listHtml += '</div>';
+                        });
 
-                selectAllUsers: function() {
-                    var checkboxes = document.querySelectorAll('#userExclusionList input[type="checkbox"]');
-                    checkboxes.forEach(function(checkbox) {
-                        checkbox.checked = true;
-                    });
-                },
+                        document.getElementById(options.listId).innerHTML = listHtml;
+                    },
 
-                resetUserDefaults: function() {
-                    this.selectAllUsers();
-                },
+                    selectAllUsers: function() {
+                        var checkboxes = document.querySelectorAll('#' + options.listId + ' input[type="checkbox"]');
+                        checkboxes.forEach(function(checkbox) {
+                            checkbox.checked = true;
+                        });
+                    },
 
-                clearAllUsers: function() {
-                    var checkboxes = document.querySelectorAll('#userExclusionList input[type="checkbox"]');
-                    checkboxes.forEach(function(checkbox) {
-                        checkbox.checked = false;
-                    });
-                },
+                    resetUserDefaults: function() {
+                        this.selectAllUsers();
+                    },
 
-                saveExclusions: function() {
-                    Dashboard.showLoadingMsg();
+                    clearAllUsers: function() {
+                        var checkboxes = document.querySelectorAll('#' + options.listId + ' input[type="checkbox"]');
+                        checkboxes.forEach(function(checkbox) {
+                            checkbox.checked = false;
+                        });
+                    },
 
-                    // Collect unchecked users (excluded users)
-                    var checkboxes = document.querySelectorAll('#userExclusionList input[type="checkbox"]');
-                    var newExcludedUserIds = [];
+                    saveExclusions: function() {
+                        var manager = this;
+                        Dashboard.showLoadingMsg();
 
-                    checkboxes.forEach(function(checkbox) {
-                        if (!checkbox.checked) {
-                            newExcludedUserIds.push(checkbox.getAttribute('data-user-id'));
-                        }
-                    });
+                        // Collect unchecked users (excluded users)
+                        var checkboxes = document.querySelectorAll('#' + options.listId + ' input[type="checkbox"]');
+                        var newExcludedUserIds = [];
 
-                    // Update configuration
-                    ApiClient.getPluginConfiguration(TranscodeNagConfig.pluginId).then(function(config) {
-                        config.ExcludedUserIds = newExcludedUserIds;
+                        checkboxes.forEach(function(checkbox) {
+                            if (!checkbox.checked) {
+                                newExcludedUserIds.push(checkbox.getAttribute('data-user-id'));
+                            }
+                        });
 
-                        ApiClient.updatePluginConfiguration(TranscodeNagConfig.pluginId, config).then(function(result) {
-                            UserExclusionManager.excludedUserIds = newExcludedUserIds;
-                            UserExclusionManager.closeModal();
+                        // Update configuration
+                        ApiClient.getPluginConfiguration(TranscodeNagConfig.pluginId).then(function(config) {
+                            config[options.configProperty] = newExcludedUserIds;
+
+                            return ApiClient.updatePluginConfiguration(TranscodeNagConfig.pluginId, config);
+                        }).then(function() {
+                            manager.excludedUserIds = newExcludedUserIds;
+                            manager.closeModal();
                             Dashboard.hideLoadingMsg();
 
                             // Show a subtle notification
                             if (newExcludedUserIds.length === 0) {
-                                Dashboard.alert('All users are now included in nag messages.');
+                                Dashboard.alert(options.allIncludedMessage);
                             } else {
-                                Dashboard.alert(newExcludedUserIds.length + ' user(s) excluded from nag messages.');
+                                Dashboard.alert(newExcludedUserIds.length + options.excludedMessageSuffix);
                             }
+                        }).catch(function(error) {
+                            console.error('Error saving user exclusions:', error);
+                            Dashboard.alert('Failed to save user exclusions. Check console for details.');
+                            Dashboard.hideLoadingMsg();
                         });
-                    });
-                }
-            };
+                    }
+                };
+            }
+
+            var UserExclusionManager = createUserExclusionManager({
+                modalId: 'userExclusionModal',
+                listId: 'userExclusionList',
+                openButtonId: 'btnManageExclusions',
+                saveButtonId: 'btnSaveExclusions',
+                cancelButtonId: 'btnCancelExclusions',
+                selectAllButtonId: 'btnUsersSelectAll',
+                resetButtonId: 'btnUsersResetDefaults',
+                clearAllButtonId: 'btnUsersClearAll',
+                configProperty: 'ExcludedUserIds',
+                allIncludedMessage: 'All users are now included in nag messages.',
+                excludedMessageSuffix: ' user(s) excluded from nag messages.'
+            });
+
+            var MotdUserExclusionManager = createUserExclusionManager({
+                modalId: 'motdUserExclusionModal',
+                listId: 'motdUserExclusionList',
+                openButtonId: 'btnManageMotdExclusions',
+                saveButtonId: 'btnSaveMotdExclusions',
+                cancelButtonId: 'btnCancelMotdExclusions',
+                selectAllButtonId: 'btnMotdUsersSelectAll',
+                resetButtonId: 'btnMotdUsersResetDefaults',
+                clearAllButtonId: 'btnMotdUsersClearAll',
+                configProperty: 'MotdExcludedUserIds',
+                allIncludedMessage: 'All users will now receive the MOTD.',
+                excludedMessageSuffix: ' user(s) excluded from the MOTD.'
+            });
 
             document.getElementById('TranscodeNagConfigPage').addEventListener('pagehide', function() {
                 LiveSessionMonitor.stopRefreshTimer();

--- a/PlaybackMonitor.cs
+++ b/PlaybackMonitor.cs
@@ -23,16 +23,25 @@ public class PlaybackMonitor : IHostedService
     private readonly TranscodeEventStore _eventStore;
     private readonly HashSet<string> _naggedPlaybacks = new();
 
+    // Notification state is tied to the SessionInfo instance rather than its ID. Jellyfin derives
+    // session IDs from client/device identifiers, so a later session can reuse the same ID.
+    private readonly HashSet<SessionInfo> _motdSentSessions = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<SessionInfo> _sessionNotificationsInProgress = new(ReferenceEqualityComparer.Instance);
+    private readonly object _sessionNotificationLock = new();
+
     // "Open Jellyfin" detection for long-lived sessions:
     // We poll session activity timestamps (via reflection) and treat a large activity jump as a new "open".
     // This keeps behavior compatible across Jellyfin builds even if the SessionInfo property name changes.
-    private readonly Dictionary<string, DateTime> _sessionLastActivityUtc = new();
+    private readonly Dictionary<SessionInfo, DateTime> _sessionLastActivityUtc = new(ReferenceEqualityComparer.Instance);
     private readonly object _sessionLastActivityLock = new();
     private Timer? _sessionPollTimer;
 
     // If a session goes idle for at least this long and then becomes active again,
     // treat it as the user "opening" Jellyfin again.
     private static readonly TimeSpan OpenIdleThreshold = TimeSpan.FromMinutes(10);
+
+    // Upper bound on how long the login nag waits behind a freshly sent MOTD.
+    private const int MaxMotdFollowUpDelayMs = 30000;
 
     public PlaybackMonitor(
         ISessionManager sessionManager,
@@ -49,9 +58,10 @@ public class PlaybackMonitor : IHostedService
     {
         _sessionManager.PlaybackStart += OnPlaybackStart;
         _sessionManager.PlaybackStopped += OnPlaybackStopped;
-        _sessionManager.SessionStarted += OnSessionStarted;
+        _sessionManager.SessionControllerConnected += OnSessionControllerConnected;
+        _sessionManager.SessionEnded += OnSessionEnded;
         // Polling is used ONLY to catch re-opens of existing sessions.
-        // (SessionStarted covers fresh sessions.)
+        // (SessionControllerConnected covers fresh sessions once messages can be delivered.)
         _sessionPollTimer = new Timer(PollSessionsForReopen, null, TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(30));
         _logger.LogInformation("PlaybackMonitor started - listening for playback and session events");
         return Task.CompletedTask;
@@ -61,7 +71,8 @@ public class PlaybackMonitor : IHostedService
     {
         _sessionManager.PlaybackStart -= OnPlaybackStart;
         _sessionManager.PlaybackStopped -= OnPlaybackStopped;
-        _sessionManager.SessionStarted -= OnSessionStarted;
+        _sessionManager.SessionControllerConnected -= OnSessionControllerConnected;
+        _sessionManager.SessionEnded -= OnSessionEnded;
         _sessionPollTimer?.Dispose();
         _logger.LogInformation("PlaybackMonitor stopped");
         return Task.CompletedTask;
@@ -81,7 +92,7 @@ public class PlaybackMonitor : IHostedService
         }
 
         // If we can't read a last-activity timestamp, polling can't safely infer "reopen".
-        // In that case, SessionStarted still works for fresh sessions.
+        // In that case, the controller-connected event still works for fresh sessions.
         foreach (var session in _sessionManager.Sessions)
         {
             if (session.Id == null || session.UserId == Guid.Empty)
@@ -95,12 +106,11 @@ public class PlaybackMonitor : IHostedService
                 continue;
             }
 
-            var sessionId = session.Id;
             var shouldTreatAsOpen = false;
 
             lock (_sessionLastActivityLock)
             {
-                if (_sessionLastActivityUtc.TryGetValue(sessionId, out var prev))
+                if (_sessionLastActivityUtc.TryGetValue(session, out var prev))
                 {
                     // If the session jumped forward by a lot, consider it a "re-open".
                     if (lastActivity.Value > prev && (lastActivity.Value - prev) >= OpenIdleThreshold)
@@ -108,18 +118,28 @@ public class PlaybackMonitor : IHostedService
                         shouldTreatAsOpen = true;
                     }
 
-                    _sessionLastActivityUtc[sessionId] = lastActivity.Value;
+                    _sessionLastActivityUtc[session] = lastActivity.Value;
                 }
                 else
                 {
                     // First time seeing this session in the poller - treat as open.
-                    _sessionLastActivityUtc[sessionId] = lastActivity.Value;
+                    _sessionLastActivityUtc[session] = lastActivity.Value;
                     shouldTreatAsOpen = true;
                 }
             }
 
             if (shouldTreatAsOpen)
             {
+                lock (_sessionNotificationLock)
+                {
+                    // A fresh-session notification may be waiting for the MOTD to expire.
+                    // Let that sequence deliver the login nag so polling cannot overtake it.
+                    if (_sessionNotificationsInProgress.Contains(session))
+                    {
+                        continue;
+                    }
+                }
+
                 _ = MaybeSendLoginOrOpenNagAsync(session, config);
             }
         }
@@ -221,8 +241,10 @@ public class PlaybackMonitor : IHostedService
 
                 if (!_naggedPlaybacks.Contains(playbackKey))
                 {
-                    await SendNagMessageAsync(session, config).ConfigureAwait(false);
-                    _naggedPlaybacks.Add(playbackKey);
+                    if (await SendNagMessageAsync(session, config).ConfigureAwait(false))
+                    {
+                        _naggedPlaybacks.Add(playbackKey);
+                    }
                 }
             }
         }
@@ -239,23 +261,6 @@ public class PlaybackMonitor : IHostedService
             var playbackKey = $"{e.Session.Id}_{e.Item.Id}";
             _naggedPlaybacks.Remove(playbackKey);
         }
-    }
-
-    private bool IsUserExcluded(Guid? userId)
-    {
-        if (userId == null || Plugin.Instance == null)
-        {
-            return false;
-        }
-
-        var config = Plugin.Instance.Configuration;
-        if (config.ExcludedUserIds == null || config.ExcludedUserIds.Length == 0)
-        {
-            return false;
-        }
-
-        var userIdString = userId.Value.ToString("N");
-        return Array.IndexOf(config.ExcludedUserIds, userIdString) >= 0;
     }
 
     private bool IsItemAllowed(SessionInfo session, Configuration.PluginConfiguration config, string context)
@@ -330,15 +335,15 @@ public class PlaybackMonitor : IHostedService
         return config.NagMessage;
     }
 
-    private async Task SendNagMessageAsync(SessionInfo session, Configuration.PluginConfiguration config)
+    private async Task<bool> SendNagMessageAsync(SessionInfo session, Configuration.PluginConfiguration config)
     {
         if (session.Id == null)
         {
-            return;
+            return false;
         }
 
         // Check if user is excluded from nag messages
-        if (IsUserExcluded(session.UserId))
+        if (TranscodeNagRules.IsUserExcluded(session.UserId, config.ExcludedUserIds))
         {
             if (config.EnableLogging)
             {
@@ -347,12 +352,12 @@ public class PlaybackMonitor : IHostedService
                     session.UserId,
                     session.UserName ?? "Unknown");
             }
-            return;
+            return false;
         }
 
         var transcodeReasons = session.TranscodingInfo?.TranscodeReasons.ToString() ?? "Unknown";
 
-        await SendMessageCommandWithDiagnosticsAsync(
+        return await SendMessageCommandWithDiagnosticsAsync(
             session,
             config,
             new MessageCommand
@@ -378,6 +383,14 @@ public class PlaybackMonitor : IHostedService
         }
 
         LogMessageDeliveryDiagnostics(session, config, context, detail);
+
+        // Jellyfin treats sending to an empty controller collection as a successful no-op.
+        // Do not report or persist that as a delivered message.
+        var (_, activeControllerCount, _) = GetSessionControllerStats(session);
+        if (activeControllerCount == 0)
+        {
+            return false;
+        }
 
         try
         {
@@ -575,39 +588,190 @@ public class PlaybackMonitor : IHostedService
         }
     }
 
-    private async void OnSessionStarted(object? sender, SessionEventArgs e)
+    private async void OnSessionControllerConnected(object? sender, SessionEventArgs e)
     {
-        if (Plugin.Instance == null || e.SessionInfo?.UserId == null)
+        if (Plugin.Instance == null
+            || e.SessionInfo is not { Id: not null } session
+            || session.UserId == Guid.Empty)
         {
             return;
         }
 
         var config = Plugin.Instance.Configuration;
 
-        if (!config.EnableLoginNag)
+        if (!config.EnableLoginNag && !config.EnableMotd)
         {
             return;
         }
 
-        // Wait a moment for session to fully initialize
-        await Task.Delay(2000).ConfigureAwait(false);
+        // More than one controller can connect to a session at nearly the same time. Run one
+        // notification sequence at a time so the login nag cannot overtake a pending MOTD.
+        lock (_sessionNotificationLock)
+        {
+            if (!_sessionNotificationsInProgress.Add(session))
+            {
+                return;
+            }
+        }
+
+        // Seed the reopen tracker now. Otherwise its first poll can classify this fresh session
+        // as a reopen and send the login nag while the MOTD is still visible.
+        var lastActivity = TryGetSessionLastActivityUtc(session);
+        if (lastActivity.HasValue)
+        {
+            lock (_sessionLastActivityLock)
+            {
+                _sessionLastActivityUtc[session] = lastActivity.Value;
+            }
+        }
 
         try
         {
-            await MaybeSendLoginOrOpenNagAsync(e.SessionInfo, config).ConfigureAwait(false);
+            var motdSent = false;
+
+            // Keep MOTD failures from suppressing the login nag, and never let this
+            // async void handler throw into the host.
+            try
+            {
+                motdSent = await MaybeSendMotdAsync(session, config).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                _logger.LogError(ex, "Error handling session-connect MOTD");
+            }
+
+            try
+            {
+                // Many clients only render one message at a time. If we just sent the MOTD,
+                // let it expire before the login nag replaces it - otherwise the nag is never
+                // seen but is still recorded as sent, suppressing it for the whole window.
+                if (motdSent && config.EnableLoginNag)
+                {
+                    // Clamped because MessageTimeoutMs is only range-checked by the config UI.
+                    await Task.Delay(Math.Clamp(config.MessageTimeoutMs, 0, MaxMotdFollowUpDelayMs)).ConfigureAwait(false);
+                }
+
+                // A session can end (and its deterministic ID can be reused) while waiting for
+                // the MOTD to expire. Only continue for the same live SessionInfo instance.
+                var currentSession = _sessionManager.Sessions.FirstOrDefault(candidate => ReferenceEquals(candidate, session));
+                if (currentSession != null)
+                {
+                    await MaybeSendLoginOrOpenNagAsync(currentSession, config).ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                _logger.LogError(ex, "Error handling session-connect login nag");
+            }
         }
-        catch (ObjectDisposedException ex)
+        finally
         {
-            _logger.LogError(ex, "Error handling session-start login nag");
+            lock (_sessionNotificationLock)
+            {
+                _sessionNotificationsInProgress.Remove(session);
+            }
         }
-        catch (InvalidOperationException ex)
+    }
+
+    private void OnSessionEnded(object? sender, SessionEventArgs e)
+    {
+        var session = e.SessionInfo;
+        if (session == null)
         {
-            _logger.LogError(ex, "Error handling session-start login nag");
+            return;
         }
-        catch (OperationCanceledException ex)
+
+        lock (_sessionNotificationLock)
         {
-            _logger.LogError(ex, "Error handling session-start login nag");
+            _motdSentSessions.Remove(session);
+            _sessionNotificationsInProgress.Remove(session);
         }
+
+        lock (_sessionLastActivityLock)
+        {
+            _sessionLastActivityUtc.Remove(session);
+        }
+    }
+
+    /// <summary>
+    /// Sends the MOTD if this session qualifies. Returns true only when a message was actually delivered.
+    /// </summary>
+    private async Task<bool> MaybeSendMotdAsync(SessionInfo session, Configuration.PluginConfiguration config)
+    {
+        if (session.Id == null || session.UserId == Guid.Empty)
+        {
+            return false;
+        }
+
+        if (!config.EnableMotd || string.IsNullOrWhiteSpace(config.MotdMessage))
+        {
+            return false;
+        }
+
+        if (TranscodeNagRules.IsUserExcluded(session.UserId, config.MotdExcludedUserIds))
+        {
+            if (config.EnableLogging)
+            {
+                _logger.LogInformation(
+                    "Skipping MOTD for excluded user {UserId} ({UserName})",
+                    session.UserId,
+                    session.UserName ?? "Unknown");
+            }
+
+            return false;
+        }
+
+        if (!TranscodeNagRules.IsMotdClientAllowed(session.Client, config))
+        {
+            if (config.EnableLogging)
+            {
+                _logger.LogInformation(
+                    "Skipping MOTD for filtered client {Client} on session {SessionId}",
+                    session.Client ?? "Unknown",
+                    session.Id);
+            }
+
+            return false;
+        }
+
+        // Claim the session before sending so concurrent controller connections cannot double-send.
+        lock (_sessionNotificationLock)
+        {
+            if (!_motdSentSessions.Add(session))
+            {
+                return false;
+            }
+        }
+
+        var sent = false;
+        try
+        {
+            sent = await SendMessageCommandWithDiagnosticsAsync(
+                session,
+                config,
+                new MessageCommand
+                {
+                    Header = "Message of the Day",
+                    Text = config.MotdMessage,
+                    TimeoutMs = config.MessageTimeoutMs
+                },
+                "motd",
+                "Message of the day").ConfigureAwait(false);
+        }
+        finally
+        {
+            // Release the claim on any failure (including an exception the send helper does not catch)
+            // so the MOTD can still be delivered if the session reconnects.
+            if (!sent)
+            {
+                lock (_sessionNotificationLock)
+                {
+                    _motdSentSessions.Remove(session);
+                }
+            }
+        }
+
+        return sent;
     }
 
     private async Task MaybeSendLoginOrOpenNagAsync(SessionInfo session, Configuration.PluginConfiguration config)
@@ -623,7 +787,7 @@ public class PlaybackMonitor : IHostedService
         }
 
         // Check if user is excluded from nag messages
-        if (IsUserExcluded(session.UserId))
+        if (TranscodeNagRules.IsUserExcluded(session.UserId, config.ExcludedUserIds))
         {
             if (config.EnableLogging)
             {

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ A Jellyfin plugin that intelligently nags users when they're transcoding due to 
 - Can send a login nag when a user keeps hitting bad transcodes over the last week or month.
 - Lets you exclude users from all nags.
 - Includes a live session monitor in the plugin settings page.
+- Can broadcast an optional Message of the Day to users at login, with its own user exclusions and client filters.
 
 ## Installation
 
@@ -84,9 +85,12 @@ Open **Dashboard** → **Plugins** → **Transcode Nag**.
 - If you want login nags, enable them and set the threshold, time window, and message. The login message supports `{{transcodes}}` and `{{timewindow}}`.
 - Use **Manage Excluded Users** to opt users out of both playback and login nags.
 - Use the built-in live session monitor to see which active sessions currently match your rules.
+- Enable **Message of the Day** (off by default) to send an announcement to everyone at login. Its options stay collapsed until the toggle is on, and it has its own message, its own **Manage Excluded Users (MOTD)** list, and its own client include/exclude filters, all independent of the nag settings.
 
 ## Behavior Notes
 
 - Playback nags happen once per video, not once per session.
 - Login nags are rate-limited and use stored history from the last 30 days.
 - If a user returns to direct play after a bad transcode, login nags are suppressed until they regress again.
+- The MOTD is sent once per session at login and is unrelated to transcode history. Sessions that were already signed in when you enabled it receive nothing until they sign in again.
+- If a user qualifies for both the MOTD and a login nag, the nag waits for the MOTD to time out first, so clients that show one message at a time still display both.

--- a/TranscodeNagRules.cs
+++ b/TranscodeNagRules.cs
@@ -59,21 +59,57 @@ internal static class TranscodeNagRules
         return false;
     }
 
-    internal static bool IsClientAllowed(string? clientName, PluginConfiguration config)
+    internal static bool IsClientAllowed(string? clientName, string[]? includedPatterns, string[]? excludedPatterns)
     {
-        ArgumentNullException.ThrowIfNull(config);
-
-        if (MatchesConfiguredClientPatterns(clientName, config.ExcludedClientPatterns))
+        if (MatchesConfiguredClientPatterns(clientName, excludedPatterns))
         {
             return false;
         }
 
-        if (!HasConfiguredClientPatterns(config.IncludedClientPatterns))
+        if (!HasConfiguredClientPatterns(includedPatterns))
         {
             return true;
         }
 
-        return MatchesConfiguredClientPatterns(clientName, config.IncludedClientPatterns);
+        return MatchesConfiguredClientPatterns(clientName, includedPatterns);
+    }
+
+    internal static bool IsClientAllowed(string? clientName, PluginConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        return IsClientAllowed(clientName, config.IncludedClientPatterns, config.ExcludedClientPatterns);
+    }
+
+    internal static bool IsMotdClientAllowed(string? clientName, PluginConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        return IsClientAllowed(clientName, config.MotdIncludedClientPatterns, config.MotdExcludedClientPatterns);
+    }
+
+    internal static bool IsUserExcluded(Guid userId, string[]? excludedUserIds)
+    {
+        if (userId == Guid.Empty || excludedUserIds == null || excludedUserIds.Length == 0)
+        {
+            return false;
+        }
+
+        foreach (var excludedUserId in excludedUserIds)
+        {
+            if (string.IsNullOrWhiteSpace(excludedUserId))
+            {
+                continue;
+            }
+
+            // Accept both "N" (Jellyfin's wire format) and dashed GUIDs so hand-edited configs still work.
+            if (Guid.TryParse(excludedUserId.Trim(), out var parsedUserId) && parsedUserId == userId)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     internal static bool IsLiveTvItem(BaseItemDto? item)

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/TranscodeNagRulesTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/TranscodeNagRulesTests.cs
@@ -95,6 +95,49 @@ public class TranscodeNagRulesTests
     }
 
     [Fact]
+    public void IsMotdClientAllowed_UsesMotdPatternsAndIgnoresNagPatterns()
+    {
+        var config = new PluginConfiguration
+        {
+            IncludedClientPatterns = new[] { "web" },
+            ExcludedClientPatterns = new[] { "android tv" },
+            MotdIncludedClientPatterns = new[] { "android tv" },
+            MotdExcludedClientPatterns = new[] { "roku" }
+        };
+
+        Assert.True(TranscodeNagRules.IsMotdClientAllowed("Jellyfin Android TV", config));
+        Assert.False(TranscodeNagRules.IsMotdClientAllowed("Jellyfin Web", config));
+        Assert.False(TranscodeNagRules.IsMotdClientAllowed("Jellyfin Roku", config));
+    }
+
+    [Fact]
+    public void IsMotdClientAllowed_AllowsEveryClientWhenNoMotdPatternsAreConfigured()
+    {
+        var config = new PluginConfiguration
+        {
+            ExcludedClientPatterns = new[] { "android tv" }
+        };
+
+        Assert.True(TranscodeNagRules.IsMotdClientAllowed("Jellyfin Android TV", config));
+        Assert.True(TranscodeNagRules.IsMotdClientAllowed("Jellyfin Web", config));
+        Assert.True(TranscodeNagRules.IsMotdClientAllowed(null, config));
+    }
+
+    [Fact]
+    public void IsUserExcluded_MatchesDashedAndDashlessGuids()
+    {
+        var userId = Guid.NewGuid();
+
+        Assert.True(TranscodeNagRules.IsUserExcluded(userId, new[] { userId.ToString("N") }));
+        Assert.True(TranscodeNagRules.IsUserExcluded(userId, new[] { userId.ToString("D") }));
+        Assert.True(TranscodeNagRules.IsUserExcluded(userId, new[] { " ", userId.ToString("N").ToUpperInvariant() }));
+        Assert.False(TranscodeNagRules.IsUserExcluded(userId, new[] { Guid.NewGuid().ToString("N") }));
+        Assert.False(TranscodeNagRules.IsUserExcluded(userId, Array.Empty<string>()));
+        Assert.False(TranscodeNagRules.IsUserExcluded(userId, null));
+        Assert.False(TranscodeNagRules.IsUserExcluded(Guid.Empty, new[] { Guid.Empty.ToString("N") }));
+    }
+
+    [Fact]
     public void IsLiveTvItem_DetectsLiveAndLiveTvItemTypes()
     {
         Assert.True(TranscodeNagRules.IsLiveTvItem(new BaseItemDto { IsLive = true, Type = BaseItemKind.Movie }));


### PR DESCRIPTION
Adds an optional Message of the Day that is sent to users at login, independent of transcoding. Off by default.

## Feature

- **Enable toggle** (default off). The rest of the MOTD options stay collapsed in the config page until it is switched on.
- **MOTD message**, using the existing message timeout.
- **Manage Excluded Users (MOTD)** — its own exclusion list, separate from the nag list.
- **Client include/exclude filters** for the MOTD, separate from the nag filters. Same case-insensitive matching, exclude wins over include.

On login the plugin checks the toggle, then the MOTD exclusion list, then the MOTD client filters, and sends the message once per session.

## Delivery fixes

- **Hook `SessionControllerConnected` instead of `SessionStarted`.** `SessionStarted` fires before the WebSocket controller is attached, so a message sent then had no controller to reach. This also removes the fixed 2s delay that was papering over it.
- **Stop reporting success when a session has no active controller.** Jellyfin treats a send to zero controllers as a successful no-op. The login nag was persisting its `NagSent` rate-limit marker on that basis, suppressing the user for the full window over a message they never saw.
- **Key session state by `SessionInfo` identity rather than session ID.** Jellyfin derives session IDs from client/device and reuses them. State is now cleaned up on `SessionEnded`.
- **Order MOTD and login nag** so clients that render one message at a time show both.

Closed — superseded.