### PR TITLE
chore: update GitHub Actions and clean up CodeQL findings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
             build-mode: none
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@v4.37.4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -52,6 +52,6 @@ jobs:
       run: dotnet build --configuration Release --no-restore
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@v4.37.4
       with:
         category: '/language:${{ matrix.language }}'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Setup .NET
       if: matrix.language == 'csharp'
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 8.0.x
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
 
     - name: Setup .NET
       uses: actions/setup-dotnet@v5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v7
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 8.0.x
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -37,7 +37,7 @@ jobs:
         git checkout "pr-${PR_NUMBER}"
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 8.0.x
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0  # Fetch all history for changelog generation
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         fetch-depth: 0  # Fetch all history for changelog generation
 
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 8.0.x
 

--- a/PlaybackMonitor.cs
+++ b/PlaybackMonitor.cs
@@ -239,12 +239,10 @@ public class PlaybackMonitor : IHostedService
                 // Record the event
                 RecordTranscodeEvent(session, transcodeInfo);
 
-                if (!_naggedPlaybacks.Contains(playbackKey))
+                if (!_naggedPlaybacks.Contains(playbackKey)
+                    && await SendNagMessageAsync(session, config).ConfigureAwait(false))
                 {
-                    if (await SendNagMessageAsync(session, config).ConfigureAwait(false))
-                    {
-                        _naggedPlaybacks.Add(playbackKey);
-                    }
+                    _naggedPlaybacks.Add(playbackKey);
                 }
             }
         }
@@ -309,13 +307,8 @@ public class PlaybackMonitor : IHostedService
 
         if (transcodeInfo != null && overrides != null && overrides.Length > 0 && config.AlertTranscodeReasons != null)
         {
-            foreach (var reasonName in config.AlertTranscodeReasons)
+            foreach (var reasonName in config.AlertTranscodeReasons.Where(reasonName => !string.IsNullOrWhiteSpace(reasonName)))
             {
-                if (string.IsNullOrWhiteSpace(reasonName))
-                {
-                    continue;
-                }
-
                 if (Enum.TryParse<TranscodeReason>(reasonName, true, out var parsedReason)
                     && (transcodeInfo.TranscodeReasons & parsedReason) != 0)
                 {


### PR DESCRIPTION
## Summary

- combine the `actions/checkout` v7 update from #16
- combine the `actions/setup-dotnet` v6 update from #17
- combine the `github/codeql-action` v4.37.4 update from #18
- resolve CodeQL maintainability alerts [10](https://github.com/voc0der/jellyfin-transcode-nag/security/code-scanning/10) and [11](https://github.com/voc0der/jellyfin-transcode-nag/security/code-scanning/11) with behavior-preserving readability changes

## Why

This keeps the GitHub Actions dependencies current and clears two low-severity CodeQL readability findings without changing the plugin's intended behavior.

## Testing

- `dotnet build --configuration Release` — passed with zero warnings
- `dotnet format whitespace --verify-no-changes` — passed
- `dotnet format style --verify-no-changes --severity warn` — passed
- `dotnet test tests/Jellyfin.Plugin.TranscodeNag.Tests/Jellyfin.Plugin.TranscodeNag.Tests.csproj --configuration Release` — 18 passed
- `actionlint .github/workflows/*.yml` — passed
- `git diff --check` — passed

Not tested against a live Jellyfin instance; the source changes are behavior-preserving control-flow simplifications.
