### PR TITLE
feat(gpu): refuse hardware transcodes before FFmpeg when VRAM is exhausted

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -70,6 +70,43 @@ public class PluginConfiguration : BasePluginConfiguration
     public string[] MotdIncludedClientPatterns { get; set; } = Array.Empty<string>();
 
     public string[] MotdExcludedClientPatterns { get; set; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets or sets a value indicating whether GPU-backed video transcodes are refused when free VRAM is low.
+    /// Defaults to off so upgrading the plugin cannot change playback behaviour on its own.
+    /// </summary>
+    public bool EnableGpuResourceGuard { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the zero-based NVIDIA GPU index the guard watches.
+    /// </summary>
+    public int GpuIndex { get; set; } = 0;
+
+    /// <summary>
+    /// Gets or sets the free-VRAM floor, in MiB. Hardware video transcodes are refused below this value.
+    /// </summary>
+    public int MinimumFreeGpuMemoryMiB { get; set; } = 1500;
+
+    /// <summary>
+    /// Gets or sets how long the nvidia-smi query may run before it is abandoned.
+    /// </summary>
+    public int GpuCheckTimeoutMilliseconds { get; set; } = 1000;
+
+    /// <summary>
+    /// Gets or sets an explicit nvidia-smi path. Empty means resolve "nvidia-smi" from PATH.
+    /// </summary>
+    public string NvidiaSmiPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the popup title shown to a client whose transcode was refused.
+    /// </summary>
+    public string GpuGuardDeniedHeader { get; set; } = "Transcoding unavailable";
+
+    /// <summary>
+    /// Gets or sets the popup body shown to a client whose transcode was refused.
+    /// Deliberately free of VRAM figures, encoder names, and other server-side detail.
+    /// </summary>
+    public string GpuGuardDeniedMessage { get; set; } = "GPU resources are currently busy. Please try again later or use Direct Play.";
 }
 
 public class ReasonMessageOverride

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -179,8 +179,9 @@
 
                     <h2>GPU Resource Guard</h2>
                     <div class="fieldDescription" style="margin-bottom: 12px;">
-                        Refuses a hardware video transcode before FFmpeg is launched when the GPU is short on memory,
-                        so a doomed transcode fails once and clearly instead of retrying. Requires <code>nvidia-smi</code>
+                        Refuses an NVIDIA hardware video transcode before FFmpeg is launched when the GPU is short
+                        on memory, so a doomed transcode fails once and clearly instead of retrying. NVIDIA only:
+                        QSV, VAAPI, and VideoToolbox transcodes are never refused. Requires <code>nvidia-smi</code>
                         to be reachable from the Jellyfin server process.
                     </div>
 
@@ -202,7 +203,7 @@
                         <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="txtMinimumFreeGpuMemoryMiB">Minimum free GPU memory (MiB):</label>
                             <input type="number" id="txtMinimumFreeGpuMemoryMiB" name="txtMinimumFreeGpuMemoryMiB" min="0" max="131072" class="emby-input" />
-                            <div class="fieldDescription">Hardware video transcoding is refused when available GPU memory is below this value. Direct Play and other non-GPU playback are unaffected.</div>
+                            <div class="fieldDescription">NVIDIA hardware video transcoding is refused when available GPU memory is below this value. Direct Play and other non-GPU playback are unaffected.</div>
                         </div>
 
                         <div class="inputContainer">

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -177,6 +177,59 @@
                         </div>
                     </div>
 
+                    <h2>GPU Resource Guard</h2>
+                    <div class="fieldDescription" style="margin-bottom: 12px;">
+                        Refuses a hardware video transcode before FFmpeg is launched when the GPU is short on memory,
+                        so a doomed transcode fails once and clearly instead of retrying. Requires <code>nvidia-smi</code>
+                        to be reachable from the Jellyfin server process.
+                    </div>
+
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input type="checkbox" is="emby-checkbox" id="chkEnableGpuResourceGuard" name="chkEnableGpuResourceGuard" />
+                            <span>Enable GPU resource guard</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">Off by default. If free GPU memory cannot be read, playback is always allowed.</div>
+                    </div>
+
+                    <div id="gpuGuardOptions" style="display: none;">
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtGpuIndex">GPU index:</label>
+                            <input type="number" id="txtGpuIndex" name="txtGpuIndex" min="0" max="15" class="emby-input" />
+                            <div class="fieldDescription">Zero-based index of the NVIDIA GPU to watch, as reported by nvidia-smi.</div>
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtMinimumFreeGpuMemoryMiB">Minimum free GPU memory (MiB):</label>
+                            <input type="number" id="txtMinimumFreeGpuMemoryMiB" name="txtMinimumFreeGpuMemoryMiB" min="0" max="131072" class="emby-input" />
+                            <div class="fieldDescription">Hardware video transcoding is refused when available GPU memory is below this value. Direct Play and other non-GPU playback are unaffected.</div>
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtGpuCheckTimeoutMs">GPU check timeout (ms):</label>
+                            <input type="number" id="txtGpuCheckTimeoutMs" name="txtGpuCheckTimeoutMs" min="100" max="10000" class="emby-input" />
+                            <div class="fieldDescription">How long to wait for nvidia-smi before giving up and allowing playback.</div>
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtNvidiaSmiPath">nvidia-smi path:</label>
+                            <input type="text" id="txtNvidiaSmiPath" name="txtNvidiaSmiPath" class="emby-input" placeholder="nvidia-smi" />
+                            <div class="fieldDescription">Optional. Leave empty to resolve nvidia-smi from PATH. Set a full path if the server cannot find it.</div>
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtGpuGuardDeniedHeader">Refusal Title:</label>
+                            <input type="text" id="txtGpuGuardDeniedHeader" name="txtGpuGuardDeniedHeader" class="emby-input" />
+                            <div class="fieldDescription">Title of the popup shown to the client whose transcode was refused.</div>
+                        </div>
+
+                        <div class="selectContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtGpuGuardDeniedMessage">Refusal Message:</label>
+                            <textarea id="txtGpuGuardDeniedMessage" name="txtGpuGuardDeniedMessage" rows="3" class="emby-input"></textarea>
+                            <div class="fieldDescription">Keep this free of server detail. VRAM figures, encoder names, and FFmpeg errors belong in the server log.</div>
+                        </div>
+                    </div>
+
                     <div>
                         <button is="emby-button" type="submit" class="raised button-submit block">
                             <span>Save</span>
@@ -541,6 +594,36 @@
                 }
             };
 
+            // Keeps the GPU guard block collapsed unless the feature is switched on.
+            var GpuGuardSection = {
+                initialized: false,
+
+                init: function() {
+                    if (this.initialized) {
+                        return;
+                    }
+
+                    document.getElementById('chkEnableGpuResourceGuard').addEventListener('change', this.updateVisibility);
+                    this.initialized = true;
+                },
+
+                updateVisibility: function() {
+                    var enabled = document.getElementById('chkEnableGpuResourceGuard').checked;
+                    document.getElementById('gpuGuardOptions').style.display = enabled ? 'block' : 'none';
+                },
+
+                // A blank or non-numeric field must not be saved as NaN.
+                readNumber: function(elementId, fallback) {
+                    var parsed = parseInt(document.getElementById(elementId).value, 10);
+                    return isNaN(parsed) || parsed < 0 ? fallback : parsed;
+                },
+
+                // A saved 0 is a real value here, so it must not be treated as "unset".
+                numberOrDefault: function(value, fallback) {
+                    return typeof value === 'number' && isFinite(value) && value >= 0 ? value : fallback;
+                }
+            };
+
             var LiveSessionMonitor = {
                 initialized: false,
                 refreshTimer: null,
@@ -848,6 +931,7 @@
                 UserExclusionManager.init();
                 MotdUserExclusionManager.init();
                 MotdSection.init();
+                GpuGuardSection.init();
                 ApiClient.getPluginConfiguration(TranscodeNagConfig.pluginId).then(function (config) {
                     document.getElementById('txtNagMessage').value = config.NagMessage || '';
                     document.getElementById('txtDelaySeconds').value = config.DelaySeconds || 5;
@@ -864,7 +948,15 @@
                     document.getElementById('txtMotdMessage').value = config.MotdMessage || '';
                     document.getElementById('txtMotdIncludedClientPatterns').value = ClientPatternEditor.formatPatterns(config.MotdIncludedClientPatterns);
                     document.getElementById('txtMotdExcludedClientPatterns').value = ClientPatternEditor.formatPatterns(config.MotdExcludedClientPatterns);
+                    document.getElementById('chkEnableGpuResourceGuard').checked = config.EnableGpuResourceGuard === true;
+                    document.getElementById('txtGpuIndex').value = GpuGuardSection.numberOrDefault(config.GpuIndex, 0);
+                    document.getElementById('txtMinimumFreeGpuMemoryMiB').value = GpuGuardSection.numberOrDefault(config.MinimumFreeGpuMemoryMiB, 1500);
+                    document.getElementById('txtGpuCheckTimeoutMs').value = GpuGuardSection.numberOrDefault(config.GpuCheckTimeoutMilliseconds, 1000);
+                    document.getElementById('txtNvidiaSmiPath').value = config.NvidiaSmiPath || '';
+                    document.getElementById('txtGpuGuardDeniedHeader').value = config.GpuGuardDeniedHeader || '';
+                    document.getElementById('txtGpuGuardDeniedMessage').value = config.GpuGuardDeniedMessage || '';
                     MotdSection.updateVisibility();
+                    GpuGuardSection.updateVisibility();
                     ReasonSelector.render(config.AlertTranscodeReasons, config.ReasonMessageOverrides);
                     LiveSessionMonitor.refresh(false, config);
                     LiveSessionMonitor.startRefreshTimer();
@@ -892,6 +984,13 @@
                     config.MotdMessage = document.getElementById('txtMotdMessage').value;
                     config.MotdIncludedClientPatterns = ClientPatternEditor.splitPatterns(document.getElementById('txtMotdIncludedClientPatterns').value);
                     config.MotdExcludedClientPatterns = ClientPatternEditor.splitPatterns(document.getElementById('txtMotdExcludedClientPatterns').value);
+                    config.EnableGpuResourceGuard = document.getElementById('chkEnableGpuResourceGuard').checked;
+                    config.GpuIndex = GpuGuardSection.readNumber('txtGpuIndex', 0);
+                    config.MinimumFreeGpuMemoryMiB = GpuGuardSection.readNumber('txtMinimumFreeGpuMemoryMiB', 1500);
+                    config.GpuCheckTimeoutMilliseconds = GpuGuardSection.readNumber('txtGpuCheckTimeoutMs', 1000);
+                    config.NvidiaSmiPath = document.getElementById('txtNvidiaSmiPath').value.trim();
+                    config.GpuGuardDeniedHeader = document.getElementById('txtGpuGuardDeniedHeader').value;
+                    config.GpuGuardDeniedMessage = document.getElementById('txtGpuGuardDeniedMessage').value;
                     config.AlertTranscodeReasons = ReasonSelector.getSelectedReasonNames();
                     config.ReasonMessageOverrides = ReasonSelector.getReasonMessageOverrides();
 

--- a/Gpu/GpuAdmissionPolicy.cs
+++ b/Gpu/GpuAdmissionPolicy.cs
@@ -1,0 +1,109 @@
+using System;
+using Jellyfin.Plugin.TranscodeNag.Configuration;
+
+namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+
+/// <summary>
+/// Why a transcode was allowed, or that it was refused.
+/// </summary>
+internal enum GpuAdmissionOutcome
+{
+    /// <summary>The guard is switched off.</summary>
+    AllowedGuardDisabled,
+
+    /// <summary>Direct Play, remux/stream copy, or audio-only - no GPU video encode involved.</summary>
+    AllowedNotGpuTranscode,
+
+    /// <summary>Free VRAM is at or above the configured floor.</summary>
+    AllowedSufficientMemory,
+
+    /// <summary>Free VRAM could not be determined; the guard is fail-open.</summary>
+    AllowedQueryFailed,
+
+    /// <summary>Free VRAM is below the configured floor.</summary>
+    Denied
+}
+
+/// <summary>
+/// The admission rules, kept free of Jellyfin and process types so they can be tested directly.
+/// </summary>
+internal static class GpuAdmissionPolicy
+{
+    /// <summary>
+    /// Returns true when Jellyfin's finished job description means a GPU-backed video encode.
+    /// </summary>
+    /// <param name="isVideoRequest">Whether the streaming request asked for video at all.</param>
+    /// <param name="outputVideoCodec">Jellyfin's chosen output video codec ("copy" for remux).</param>
+    /// <param name="commandLineArguments">The FFmpeg arguments Jellyfin built for this job.</param>
+    /// <returns>True when the job needs NVIDIA GPU memory.</returns>
+    internal static bool RequiresGpuVideoTranscode(
+        bool isVideoRequest,
+        string? outputVideoCodec,
+        string? commandLineArguments)
+    {
+        // Audio-only requests never allocate video memory.
+        if (!isVideoRequest)
+        {
+            return false;
+        }
+
+        // Stream copy: container remux or Direct Stream. The video is passed through untouched.
+        if (IsCopyCodec(outputVideoCodec))
+        {
+            return false;
+        }
+
+        return NvidiaTranscodeDetector.UsesNvidiaGpu(commandLineArguments);
+    }
+
+    /// <summary>
+    /// Applies the configured threshold to a free-VRAM reading.
+    /// </summary>
+    /// <param name="config">Plugin configuration.</param>
+    /// <param name="requiresGpuVideoTranscode">Result of <see cref="RequiresGpuVideoTranscode"/>.</param>
+    /// <param name="memory">The free-VRAM reading, or null when the guard short-circuited before querying.</param>
+    /// <returns>The admission outcome.</returns>
+    internal static GpuAdmissionOutcome Evaluate(
+        PluginConfiguration config,
+        bool requiresGpuVideoTranscode,
+        GpuMemoryQueryResult? memory)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (!config.EnableGpuResourceGuard)
+        {
+            return GpuAdmissionOutcome.AllowedGuardDisabled;
+        }
+
+        if (!requiresGpuVideoTranscode)
+        {
+            return GpuAdmissionOutcome.AllowedNotGpuTranscode;
+        }
+
+        // Fail open: an unknown GPU state must never turn into a blanket denial.
+        if (memory is not { Success: true } reading)
+        {
+            return GpuAdmissionOutcome.AllowedQueryFailed;
+        }
+
+        return reading.FreeMiB >= config.MinimumFreeGpuMemoryMiB
+            ? GpuAdmissionOutcome.AllowedSufficientMemory
+            : GpuAdmissionOutcome.Denied;
+    }
+
+    /// <summary>
+    /// Returns true when the guard must read GPU state before deciding.
+    /// </summary>
+    /// <param name="config">Plugin configuration.</param>
+    /// <param name="requiresGpuVideoTranscode">Result of <see cref="RequiresGpuVideoTranscode"/>.</param>
+    /// <returns>True when a GPU query is needed.</returns>
+    internal static bool RequiresGpuQuery(PluginConfiguration config, bool requiresGpuVideoTranscode)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        return config.EnableGpuResourceGuard && requiresGpuVideoTranscode;
+    }
+
+    internal static bool IsCopyCodec(string? codec)
+        => string.Equals(codec, "copy", StringComparison.OrdinalIgnoreCase);
+}

--- a/Gpu/GpuMemoryQueryResult.cs
+++ b/Gpu/GpuMemoryQueryResult.cs
@@ -1,0 +1,33 @@
+namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+
+/// <summary>
+/// Outcome of a single free-VRAM lookup.
+/// </summary>
+public readonly struct GpuMemoryQueryResult
+{
+    private GpuMemoryQueryResult(bool success, int freeMiB, string? failureReason)
+    {
+        Success = success;
+        FreeMiB = freeMiB;
+        FailureReason = failureReason;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether free VRAM could be determined.
+    /// </summary>
+    public bool Success { get; }
+
+    /// <summary>
+    /// Gets the free VRAM in MiB. Only meaningful when <see cref="Success"/> is true.
+    /// </summary>
+    public int FreeMiB { get; }
+
+    /// <summary>
+    /// Gets a short, log-safe description of why the query failed.
+    /// </summary>
+    public string? FailureReason { get; }
+
+    public static GpuMemoryQueryResult FromFreeMiB(int freeMiB) => new(true, freeMiB, null);
+
+    public static GpuMemoryQueryResult Failed(string reason) => new(false, 0, reason);
+}

--- a/Gpu/GpuResourceGuard.cs
+++ b/Gpu/GpuResourceGuard.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.TranscodeNag.Configuration;
+using Jellyfin.Plugin.TranscodeNag.Messaging;
+using MediaBrowser.Model.Session;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+
+/// <summary>
+/// Admission control for GPU-backed video transcodes.
+/// </summary>
+/// <remarks>
+/// This is admission control, not a GPU scheduler. A reading is taken immediately before Jellyfin
+/// is allowed to launch FFmpeg, and there is inherently a race between that reading and the
+/// allocation FFmpeg goes on to make. Clearing the threshold does not guarantee the allocation
+/// succeeds; the point is to refuse the predictable failures when VRAM is plainly exhausted.
+/// </remarks>
+public sealed class GpuResourceGuard
+{
+    // Jellyfin (and clients) re-request a failed stream within seconds. Every attempt is still
+    // refused; this only stops the client popup and the warning log repeating.
+    private static readonly TimeSpan NotificationSuppressionWindow = TimeSpan.FromSeconds(10);
+
+    private const string DefaultDeniedHeader = "Transcoding unavailable";
+    private const string DefaultDeniedMessage = "GPU resources are currently busy. Please try again later or use Direct Play.";
+
+    private readonly IGpuMemoryProvider _gpuMemoryProvider;
+    private readonly IClientMessageService _clientMessageService;
+    private readonly ILogger<GpuResourceGuard> _logger;
+    private readonly Func<PluginConfiguration?> _configurationAccessor;
+
+    private readonly Dictionary<string, DateTimeOffset> _lastNotifiedUtc = new(StringComparer.Ordinal);
+    private readonly object _suppressionLock = new();
+
+    public GpuResourceGuard(
+        IGpuMemoryProvider gpuMemoryProvider,
+        IClientMessageService clientMessageService,
+        ILogger<GpuResourceGuard> logger)
+        : this(gpuMemoryProvider, clientMessageService, logger, () => Plugin.Instance?.Configuration)
+    {
+    }
+
+    internal GpuResourceGuard(
+        IGpuMemoryProvider gpuMemoryProvider,
+        IClientMessageService clientMessageService,
+        ILogger<GpuResourceGuard> logger,
+        Func<PluginConfiguration?> configurationAccessor)
+    {
+        _gpuMemoryProvider = gpuMemoryProvider;
+        _clientMessageService = clientMessageService;
+        _logger = logger;
+        _configurationAccessor = configurationAccessor;
+    }
+
+    /// <summary>
+    /// Decides whether Jellyfin may launch this transcode, notifying the requesting client on refusal.
+    /// </summary>
+    /// <param name="request">The transcode Jellyfin is about to launch.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True when the transcode may proceed.</returns>
+    public async Task<bool> IsAdmittedAsync(GpuTranscodeRequest request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var config = _configurationAccessor();
+        if (config == null)
+        {
+            // The plugin is not fully loaded; never stand between Jellyfin and playback.
+            return true;
+        }
+
+        var requiresGpu = GpuAdmissionPolicy.RequiresGpuVideoTranscode(
+            request.IsVideoRequest,
+            request.OutputVideoCodec,
+            request.CommandLineArguments);
+
+        GpuMemoryQueryResult? memory = null;
+        if (GpuAdmissionPolicy.RequiresGpuQuery(config, requiresGpu))
+        {
+            memory = await _gpuMemoryProvider.GetFreeMemoryAsync(
+                config.GpuIndex,
+                config.GpuCheckTimeoutMilliseconds,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        var outcome = GpuAdmissionPolicy.Evaluate(config, requiresGpu, memory);
+
+        if (outcome == GpuAdmissionOutcome.AllowedQueryFailed)
+        {
+            LogQueryFailure(config, memory);
+        }
+
+        if (outcome != GpuAdmissionOutcome.Denied)
+        {
+            _logger.LogDebug(
+                "GPU resource guard allowed transcode of {ItemName}: {Outcome}",
+                request.ItemName ?? "Unknown",
+                outcome);
+            return true;
+        }
+
+        await DenyAsync(request, config, memory!.Value, cancellationToken).ConfigureAwait(false);
+        return false;
+    }
+
+    /// <summary>
+    /// Builds the server-side refusal text. This travels in the exception, not to the client:
+    /// Jellyfin only returns exception messages to callers in a Development environment.
+    /// </summary>
+    /// <returns>The server-side refusal reason.</returns>
+    public string BuildRefusalReason()
+    {
+        var config = _configurationAccessor();
+        if (config == null)
+        {
+            return "Transcode Nag refused this hardware transcode: insufficient free GPU memory.";
+        }
+
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "Transcode Nag refused this hardware transcode: free GPU memory on GPU {0} is below the configured minimum of {1} MiB.",
+            config.GpuIndex,
+            config.MinimumFreeGpuMemoryMiB);
+    }
+
+    private async Task DenyAsync(
+        GpuTranscodeRequest request,
+        PluginConfiguration config,
+        GpuMemoryQueryResult memory,
+        CancellationToken cancellationToken)
+    {
+        var session = _clientMessageService.ResolveSession(request.DeviceId, request.UserId, request.ItemId);
+        var notify = ShouldNotify(BuildSuppressionKey(request));
+
+        if (!notify)
+        {
+            // Still refused - only the popup and the warning are de-duplicated.
+            _logger.LogDebug(
+                "GPU transcode blocked again for item {ItemName} within the notification suppression window",
+                request.ItemName ?? "Unknown");
+            return;
+        }
+
+        _logger.LogWarning(
+            "GPU transcode blocked for session {SessionId}, user {UserName}, device {DeviceName}, item {ItemName}: free VRAM {FreeMiB} MiB below configured threshold {ThresholdMiB} MiB on GPU {GpuIndex}",
+            session?.Id ?? "Unknown",
+            session?.UserName ?? "Unknown",
+            session?.DeviceName ?? "Unknown",
+            request.ItemName ?? "Unknown",
+            memory.FreeMiB,
+            config.MinimumFreeGpuMemoryMiB,
+            config.GpuIndex);
+
+        if (session == null)
+        {
+            _logger.LogDebug(
+                "No session could be correlated to the refused transcode of {ItemName}; the refusal still stands",
+                request.ItemName ?? "Unknown");
+            return;
+        }
+
+        // Delivery is best effort. A client that cannot show a popup is still refused.
+        await _clientMessageService.SendMessageAsync(
+            session,
+            new MessageCommand
+            {
+                // An admin who blanks these fields should still get a usable popup.
+                Header = Fallback(config.GpuGuardDeniedHeader, DefaultDeniedHeader),
+                Text = Fallback(config.GpuGuardDeniedMessage, DefaultDeniedMessage),
+                TimeoutMs = config.MessageTimeoutMs
+            },
+            "gpu guard denial",
+            "Hardware transcode refused",
+            config.EnableLogging,
+            _logger,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private void LogQueryFailure(PluginConfiguration config, GpuMemoryQueryResult? memory)
+    {
+        if (!ShouldNotify("query-failure|" + config.GpuIndex.ToString(CultureInfo.InvariantCulture)))
+        {
+            return;
+        }
+
+        _logger.LogWarning(
+            "Unable to query free VRAM for GPU {GpuIndex}; allowing playback because GPU resource guard is fail-open ({Reason})",
+            config.GpuIndex,
+            memory?.FailureReason ?? "no result");
+    }
+
+    private static string Fallback(string? configured, string defaultText)
+        => string.IsNullOrWhiteSpace(configured) ? defaultText : configured;
+
+    private static string BuildSuppressionKey(GpuTranscodeRequest request)
+    {
+        return string.Join(
+            '|',
+            request.DeviceId ?? string.Empty,
+            request.PlaySessionId ?? string.Empty,
+            request.ItemId.ToString("N", CultureInfo.InvariantCulture));
+    }
+
+    private bool ShouldNotify(string key)
+    {
+        var now = DateTimeOffset.UtcNow;
+
+        lock (_suppressionLock)
+        {
+            if (_lastNotifiedUtc.TryGetValue(key, out var previous)
+                && now - previous < NotificationSuppressionWindow)
+            {
+                return false;
+            }
+
+            PruneExpired(now);
+            _lastNotifiedUtc[key] = now;
+            return true;
+        }
+    }
+
+    private void PruneExpired(DateTimeOffset now)
+    {
+        if (_lastNotifiedUtc.Count == 0)
+        {
+            return;
+        }
+
+        List<string>? expired = null;
+        foreach (var entry in _lastNotifiedUtc)
+        {
+            if (now - entry.Value >= NotificationSuppressionWindow)
+            {
+                (expired ??= new List<string>()).Add(entry.Key);
+            }
+        }
+
+        if (expired == null)
+        {
+            return;
+        }
+
+        foreach (var key in expired)
+        {
+            _lastNotifiedUtc.Remove(key);
+        }
+    }
+}

--- a/Gpu/GpuResourceGuard.cs
+++ b/Gpu/GpuResourceGuard.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.TranscodeNag.Configuration;
@@ -245,19 +246,10 @@ public sealed class GpuResourceGuard
             return;
         }
 
-        List<string>? expired = null;
-        foreach (var entry in _lastNotifiedUtc)
-        {
-            if (now - entry.Value >= NotificationSuppressionWindow)
-            {
-                (expired ??= new List<string>()).Add(entry.Key);
-            }
-        }
-
-        if (expired == null)
-        {
-            return;
-        }
+        var expired = _lastNotifiedUtc
+            .Where(entry => now - entry.Value >= NotificationSuppressionWindow)
+            .Select(entry => entry.Key)
+            .ToList();
 
         foreach (var key in expired)
         {

--- a/Gpu/GpuResourceGuard.cs
+++ b/Gpu/GpuResourceGuard.cs
@@ -103,7 +103,22 @@ public sealed class GpuResourceGuard
             return true;
         }
 
-        await DenyAsync(request, config, memory!.Value, cancellationToken).ConfigureAwait(false);
+        // The decision is made. Everything past this point is notification and logging, and none
+        // of it may reverse the refusal: an exception escaping here would reach the decorator's
+        // fail-open catch and admit the very transcode we just judged unsafe. ClientMessageService
+        // does not catch every failure Jellyfin's WebSocket send path can raise.
+        try
+        {
+            await DenyAsync(request, config, memory!.Value, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to notify the client about the refused GPU transcode of {ItemName}; the refusal still stands",
+                request.ItemName ?? "Unknown");
+        }
+
         return false;
     }
 

--- a/Gpu/GpuTranscodeRequest.cs
+++ b/Gpu/GpuTranscodeRequest.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+
+/// <summary>
+/// Everything the guard needs about a transcode Jellyfin is about to launch, lifted out of
+/// <c>StreamState</c> so the policy can be exercised without a live server.
+/// </summary>
+public sealed class GpuTranscodeRequest
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the streaming request asked for video.
+    /// False for audio-only streams.
+    /// </summary>
+    public bool IsVideoRequest { get; set; }
+
+    /// <summary>
+    /// Gets or sets Jellyfin's chosen output video codec. "copy" means remux/Direct Stream.
+    /// </summary>
+    public string? OutputVideoCodec { get; set; }
+
+    /// <summary>
+    /// Gets or sets the FFmpeg arguments Jellyfin built for this job.
+    /// </summary>
+    public string? CommandLineArguments { get; set; }
+
+    /// <summary>
+    /// Gets or sets the requesting device ID. The correlation key for the client message.
+    /// </summary>
+    public string? DeviceId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the play session ID, used to keep repeated attempts at one playback together.
+    /// </summary>
+    public string? PlaySessionId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the authenticated user, or <see cref="Guid.Empty"/> when unknown.
+    /// </summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the item being played.
+    /// </summary>
+    public Guid ItemId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the item name, for logging only.
+    /// </summary>
+    public string? ItemName { get; set; }
+}

--- a/Gpu/GuardedTranscodeManager.cs
+++ b/Gpu/GuardedTranscodeManager.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Streaming;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+
+/// <summary>
+/// Wraps Jellyfin's <see cref="ITranscodeManager"/> so the GPU guard runs immediately before
+/// FFmpeg is launched.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every streaming FFmpeg process in Jellyfin 10.10-10.11 starts through
+/// <see cref="ITranscodeManager.StartFfMpeg"/> - <c>DynamicHlsController</c> (playlist and segment)
+/// and <c>FileStreamResponseHelpers</c> (progressive). Refusing here means the process is never
+/// created, which is the difference between one clean refusal and the retry storm of doomed
+/// FFmpeg launches Jellyfin produces when CUDA cannot allocate.
+/// </para>
+/// <para>
+/// The refusal is an <see cref="ArgumentException"/>, which is exactly how Jellyfin itself refuses
+/// a video transcode a user lacks permission for, and which its exception middleware maps to
+/// HTTP 400 - a terminal answer rather than a retryable server error.
+/// </para>
+/// </remarks>
+public sealed class GuardedTranscodeManager : ITranscodeManager, IDisposable
+{
+    private readonly ITranscodeManager _inner;
+    private readonly GpuResourceGuard _guard;
+    private readonly ILogger<GuardedTranscodeManager> _logger;
+    private bool _disposed;
+
+    public GuardedTranscodeManager(
+        ITranscodeManager inner,
+        GpuResourceGuard guard,
+        ILogger<GuardedTranscodeManager> logger)
+    {
+        _inner = inner;
+        _guard = guard;
+        _logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<TranscodingJob> StartFfMpeg(
+        StreamState state,
+        string outputPath,
+        string commandLineArguments,
+        Guid userId,
+        TranscodingJobType transcodingJobType,
+        CancellationTokenSource cancellationTokenSource,
+        string? workingDirectory = null)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        ArgumentNullException.ThrowIfNull(cancellationTokenSource);
+
+        var admitted = true;
+
+        try
+        {
+            admitted = await _guard.IsAdmittedAsync(
+                BuildRequest(state, commandLineArguments, userId),
+                cancellationTokenSource.Token).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException && ex is not OperationCanceledException)
+        {
+            // A broken guard must never break playback.
+            _logger.LogError(ex, "GPU resource guard failed; allowing the transcode to proceed");
+        }
+
+        if (!admitted)
+        {
+            throw new ArgumentException(_guard.BuildRefusalReason());
+        }
+
+        return await _inner.StartFfMpeg(
+            state,
+            outputPath,
+            commandLineArguments,
+            userId,
+            transcodingJobType,
+            cancellationTokenSource,
+            workingDirectory).ConfigureAwait(false);
+    }
+
+    private static GpuTranscodeRequest BuildRequest(StreamState state, string commandLineArguments, Guid userId)
+    {
+        var request = state.Request;
+
+        return new GpuTranscodeRequest
+        {
+            // Jellyfin has already made the playback decision; these are its answers, not ours.
+            IsVideoRequest = state.VideoRequest != null,
+            OutputVideoCodec = state.OutputVideoCodec,
+            CommandLineArguments = commandLineArguments,
+            DeviceId = request?.DeviceId,
+            PlaySessionId = request?.PlaySessionId,
+            UserId = userId,
+            ItemId = request?.Id ?? Guid.Empty,
+            ItemName = state.MediaSource?.Name
+        };
+    }
+
+    /// <inheritdoc />
+    public TranscodingJob? GetTranscodingJob(string playSessionId)
+        => _inner.GetTranscodingJob(playSessionId);
+
+    /// <inheritdoc />
+    public TranscodingJob? GetTranscodingJob(string path, TranscodingJobType type)
+        => _inner.GetTranscodingJob(path, type);
+
+    /// <inheritdoc />
+    public void PingTranscodingJob(string playSessionId, bool? isUserPaused)
+        => _inner.PingTranscodingJob(playSessionId, isUserPaused);
+
+    /// <inheritdoc />
+    public Task KillTranscodingJobs(string deviceId, string? playSessionId, Func<string, bool> deleteFiles)
+        => _inner.KillTranscodingJobs(deviceId, playSessionId, deleteFiles);
+
+    /// <inheritdoc />
+    public void ReportTranscodingProgress(
+        TranscodingJob job,
+        StreamState state,
+        TimeSpan? transcodingPosition,
+        float? framerate,
+        double? percentComplete,
+        long? bytesTranscoded,
+        int? bitRate)
+        => _inner.ReportTranscodingProgress(job, state, transcodingPosition, framerate, percentComplete, bytesTranscoded, bitRate);
+
+    /// <inheritdoc />
+    public TranscodingJob? OnTranscodeBeginRequest(string path, TranscodingJobType type)
+        => _inner.OnTranscodeBeginRequest(path, type);
+
+    /// <inheritdoc />
+    public void OnTranscodeEndRequest(TranscodingJob job)
+        => _inner.OnTranscodeEndRequest(job);
+
+    /// <inheritdoc />
+    public ValueTask<IDisposable> LockAsync(string outputPath, CancellationToken cancellationToken)
+        => _inner.LockAsync(outputPath, cancellationToken);
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+
+        // The container created the inner manager through this decorator's factory, so its
+        // lifetime is ours to end.
+        (_inner as IDisposable)?.Dispose();
+    }
+}

--- a/Gpu/IGpuMemoryProvider.cs
+++ b/Gpu/IGpuMemoryProvider.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+
+/// <summary>
+/// Reads free video memory for a single GPU.
+/// </summary>
+public interface IGpuMemoryProvider
+{
+    /// <summary>
+    /// Gets the free VRAM for <paramref name="gpuIndex"/>.
+    /// Implementations never throw for an unavailable GPU, driver, or tool; they return a failed result instead.
+    /// </summary>
+    /// <param name="gpuIndex">Zero-based GPU index.</param>
+    /// <param name="timeoutMilliseconds">Upper bound on how long the lookup may take.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The free memory, or a failure describing why it is unknown.</returns>
+    Task<GpuMemoryQueryResult> GetFreeMemoryAsync(int gpuIndex, int timeoutMilliseconds, CancellationToken cancellationToken);
+}

--- a/Gpu/NvidiaSmiGpuMemoryProvider.cs
+++ b/Gpu/NvidiaSmiGpuMemoryProvider.cs
@@ -91,6 +91,10 @@ public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
             CacheFailure(gpuIndex, result);
             return result;
         }
+        catch (OperationCanceledException)
+        {
+            return GpuMemoryQueryResult.Failed("the request was cancelled before the GPU could be queried");
+        }
         finally
         {
             _queryLock.Release();
@@ -116,17 +120,14 @@ public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
 
     private void CacheFailure(int gpuIndex, GpuMemoryQueryResult result)
     {
+        if (result.Success)
+        {
+            // A successful reading decides whether a transcode launches, so it is never reused.
+            return;
+        }
+
         lock (_cacheLock)
         {
-            if (result.Success)
-            {
-                // Never let a successful reading be served to a later admission, and drop any
-                // stale failure now that the GPU is answering again.
-                _cachedFailureGpuIndex = -1;
-                _cachedFailureAtUtc = DateTimeOffset.MinValue;
-                return;
-            }
-
             _cachedFailureGpuIndex = gpuIndex;
             _cachedFailure = result;
             _cachedFailureAtUtc = DateTimeOffset.UtcNow;
@@ -209,12 +210,16 @@ public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
 
             return GpuMemoryQueryResult.FromFreeMiB(freeMiB);
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The caller's request went away. Let this travel past the caching layer: it says
+            // nothing about the GPU, and caching it would let the next admission skip its check.
+            throw;
+        }
         catch (OperationCanceledException)
         {
-            return GpuMemoryQueryResult.Failed(
-                cancellationToken.IsCancellationRequested
-                    ? "the request was cancelled before the GPU could be queried"
-                    : $"{executable} did not respond within {timeoutMilliseconds} ms");
+            // A genuine timeout. This one is worth caching - it is the expensive failure.
+            return GpuMemoryQueryResult.Failed($"{executable} did not respond within {timeoutMilliseconds} ms");
         }
         catch (InvalidOperationException ex)
         {

--- a/Gpu/NvidiaSmiGpuMemoryProvider.cs
+++ b/Gpu/NvidiaSmiGpuMemoryProvider.cs
@@ -15,34 +15,41 @@ public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
 {
     private const string DefaultExecutable = "nvidia-smi";
 
-    // Denied HLS segment requests arrive in bursts. Reusing a very recent reading keeps the guard
-    // from spawning a process per retry while staying far shorter than any realistic VRAM swing.
-    private static readonly TimeSpan DefaultCacheWindow = TimeSpan.FromSeconds(1);
+    // Only FAILED lookups are ever reused, and only briefly.
+    //
+    // A successful reading decides whether a transcode launches, so it must always be fresh:
+    // reusing one would hand two transcodes arriving close together the same pre-allocation
+    // number and admit both - the contention this feature exists to prevent.
+    //
+    // A failed lookup cannot change any decision (the guard is fail-open either way), and it is
+    // the expensive case: without this, a hung nvidia-smi would cost every queued admission the
+    // full timeout in turn.
+    private static readonly TimeSpan DefaultFailureCacheWindow = TimeSpan.FromSeconds(1);
 
     private readonly ILogger<NvidiaSmiGpuMemoryProvider> _logger;
     private readonly Func<string> _executablePathAccessor;
-    private readonly TimeSpan _cacheWindow;
+    private readonly TimeSpan _failureCacheWindow;
     private readonly SemaphoreSlim _queryLock = new(1, 1);
     private readonly object _cacheLock = new();
 
-    private int _cachedGpuIndex = -1;
-    private GpuMemoryQueryResult _cachedResult;
-    private DateTimeOffset _cachedAtUtc = DateTimeOffset.MinValue;
+    private int _cachedFailureGpuIndex = -1;
+    private GpuMemoryQueryResult _cachedFailure;
+    private DateTimeOffset _cachedFailureAtUtc = DateTimeOffset.MinValue;
     private bool _disposed;
 
     public NvidiaSmiGpuMemoryProvider(ILogger<NvidiaSmiGpuMemoryProvider> logger)
-        : this(logger, () => Plugin.Instance?.Configuration.NvidiaSmiPath ?? string.Empty, DefaultCacheWindow)
+        : this(logger, () => Plugin.Instance?.Configuration.NvidiaSmiPath ?? string.Empty, DefaultFailureCacheWindow)
     {
     }
 
     internal NvidiaSmiGpuMemoryProvider(
         ILogger<NvidiaSmiGpuMemoryProvider> logger,
         Func<string> executablePathAccessor,
-        TimeSpan cacheWindow)
+        TimeSpan failureCacheWindow)
     {
         _logger = logger;
         _executablePathAccessor = executablePathAccessor;
-        _cacheWindow = cacheWindow;
+        _failureCacheWindow = failureCacheWindow;
     }
 
     /// <inheritdoc />
@@ -51,9 +58,9 @@ public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
         int timeoutMilliseconds,
         CancellationToken cancellationToken)
     {
-        if (TryReadCache(gpuIndex, out var cached))
+        if (TryReadCachedFailure(gpuIndex, out var cachedFailure))
         {
-            return cached;
+            return cachedFailure;
         }
 
         try
@@ -71,14 +78,17 @@ public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
 
         try
         {
-            // A burst of concurrent requests collapses onto the first query's result.
-            if (TryReadCache(gpuIndex, out cached))
+            // Re-check under the lock: a query that failed while this caller was queued spares it
+            // from repeating the same doomed (and possibly slow) lookup.
+            if (TryReadCachedFailure(gpuIndex, out cachedFailure))
             {
-                return cached;
+                return cachedFailure;
             }
 
+            // Serialised, so concurrent admissions each take their own reading in turn rather
+            // than spawning a process apiece.
             var result = await RunQueryAsync(gpuIndex, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
-            WriteCache(gpuIndex, result);
+            CacheFailure(gpuIndex, result);
             return result;
         }
         finally
@@ -87,15 +97,15 @@ public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
         }
     }
 
-    private bool TryReadCache(int gpuIndex, out GpuMemoryQueryResult result)
+    private bool TryReadCachedFailure(int gpuIndex, out GpuMemoryQueryResult result)
     {
         lock (_cacheLock)
         {
-            if (_cachedGpuIndex == gpuIndex
-                && _cacheWindow > TimeSpan.Zero
-                && DateTimeOffset.UtcNow - _cachedAtUtc < _cacheWindow)
+            if (_cachedFailureGpuIndex == gpuIndex
+                && _failureCacheWindow > TimeSpan.Zero
+                && DateTimeOffset.UtcNow - _cachedFailureAtUtc < _failureCacheWindow)
             {
-                result = _cachedResult;
+                result = _cachedFailure;
                 return true;
             }
         }
@@ -104,13 +114,22 @@ public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
         return false;
     }
 
-    private void WriteCache(int gpuIndex, GpuMemoryQueryResult result)
+    private void CacheFailure(int gpuIndex, GpuMemoryQueryResult result)
     {
         lock (_cacheLock)
         {
-            _cachedGpuIndex = gpuIndex;
-            _cachedResult = result;
-            _cachedAtUtc = DateTimeOffset.UtcNow;
+            if (result.Success)
+            {
+                // Never let a successful reading be served to a later admission, and drop any
+                // stale failure now that the GPU is answering again.
+                _cachedFailureGpuIndex = -1;
+                _cachedFailureAtUtc = DateTimeOffset.MinValue;
+                return;
+            }
+
+            _cachedFailureGpuIndex = gpuIndex;
+            _cachedFailure = result;
+            _cachedFailureAtUtc = DateTimeOffset.UtcNow;
         }
     }
 

--- a/Gpu/NvidiaSmiGpuMemoryProvider.cs
+++ b/Gpu/NvidiaSmiGpuMemoryProvider.cs
@@ -1,0 +1,275 @@
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+
+/// <summary>
+/// Reads free VRAM by running nvidia-smi with a narrow machine-readable query.
+/// </summary>
+public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
+{
+    private const string DefaultExecutable = "nvidia-smi";
+
+    // Denied HLS segment requests arrive in bursts. Reusing a very recent reading keeps the guard
+    // from spawning a process per retry while staying far shorter than any realistic VRAM swing.
+    private static readonly TimeSpan DefaultCacheWindow = TimeSpan.FromSeconds(1);
+
+    private readonly ILogger<NvidiaSmiGpuMemoryProvider> _logger;
+    private readonly Func<string> _executablePathAccessor;
+    private readonly TimeSpan _cacheWindow;
+    private readonly SemaphoreSlim _queryLock = new(1, 1);
+    private readonly object _cacheLock = new();
+
+    private int _cachedGpuIndex = -1;
+    private GpuMemoryQueryResult _cachedResult;
+    private DateTimeOffset _cachedAtUtc = DateTimeOffset.MinValue;
+    private bool _disposed;
+
+    public NvidiaSmiGpuMemoryProvider(ILogger<NvidiaSmiGpuMemoryProvider> logger)
+        : this(logger, () => Plugin.Instance?.Configuration.NvidiaSmiPath ?? string.Empty, DefaultCacheWindow)
+    {
+    }
+
+    internal NvidiaSmiGpuMemoryProvider(
+        ILogger<NvidiaSmiGpuMemoryProvider> logger,
+        Func<string> executablePathAccessor,
+        TimeSpan cacheWindow)
+    {
+        _logger = logger;
+        _executablePathAccessor = executablePathAccessor;
+        _cacheWindow = cacheWindow;
+    }
+
+    /// <inheritdoc />
+    public async Task<GpuMemoryQueryResult> GetFreeMemoryAsync(
+        int gpuIndex,
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken)
+    {
+        if (TryReadCache(gpuIndex, out var cached))
+        {
+            return cached;
+        }
+
+        try
+        {
+            await _queryLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return GpuMemoryQueryResult.Failed("the request was cancelled before the GPU could be queried");
+        }
+        catch (ObjectDisposedException)
+        {
+            return GpuMemoryQueryResult.Failed("the plugin is shutting down");
+        }
+
+        try
+        {
+            // A burst of concurrent requests collapses onto the first query's result.
+            if (TryReadCache(gpuIndex, out cached))
+            {
+                return cached;
+            }
+
+            var result = await RunQueryAsync(gpuIndex, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
+            WriteCache(gpuIndex, result);
+            return result;
+        }
+        finally
+        {
+            _queryLock.Release();
+        }
+    }
+
+    private bool TryReadCache(int gpuIndex, out GpuMemoryQueryResult result)
+    {
+        lock (_cacheLock)
+        {
+            if (_cachedGpuIndex == gpuIndex
+                && _cacheWindow > TimeSpan.Zero
+                && DateTimeOffset.UtcNow - _cachedAtUtc < _cacheWindow)
+            {
+                result = _cachedResult;
+                return true;
+            }
+        }
+
+        result = default;
+        return false;
+    }
+
+    private void WriteCache(int gpuIndex, GpuMemoryQueryResult result)
+    {
+        lock (_cacheLock)
+        {
+            _cachedGpuIndex = gpuIndex;
+            _cachedResult = result;
+            _cachedAtUtc = DateTimeOffset.UtcNow;
+        }
+    }
+
+    private async Task<GpuMemoryQueryResult> RunQueryAsync(
+        int gpuIndex,
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken)
+    {
+        var configuredPath = _executablePathAccessor();
+        var executable = string.IsNullOrWhiteSpace(configuredPath) ? DefaultExecutable : configuredPath.Trim();
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = executable,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+
+        // ArgumentList avoids any shell or quoting interpretation of these values.
+        startInfo.ArgumentList.Add("--query-gpu=index,memory.free");
+        startInfo.ArgumentList.Add("--format=csv,noheader,nounits");
+
+        using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeoutSource.CancelAfter(Math.Max(1, timeoutMilliseconds));
+
+        using var process = new Process { StartInfo = startInfo };
+
+        try
+        {
+            if (!process.Start())
+            {
+                return GpuMemoryQueryResult.Failed($"{executable} could not be started");
+            }
+        }
+        catch (Win32Exception ex)
+        {
+            // Covers "not found" and "permission denied" for the executable itself.
+            return GpuMemoryQueryResult.Failed($"{executable} is not available ({ex.Message})");
+        }
+        catch (InvalidOperationException ex)
+        {
+            return GpuMemoryQueryResult.Failed($"{executable} could not be started ({ex.Message})");
+        }
+        catch (PlatformNotSupportedException ex)
+        {
+            return GpuMemoryQueryResult.Failed($"{executable} cannot be started on this platform ({ex.Message})");
+        }
+
+        // Both pipes must be drained or the child can block on a full buffer. They are started
+        // before the wait and observed in the finally, so a timeout kill cannot leave a faulted
+        // task behind unobserved.
+        Task<string>? stdoutTask = null;
+        Task<string>? stderrTask = null;
+
+        try
+        {
+            stdoutTask = process.StandardOutput.ReadToEndAsync(timeoutSource.Token);
+            stderrTask = process.StandardError.ReadToEndAsync(timeoutSource.Token);
+
+            await process.WaitForExitAsync(timeoutSource.Token).ConfigureAwait(false);
+
+            var stdout = await stdoutTask.ConfigureAwait(false);
+            var stderr = (await stderrTask.ConfigureAwait(false)).Trim();
+
+            if (process.ExitCode != 0)
+            {
+                return GpuMemoryQueryResult.Failed(
+                    $"{executable} exited with code {process.ExitCode}{(stderr.Length == 0 ? string.Empty : ": " + FirstLine(stderr))}");
+            }
+
+            if (!NvidiaSmiOutputParser.TryGetFreeMiB(stdout, gpuIndex, out var freeMiB))
+            {
+                return GpuMemoryQueryResult.Failed($"{executable} did not report a usable value for GPU {gpuIndex}");
+            }
+
+            return GpuMemoryQueryResult.FromFreeMiB(freeMiB);
+        }
+        catch (OperationCanceledException)
+        {
+            return GpuMemoryQueryResult.Failed(
+                cancellationToken.IsCancellationRequested
+                    ? "the request was cancelled before the GPU could be queried"
+                    : $"{executable} did not respond within {timeoutMilliseconds} ms");
+        }
+        catch (InvalidOperationException ex)
+        {
+            return GpuMemoryQueryResult.Failed($"{executable} could not be read ({ex.Message})");
+        }
+        catch (IOException ex)
+        {
+            return GpuMemoryQueryResult.Failed($"{executable} could not be read ({ex.Message})");
+        }
+        finally
+        {
+            TryKill(process, executable);
+            Observe(stdoutTask);
+            Observe(stderrTask);
+        }
+    }
+
+    /// <summary>
+    /// Swallows the result of an abandoned read so a cancelled or broken pipe cannot surface
+    /// as an unobserved task exception.
+    /// </summary>
+    /// <param name="task">The read task, or null if it was never started.</param>
+    private static void Observe(Task? task)
+    {
+        if (task == null || task.IsCompletedSuccessfully)
+        {
+            return;
+        }
+
+        _ = task.ContinueWith(
+            static completed => _ = completed.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
+    }
+
+    private void TryKill(Process process, string executable)
+    {
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+        }
+        catch (InvalidOperationException)
+        {
+            // Already gone.
+        }
+        catch (NotSupportedException ex)
+        {
+            _logger.LogDebug(ex, "Unable to terminate {Executable}", executable);
+        }
+        catch (Win32Exception ex)
+        {
+            _logger.LogDebug(ex, "Unable to terminate {Executable}", executable);
+        }
+    }
+
+    private static string FirstLine(string text)
+    {
+        var end = text.IndexOf('\n', StringComparison.Ordinal);
+        return end < 0 ? text : text[..end].Trim();
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _queryLock.Dispose();
+    }
+}

--- a/Gpu/NvidiaSmiOutputParser.cs
+++ b/Gpu/NvidiaSmiOutputParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Linq;
 
 namespace Jellyfin.Plugin.TranscodeNag.Gpu;
 
@@ -26,47 +27,53 @@ internal static class NvidiaSmiOutputParser
             return false;
         }
 
-        foreach (var rawLine in output.Split('\n'))
+        var rows = output
+            .Split('\n')
+            .Select(rawLine => rawLine.Trim())
+            .Where(line => line.Contains(',', StringComparison.Ordinal));
+
+        foreach (var row in rows)
         {
-            var line = rawLine.Trim();
-            if (line.Length == 0)
-            {
-                continue;
-            }
+            var separator = row.IndexOf(',', StringComparison.Ordinal);
 
-            var separator = line.IndexOf(',', StringComparison.Ordinal);
-            if (separator < 0)
-            {
-                continue;
-            }
-
-            var indexText = line.AsSpan(0, separator).Trim();
-            var freeText = line.AsSpan(separator + 1).Trim();
-
-            // A second comma would mean the caller changed the query; only the first two fields are ours.
-            var extraSeparator = freeText.IndexOf(',');
-            if (extraSeparator >= 0)
-            {
-                freeText = freeText[..extraSeparator].Trim();
-            }
-
-            if (!int.TryParse(indexText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedIndex)
+            if (!int.TryParse(
+                    row.AsSpan(0, separator).Trim(),
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var parsedIndex)
                 || parsedIndex != gpuIndex)
             {
                 continue;
             }
 
-            if (!int.TryParse(freeText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedFree)
-                || parsedFree < 0)
-            {
-                // The index matched but the value is unusable (for example "[N/A]" while the driver reloads).
-                return false;
-            }
-
-            freeMiB = parsedFree;
-            return true;
+            // The index matched, so this is our row. A value we cannot read (for example "[N/A]"
+            // while the driver reloads) means the lookup failed, not that we keep scanning.
+            return TryParseFreeMiB(row.AsSpan(separator + 1), out freeMiB);
         }
 
         return false;
+    }
+
+    private static bool TryParseFreeMiB(ReadOnlySpan<char> value, out int freeMiB)
+    {
+        freeMiB = 0;
+
+        var trimmed = value.Trim();
+
+        // A second comma would mean the caller changed the query; only the first two fields are ours.
+        var extraSeparator = trimmed.IndexOf(',');
+        if (extraSeparator >= 0)
+        {
+            trimmed = trimmed[..extraSeparator].Trim();
+        }
+
+        if (!int.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            || parsed < 0)
+        {
+            return false;
+        }
+
+        freeMiB = parsed;
+        return true;
     }
 }

--- a/Gpu/NvidiaSmiOutputParser.cs
+++ b/Gpu/NvidiaSmiOutputParser.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Globalization;
+
+namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+
+/// <summary>
+/// Parses the machine-readable nvidia-smi output the guard asks for:
+/// <c>--query-gpu=index,memory.free --format=csv,noheader,nounits</c>.
+/// Kept separate from process handling so it can be unit tested directly.
+/// </summary>
+internal static class NvidiaSmiOutputParser
+{
+    /// <summary>
+    /// Finds the free-memory value for <paramref name="gpuIndex"/> in a csv,noheader,nounits payload.
+    /// </summary>
+    /// <param name="output">Raw stdout from nvidia-smi.</param>
+    /// <param name="gpuIndex">Zero-based GPU index to look for.</param>
+    /// <param name="freeMiB">Parsed free memory in MiB.</param>
+    /// <returns>True when the requested index was present and parsed.</returns>
+    internal static bool TryGetFreeMiB(string? output, int gpuIndex, out int freeMiB)
+    {
+        freeMiB = 0;
+
+        if (string.IsNullOrWhiteSpace(output))
+        {
+            return false;
+        }
+
+        foreach (var rawLine in output.Split('\n'))
+        {
+            var line = rawLine.Trim();
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            var separator = line.IndexOf(',', StringComparison.Ordinal);
+            if (separator < 0)
+            {
+                continue;
+            }
+
+            var indexText = line.AsSpan(0, separator).Trim();
+            var freeText = line.AsSpan(separator + 1).Trim();
+
+            // A second comma would mean the caller changed the query; only the first two fields are ours.
+            var extraSeparator = freeText.IndexOf(',');
+            if (extraSeparator >= 0)
+            {
+                freeText = freeText[..extraSeparator].Trim();
+            }
+
+            if (!int.TryParse(indexText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedIndex)
+                || parsedIndex != gpuIndex)
+            {
+                continue;
+            }
+
+            if (!int.TryParse(freeText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedFree)
+                || parsedFree < 0)
+            {
+                // The index matched but the value is unusable (for example "[N/A]" while the driver reloads).
+                return false;
+            }
+
+            freeMiB = parsedFree;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Gpu/NvidiaTranscodeDetector.cs
+++ b/Gpu/NvidiaTranscodeDetector.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Jellyfin.Plugin.TranscodeNag.Gpu;
 
@@ -128,31 +129,14 @@ internal static class NvidiaTranscodeDetector
 
     private static bool IsVideoCodecFlag(string flag)
     {
-        foreach (var prefix in VideoCodecFlagPrefixes)
-        {
-            // Matches "-c:v" as well as the stream-qualified "-codec:v:0".
-            if (flag.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
-                && (flag.Length == prefix.Length || flag[prefix.Length] == ':'))
-            {
-                return true;
-            }
-        }
-
-        return false;
+        // Matches "-c:v" as well as the stream-qualified "-codec:v:0".
+        return VideoCodecFlagPrefixes.Any(prefix =>
+            flag.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            && (flag.Length == prefix.Length || flag[prefix.Length] == ':'));
     }
 
     private static bool IsFilterFlag(string flag)
-    {
-        foreach (var filterFlag in FilterFlags)
-        {
-            if (Is(flag, filterFlag))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+        => FilterFlags.Any(filterFlag => Is(flag, filterFlag));
 
     private static bool StartsWithDeviceType(string value, string deviceType)
     {

--- a/Gpu/NvidiaTranscodeDetector.cs
+++ b/Gpu/NvidiaTranscodeDetector.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+
+namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+
+/// <summary>
+/// Decides whether an FFmpeg invocation Jellyfin is about to launch will touch the NVIDIA GPU.
+/// </summary>
+/// <remarks>
+/// This reads Jellyfin's own finished command line rather than re-deriving codec compatibility.
+/// If Jellyfin decided on CUDA/NVENC, the flags are already there; if it chose CPU, DirectPlay,
+/// or a stream copy, they are not.
+/// </remarks>
+internal static class NvidiaTranscodeDetector
+{
+    private static readonly string[] VideoCodecFlagPrefixes = { "-c:v", "-codec:v", "-vcodec" };
+
+    private static readonly string[] FilterFlags = { "-vf", "-filter:v", "-filter_complex", "-lavfi" };
+
+    /// <summary>
+    /// Returns true when the command line uses CUDA/NVENC/NVDEC in any role: hardware decode,
+    /// hardware filtering, or hardware encode. All three hold VRAM.
+    /// </summary>
+    /// <param name="commandLineArguments">The FFmpeg arguments Jellyfin built for this job.</param>
+    /// <returns>True when the job needs NVIDIA GPU memory.</returns>
+    internal static bool UsesNvidiaGpu(string? commandLineArguments)
+    {
+        if (string.IsNullOrWhiteSpace(commandLineArguments))
+        {
+            return false;
+        }
+
+        var tokens = Tokenize(commandLineArguments);
+
+        for (var i = 0; i < tokens.Count; i++)
+        {
+            var flag = tokens[i];
+            if (flag.Length == 0 || flag[0] != '-')
+            {
+                continue;
+            }
+
+            // Every marker below is a flag/value pair, so a trailing flag can never match.
+            if (i + 1 >= tokens.Count)
+            {
+                break;
+            }
+
+            var value = tokens[i + 1];
+
+            // -hwaccel cuda / -hwaccel nvdec / -hwaccel_output_format cuda
+            if ((Is(flag, "-hwaccel") || Is(flag, "-hwaccel_output_format"))
+                && (Is(value, "cuda") || Is(value, "nvdec")))
+            {
+                return true;
+            }
+
+            // -init_hw_device cuda=cu:0
+            if (Is(flag, "-init_hw_device") && StartsWithDeviceType(value, "cuda"))
+            {
+                return true;
+            }
+
+            // -codec:v:0 av1_nvenc, -c:v h264_cuvid
+            if (IsVideoCodecFlag(flag)
+                && (EndsWith(value, "_nvenc") || EndsWith(value, "_cuvid")))
+            {
+                return true;
+            }
+
+            // -vf "tonemap_cuda=...,scale_cuda=..." - filter graphs never contain file paths,
+            // so a substring match here cannot be tripped by a media file name.
+            if (IsFilterFlag(flag)
+                && (Contains(value, "_cuda") || Contains(value, "_npp") || Contains(value, "cuda=")))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Splits an FFmpeg argument string on whitespace, honouring double-quoted values
+    /// (Jellyfin quotes media paths and filter graphs that contain spaces).
+    /// </summary>
+    /// <param name="commandLine">The raw argument string.</param>
+    /// <returns>The unquoted tokens.</returns>
+    internal static List<string> Tokenize(string commandLine)
+    {
+        var tokens = new List<string>();
+        var current = new System.Text.StringBuilder();
+        var inQuotes = false;
+        var hasToken = false;
+
+        foreach (var c in commandLine)
+        {
+            if (c == '"')
+            {
+                inQuotes = !inQuotes;
+                hasToken = true;
+                continue;
+            }
+
+            if (!inQuotes && char.IsWhiteSpace(c))
+            {
+                if (hasToken)
+                {
+                    tokens.Add(current.ToString());
+                    current.Clear();
+                    hasToken = false;
+                }
+
+                continue;
+            }
+
+            current.Append(c);
+            hasToken = true;
+        }
+
+        if (hasToken)
+        {
+            tokens.Add(current.ToString());
+        }
+
+        return tokens;
+    }
+
+    private static bool IsVideoCodecFlag(string flag)
+    {
+        foreach (var prefix in VideoCodecFlagPrefixes)
+        {
+            // Matches "-c:v" as well as the stream-qualified "-codec:v:0".
+            if (flag.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+                && (flag.Length == prefix.Length || flag[prefix.Length] == ':'))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsFilterFlag(string flag)
+    {
+        foreach (var filterFlag in FilterFlags)
+        {
+            if (Is(flag, filterFlag))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool StartsWithDeviceType(string value, string deviceType)
+    {
+        // "cuda" alone, or "cuda=cu:0".
+        return Is(value, deviceType)
+            || value.StartsWith(deviceType + "=", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool Is(string value, string expected)
+        => string.Equals(value, expected, StringComparison.OrdinalIgnoreCase);
+
+    private static bool EndsWith(string value, string suffix)
+        => value.EndsWith(suffix, StringComparison.OrdinalIgnoreCase);
+
+    private static bool Contains(string value, string fragment)
+        => value.Contains(fragment, StringComparison.OrdinalIgnoreCase);
+}

--- a/Messaging/ClientMessageService.cs
+++ b/Messaging/ClientMessageService.cs
@@ -1,0 +1,256 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Common.Extensions;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Session;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.TranscodeNag.Messaging;
+
+/// <summary>
+/// The shared session-resolution and DisplayMessage plumbing used by every notification the plugin sends.
+/// </summary>
+public sealed class ClientMessageService : IClientMessageService
+{
+    private readonly ISessionManager _sessionManager;
+
+    public ClientMessageService(ISessionManager sessionManager)
+    {
+        _sessionManager = sessionManager;
+    }
+
+    /// <inheritdoc />
+    public SessionInfo? ResolveSession(string? deviceId, Guid userId, Guid itemId)
+        => SelectSession(_sessionManager.Sessions, deviceId, userId, itemId);
+
+    /// <summary>
+    /// The session-selection rules, separated from <see cref="ISessionManager"/> so they can be tested directly.
+    /// </summary>
+    /// <param name="sessions">The live sessions to choose from.</param>
+    /// <param name="deviceId">The device ID from the streaming request.</param>
+    /// <param name="userId">The authenticated user, or <see cref="Guid.Empty"/> if unknown.</param>
+    /// <param name="itemId">The item being requested, used to break ties.</param>
+    /// <returns>The matching session, or null when it cannot be identified unambiguously.</returns>
+    internal static SessionInfo? SelectSession(
+        IEnumerable<SessionInfo>? sessions,
+        string? deviceId,
+        Guid userId,
+        Guid itemId)
+    {
+        if (sessions == null)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(deviceId))
+        {
+            var deviceMatches = sessions
+                .Where(session => session.Id != null
+                    && string.Equals(session.DeviceId, deviceId, StringComparison.Ordinal))
+                .ToList();
+
+            // A device can carry a stale session for whoever signed in previously, so the
+            // requesting user must match too. No match means no message rather than a message
+            // to somebody else's session.
+            if (userId != Guid.Empty)
+            {
+                deviceMatches = deviceMatches.Where(session => SessionBelongsToUser(session, userId)).ToList();
+            }
+
+            return SelectBestMatch(deviceMatches, itemId);
+        }
+
+        if (userId == Guid.Empty)
+        {
+            return null;
+        }
+
+        // No device ID to correlate on. Only message a user session when there is exactly one,
+        // so a second session of the same user can never receive another session's warning.
+        var candidates = sessions
+            .Where(session => session.Id != null && SessionBelongsToUser(session, userId))
+            .ToList();
+
+        return candidates.Count == 1 ? candidates[0] : null;
+    }
+
+    /// <inheritdoc />
+    public async Task<bool> SendMessageAsync(
+        SessionInfo session,
+        MessageCommand command,
+        string context,
+        string detail,
+        bool enableLogging,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        if (session.Id == null)
+        {
+            return false;
+        }
+
+        LogMessageDeliveryDiagnostics(session, context, detail, enableLogging, logger);
+
+        // Jellyfin treats sending to an empty controller collection as a successful no-op.
+        // Do not report or persist that as a delivered message.
+        var (_, activeControllerCount, _) = GetSessionControllerStats(session);
+        if (activeControllerCount == 0)
+        {
+            return false;
+        }
+
+        try
+        {
+            await _sessionManager.SendMessageCommand(
+                null,
+                session.Id,
+                command,
+                cancellationToken).ConfigureAwait(false);
+
+            if (enableLogging)
+            {
+                logger.LogInformation(
+                    "Completed {Context} message send to session {SessionId}",
+                    context,
+                    session.Id);
+            }
+
+            return true;
+        }
+        catch (ResourceNotFoundException ex)
+        {
+            logger.LogError(ex, "Error sending {Context} message to session {SessionId}", context, session.Id);
+        }
+        catch (ObjectDisposedException ex)
+        {
+            logger.LogError(ex, "Error sending {Context} message to session {SessionId}", context, session.Id);
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.LogError(ex, "Error sending {Context} message to session {SessionId}", context, session.Id);
+        }
+        catch (OperationCanceledException ex)
+        {
+            logger.LogError(ex, "Error sending {Context} message to session {SessionId}", context, session.Id);
+        }
+        catch (ArgumentException ex)
+        {
+            logger.LogError(ex, "Error sending {Context} message to session {SessionId}", context, session.Id);
+        }
+
+        return false;
+    }
+
+    private static bool SessionBelongsToUser(SessionInfo session, Guid userId)
+    {
+        return session.UserId == userId || session.ContainsUser(userId);
+    }
+
+    private static SessionInfo? SelectBestMatch(List<SessionInfo> candidates, Guid itemId)
+    {
+        if (candidates.Count == 0)
+        {
+            return null;
+        }
+
+        if (candidates.Count == 1)
+        {
+            return candidates[0];
+        }
+
+        // Several live sessions share the device (for example a client that reconnected).
+        // Prefer the one already playing this item; otherwise take the first.
+        if (itemId != Guid.Empty)
+        {
+            var playingMatch = candidates.FirstOrDefault(session => session.NowPlayingItem?.Id == itemId);
+            if (playingMatch != null)
+            {
+                return playingMatch;
+            }
+        }
+
+        return candidates[0];
+    }
+
+    private static void LogMessageDeliveryDiagnostics(
+        SessionInfo session,
+        string context,
+        string detail,
+        bool enableLogging,
+        ILogger logger)
+    {
+        if (!enableLogging)
+        {
+            return;
+        }
+
+        var (controllerCount, activeControllerCount, mediaControlControllerCount) = GetSessionControllerStats(session);
+        var supportedCommands = FormatSupportedCommands(session.SupportedCommands);
+        var supportsDisplayMessage = session.SupportedCommands?.Contains(GeneralCommandType.DisplayMessage) == true;
+
+        logger.LogInformation(
+            "Sending {Context} message to session {SessionId} ({Client} {ApplicationVersion}) for user {UserName} on device {DeviceName} ({DeviceId}) - {Detail}; Controllers: {ControllerCount} total, {ActiveControllerCount} active, {MediaControlControllerCount} media-control; SupportsRemoteControl: {SupportsRemoteControl}; SupportsMediaControl: {SupportsMediaControl}; SupportsDisplayMessage: {SupportsDisplayMessage}; SupportedCommands: {SupportedCommands}",
+            context,
+            session.Id ?? "Unknown",
+            session.Client ?? "Unknown",
+            session.ApplicationVersion ?? "Unknown",
+            session.UserName ?? "Unknown",
+            session.DeviceName ?? "Unknown",
+            session.DeviceId ?? "Unknown",
+            detail,
+            controllerCount,
+            activeControllerCount,
+            mediaControlControllerCount,
+            session.SupportsRemoteControl,
+            session.SupportsMediaControl,
+            supportsDisplayMessage,
+            supportedCommands);
+
+        if (controllerCount == 0 || activeControllerCount == 0)
+        {
+            logger.LogWarning(
+                "{Context} target session {SessionId} has {ControllerCount} controller(s) and {ActiveControllerCount} active controller(s). Jellyfin may accept the command without any client receiving a popup; check WebSocket/reverse proxy/client session state.",
+                context,
+                session.Id ?? "Unknown",
+                controllerCount,
+                activeControllerCount);
+        }
+        else if (!supportsDisplayMessage)
+        {
+            logger.LogWarning(
+                "{Context} target session {SessionId} does not advertise DisplayMessage support. The client may ignore the nag popup.",
+                context,
+                session.Id ?? "Unknown");
+        }
+    }
+
+    private static (int ControllerCount, int ActiveControllerCount, int MediaControlControllerCount) GetSessionControllerStats(SessionInfo session)
+    {
+        var controllers = session.SessionControllers;
+        if (controllers == null)
+        {
+            return (0, 0, 0);
+        }
+
+        return (
+            controllers.Count,
+            controllers.Count(controller => controller.IsSessionActive),
+            controllers.Count(controller => controller.SupportsMediaControl));
+    }
+
+    private static string FormatSupportedCommands(IReadOnlyList<GeneralCommandType>? supportedCommands)
+    {
+        if (supportedCommands == null || supportedCommands.Count == 0)
+        {
+            return "None";
+        }
+
+        return string.Join(", ", supportedCommands);
+    }
+}

--- a/Messaging/IClientMessageService.cs
+++ b/Messaging/IClientMessageService.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Session;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.TranscodeNag.Messaging;
+
+/// <summary>
+/// Resolves Jellyfin sessions and delivers DisplayMessage popups to a single one of them.
+/// </summary>
+public interface IClientMessageService
+{
+    /// <summary>
+    /// Finds the one session a streaming request belongs to.
+    /// </summary>
+    /// <remarks>
+    /// Device ID is the correlation key Jellyfin itself uses for streaming requests, so parallel
+    /// sessions belonging to the same user are never confused with each other. When the request
+    /// carries no device ID, a user match is only used if it is unambiguous.
+    /// </remarks>
+    /// <param name="deviceId">The device ID from the streaming request.</param>
+    /// <param name="userId">The authenticated user, or <see cref="Guid.Empty"/> if unknown.</param>
+    /// <param name="itemId">The item being requested, used to break ties.</param>
+    /// <returns>The matching session, or null when it cannot be identified unambiguously.</returns>
+    SessionInfo? ResolveSession(string? deviceId, Guid userId, Guid itemId);
+
+    /// <summary>
+    /// Sends a message command to one session, logging the same delivery diagnostics for every caller.
+    /// </summary>
+    /// <param name="session">Target session.</param>
+    /// <param name="command">The message to display.</param>
+    /// <param name="context">Short label for logs, for example "playback nag".</param>
+    /// <param name="detail">Extra log detail for this specific send.</param>
+    /// <param name="enableLogging">Whether informational delivery logging is switched on.</param>
+    /// <param name="logger">The caller's logger, so log categories stay with the feature that sent the message.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>True only when Jellyfin accepted the command for a live controller.</returns>
+    Task<bool> SendMessageAsync(
+        SessionInfo session,
+        MessageCommand command,
+        string context,
+        string detail,
+        bool enableLogging,
+        ILogger logger,
+        CancellationToken cancellationToken);
+}

--- a/PlaybackMonitor.cs
+++ b/PlaybackMonitor.cs
@@ -5,9 +5,9 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Jellyfin.Plugin.TranscodeNag.Data;
+using Jellyfin.Plugin.TranscodeNag.Messaging;
 using Jellyfin.Plugin.TranscodeNag.Models;
 using MediaBrowser.Common.Configuration;
-using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Session;
@@ -19,6 +19,7 @@ namespace Jellyfin.Plugin.TranscodeNag;
 public class PlaybackMonitor : IHostedService
 {
     private readonly ISessionManager _sessionManager;
+    private readonly IClientMessageService _clientMessageService;
     private readonly ILogger<PlaybackMonitor> _logger;
     private readonly TranscodeEventStore _eventStore;
     private readonly HashSet<string> _naggedPlaybacks = new();
@@ -45,11 +46,13 @@ public class PlaybackMonitor : IHostedService
 
     public PlaybackMonitor(
         ISessionManager sessionManager,
+        IClientMessageService clientMessageService,
         IApplicationPaths applicationPaths,
         ILogger<PlaybackMonitor> logger,
         ILogger<TranscodeEventStore> eventStoreLogger)
     {
         _sessionManager = sessionManager;
+        _clientMessageService = clientMessageService;
         _logger = logger;
         _eventStore = new TranscodeEventStore(applicationPaths, eventStoreLogger);
     }
@@ -64,6 +67,17 @@ public class PlaybackMonitor : IHostedService
         // (SessionControllerConnected covers fresh sessions once messages can be delivered.)
         _sessionPollTimer = new Timer(PollSessionsForReopen, null, TimeSpan.FromSeconds(15), TimeSpan.FromSeconds(30));
         _logger.LogInformation("PlaybackMonitor started - listening for playback and session events");
+
+        // The guard is wired into Jellyfin's transcode manager at service-registration time, long
+        // before any logger exists. Surface a failed hookup here so it is not silent.
+        var decorationFailure = PluginServiceRegistrator.DecorationFailure;
+        if (decorationFailure != null)
+        {
+            _logger.LogWarning(
+                "GPU resource guard is not installed and will never refuse a transcode on this server ({Reason}). All other Transcode Nag features are unaffected.",
+                decorationFailure);
+        }
+
         return Task.CompletedTask;
     }
 
@@ -363,143 +377,23 @@ public class PlaybackMonitor : IHostedService
             $"Reasons: {transcodeReasons}").ConfigureAwait(false);
     }
 
-    private async Task<bool> SendMessageCommandWithDiagnosticsAsync(
+    private Task<bool> SendMessageCommandWithDiagnosticsAsync(
         SessionInfo session,
         Configuration.PluginConfiguration config,
         MessageCommand command,
         string context,
         string detail)
     {
-        if (session.Id == null)
-        {
-            return false;
-        }
-
-        LogMessageDeliveryDiagnostics(session, config, context, detail);
-
-        // Jellyfin treats sending to an empty controller collection as a successful no-op.
-        // Do not report or persist that as a delivered message.
-        var (_, activeControllerCount, _) = GetSessionControllerStats(session);
-        if (activeControllerCount == 0)
-        {
-            return false;
-        }
-
-        try
-        {
-            await _sessionManager.SendMessageCommand(
-                null,
-                session.Id,
-                command,
-                CancellationToken.None).ConfigureAwait(false);
-
-            if (config.EnableLogging)
-            {
-                _logger.LogInformation(
-                    "Completed {Context} message send to session {SessionId}",
-                    context,
-                    session.Id);
-            }
-
-            return true;
-        }
-        catch (ResourceNotFoundException ex)
-        {
-            _logger.LogError(ex, "Error sending {Context} message to session {SessionId}", context, session.Id);
-        }
-        catch (ObjectDisposedException ex)
-        {
-            _logger.LogError(ex, "Error sending {Context} message to session {SessionId}", context, session.Id);
-        }
-        catch (InvalidOperationException ex)
-        {
-            _logger.LogError(ex, "Error sending {Context} message to session {SessionId}", context, session.Id);
-        }
-        catch (OperationCanceledException ex)
-        {
-            _logger.LogError(ex, "Error sending {Context} message to session {SessionId}", context, session.Id);
-        }
-        catch (ArgumentException ex)
-        {
-            _logger.LogError(ex, "Error sending {Context} message to session {SessionId}", context, session.Id);
-        }
-
-        return false;
-    }
-
-    private void LogMessageDeliveryDiagnostics(
-        SessionInfo session,
-        Configuration.PluginConfiguration config,
-        string context,
-        string detail)
-    {
-        if (!config.EnableLogging)
-        {
-            return;
-        }
-
-        var (controllerCount, activeControllerCount, mediaControlControllerCount) = GetSessionControllerStats(session);
-        var supportedCommands = FormatSupportedCommands(session.SupportedCommands);
-        var supportsDisplayMessage = session.SupportedCommands?.Contains(GeneralCommandType.DisplayMessage) == true;
-
-        _logger.LogInformation(
-            "Sending {Context} message to session {SessionId} ({Client} {ApplicationVersion}) for user {UserName} on device {DeviceName} ({DeviceId}) - {Detail}; Controllers: {ControllerCount} total, {ActiveControllerCount} active, {MediaControlControllerCount} media-control; SupportsRemoteControl: {SupportsRemoteControl}; SupportsMediaControl: {SupportsMediaControl}; SupportsDisplayMessage: {SupportsDisplayMessage}; SupportedCommands: {SupportedCommands}",
+        // The logger is passed through so these diagnostics keep appearing under PlaybackMonitor's
+        // category rather than moving to the shared service.
+        return _clientMessageService.SendMessageAsync(
+            session,
+            command,
             context,
-            session.Id ?? "Unknown",
-            session.Client ?? "Unknown",
-            session.ApplicationVersion ?? "Unknown",
-            session.UserName ?? "Unknown",
-            session.DeviceName ?? "Unknown",
-            session.DeviceId ?? "Unknown",
             detail,
-            controllerCount,
-            activeControllerCount,
-            mediaControlControllerCount,
-            session.SupportsRemoteControl,
-            session.SupportsMediaControl,
-            supportsDisplayMessage,
-            supportedCommands);
-
-        if (controllerCount == 0 || activeControllerCount == 0)
-        {
-            _logger.LogWarning(
-                "{Context} target session {SessionId} has {ControllerCount} controller(s) and {ActiveControllerCount} active controller(s). Jellyfin may accept the command without any client receiving a popup; check WebSocket/reverse proxy/client session state.",
-                context,
-                session.Id ?? "Unknown",
-                controllerCount,
-                activeControllerCount);
-        }
-        else if (!supportsDisplayMessage)
-        {
-            _logger.LogWarning(
-                "{Context} target session {SessionId} does not advertise DisplayMessage support. The client may ignore the nag popup.",
-                context,
-                session.Id ?? "Unknown");
-        }
-    }
-
-    private static (int ControllerCount, int ActiveControllerCount, int MediaControlControllerCount) GetSessionControllerStats(SessionInfo session)
-    {
-        var controllers = session.SessionControllers;
-        if (controllers == null)
-        {
-            return (0, 0, 0);
-        }
-
-        return (
-            controllers.Count,
-            controllers.Count(controller => controller.IsSessionActive),
-            controllers.Count(controller => controller.SupportsMediaControl));
-    }
-
-    private static string FormatSupportedCommands(IReadOnlyList<GeneralCommandType>? supportedCommands)
-    {
-        if (supportedCommands == null || supportedCommands.Count == 0)
-        {
-            return "None";
-        }
-
-        return string.Join(", ", supportedCommands);
+            config.EnableLogging,
+            _logger,
+            CancellationToken.None);
     }
 
     private void RecordTranscodeEvent(SessionInfo session, TranscodingInfo transcodeInfo)

--- a/PluginServiceRegistrator.cs
+++ b/PluginServiceRegistrator.cs
@@ -1,13 +1,94 @@
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Jellyfin.Plugin.TranscodeNag.Gpu;
+using Jellyfin.Plugin.TranscodeNag.Messaging;
 using MediaBrowser.Controller;
+using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Plugins;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.TranscodeNag;
 
 public class PluginServiceRegistrator : IPluginServiceRegistrator
 {
+    /// <summary>
+    /// Gets why the GPU guard could not be installed, or null when it was.
+    /// Read once by <see cref="PlaybackMonitor"/> at startup.
+    /// </summary>
+    internal static string? DecorationFailure { get; private set; }
+
     public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
     {
+        serviceCollection.AddSingleton<IClientMessageService, ClientMessageService>();
+        serviceCollection.AddSingleton<IGpuMemoryProvider, NvidiaSmiGpuMemoryProvider>();
+        serviceCollection.AddSingleton<GpuResourceGuard>();
         serviceCollection.AddHostedService<PlaybackMonitor>();
+
+        TryDecorateTranscodeManager(serviceCollection);
+    }
+
+    /// <summary>
+    /// Wraps Jellyfin's <c>ITranscodeManager</c> so the GPU guard can refuse a hardware transcode
+    /// before FFmpeg is launched.
+    /// </summary>
+    /// <remarks>
+    /// Jellyfin calls plugin service registrators after its own <c>RegisterServices</c>, so the core
+    /// descriptor is already in the collection and can be replaced by one that decorates it. The
+    /// call is isolated behind a non-inlined method and a broad catch because <c>ITranscodeManager</c>
+    /// does not exist before Jellyfin 10.10 - on an older server the type load must degrade to
+    /// "no guard", not to a malfunctioning plugin that also loses the nag features.
+    /// </remarks>
+    internal static void TryDecorateTranscodeManager(IServiceCollection serviceCollection)
+    {
+        DecorationFailure = null;
+
+        try
+        {
+            DecorateTranscodeManager(serviceCollection);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            // Losing the GPU guard must not cost the user the nag and MOTD features: Jellyfin
+            // marks a plugin malfunctioned if a registrator throws. PlaybackMonitor reports this
+            // on startup so the degradation is visible in the log rather than silent.
+            DecorationFailure = ex.GetType().Name + ": " + ex.Message;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void DecorateTranscodeManager(IServiceCollection serviceCollection)
+    {
+        var descriptor = serviceCollection.LastOrDefault(service => service.ServiceType == typeof(ITranscodeManager));
+
+        // Without a concrete implementation type there is no safe way to rebuild the inner manager,
+        // so the guard stands down rather than guessing.
+        if (descriptor == null)
+        {
+            DecorationFailure = "no ITranscodeManager registration was found";
+            return;
+        }
+
+        if (descriptor.ImplementationType == null)
+        {
+            DecorationFailure = "the ITranscodeManager registration is not a concrete implementation type";
+            return;
+        }
+
+        var implementationType = descriptor.ImplementationType;
+        var lifetime = descriptor.Lifetime;
+
+        var replacement = new ServiceDescriptor(
+            typeof(ITranscodeManager),
+            provider => new GuardedTranscodeManager(
+                (ITranscodeManager)ActivatorUtilities.CreateInstance(provider, implementationType),
+                provider.GetRequiredService<GpuResourceGuard>(),
+                provider.GetRequiredService<ILogger<GuardedTranscodeManager>>()),
+            lifetime);
+
+        // Swap without an intermediate state in which nothing provides ITranscodeManager.
+        serviceCollection.Remove(descriptor);
+        serviceCollection.Add(replacement);
     }
 }

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ A Jellyfin plugin that intelligently nags users when they're transcoding due to 
 - Lets you exclude users from all nags.
 - Includes a live session monitor in the plugin settings page.
 - Can broadcast an optional Message of the Day to users at login, with its own user exclusions and client filters.
-- Can refuse a hardware (NVIDIA) video transcode before FFmpeg starts when the GPU is out of memory, instead of letting it fail and retry.
+- Can refuse an NVIDIA hardware transcode before FFmpeg starts when free VRAM is below a threshold.
 
 ## Installation
 
@@ -87,35 +87,7 @@ Open **Dashboard** → **Plugins** → **Transcode Nag**.
 - Use **Manage Excluded Users** to opt users out of both playback and login nags.
 - Use the built-in live session monitor to see which active sessions currently match your rules.
 - Enable **Message of the Day** (off by default) to send an announcement to everyone at login. Its options stay collapsed until the toggle is on, and it has its own message, its own **Manage Excluded Users (MOTD)** list, and its own client include/exclude filters, all independent of the nag settings.
-- Enable **GPU resource guard** (off by default) to set a free-VRAM floor, the GPU index to watch, the nvidia-smi timeout and path, and the popup a refused client sees.
-
-## GPU Resource Guard
-
-When a GPU is shared with another workload, a second 4K hardware transcode can fail to allocate
-VRAM. Jellyfin's response is to launch FFmpeg, watch it die, and retry - several dead processes and
-a generic playback error for the user.
-
-With the guard enabled, Transcode Nag checks free VRAM at the moment Jellyfin is about to start
-FFmpeg and refuses the job if it is below your threshold. No FFmpeg process is created, the
-requesting client gets a **Transcoding unavailable** popup, and the server log carries one clear
-line naming the session, user, device, item, free VRAM, and threshold.
-
-**What is guarded.** Only jobs that both encode video (not a stream copy) and use the NVIDIA path -
-`-hwaccel cuda`, `*_nvenc`, `*_cuvid`, or CUDA/NPP filters. Direct Play, Direct Stream, container
-remuxing, audio-only transcodes, and CPU-only video transcodes are never refused. This is read from
-the FFmpeg command line Jellyfin has already built, so the plugin does not second-guess Jellyfin's
-own playback decision.
-
-**Fail-open.** If `nvidia-smi` is missing, times out, returns malformed output, or does not know the
-configured GPU index, the guard logs a warning and allows playback. It never denies on ignorance.
-
-**Requirements.** `nvidia-smi` must be runnable by the Jellyfin server process. In a container that
-means the NVIDIA container runtime. Set an explicit path in the settings if it is not on `PATH`.
-
-**Scope.** This is admission control, not a GPU scheduler. It never kills running transcodes,
-touches other GPU workloads, or changes transcoding quality. There is an unavoidable race between
-reading free VRAM and FFmpeg allocating it, so clearing the threshold is not a guarantee - the point
-is to refuse the failures that are predictable because VRAM is plainly exhausted.
+- Enable **GPU resource guard** (off by default) to set the GPU index, minimum free VRAM, nvidia-smi timeout and path, and the message a refused client sees. `nvidia-smi` must be runnable by the Jellyfin server process.
 
 ## Behavior Notes
 
@@ -124,6 +96,5 @@ is to refuse the failures that are predictable because VRAM is plainly exhausted
 - If a user returns to direct play after a bad transcode, login nags are suppressed until they regress again.
 - The MOTD is sent once per session at login and is unrelated to transcode history. Sessions that were already signed in when you enabled it receive nothing until they sign in again.
 - If a user qualifies for both the MOTD and a login nag, the nag waits for the MOTD to time out first, so clients that show one message at a time still display both.
-- A guard refusal returns HTTP 400 to the stream request - the same terminal answer Jellyfin gives when a user lacks video transcoding permission - so clients stop rather than retry.
-- Repeated attempts at the same refused stream are each refused, but the client popup and the warning log are de-duplicated for 10 seconds.
-- Freeing GPU memory restores normal playback on the next attempt. No setting change or restart is needed.
+- The GPU guard only refuses NVIDIA video transcodes. Direct Play, Direct Stream, remux, audio-only, and CPU transcodes are never refused, and playback is allowed whenever free VRAM cannot be read.
+- A refused stream returns HTTP 400 and starts no FFmpeg process. Freeing GPU memory restores playback on the next attempt, with no setting change or restart.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ A Jellyfin plugin that intelligently nags users when they're transcoding due to 
 - Lets you exclude users from all nags.
 - Includes a live session monitor in the plugin settings page.
 - Can broadcast an optional Message of the Day to users at login, with its own user exclusions and client filters.
+- Can refuse a hardware (NVIDIA) video transcode before FFmpeg starts when the GPU is out of memory, instead of letting it fail and retry.
 
 ## Installation
 
@@ -86,6 +87,35 @@ Open **Dashboard** → **Plugins** → **Transcode Nag**.
 - Use **Manage Excluded Users** to opt users out of both playback and login nags.
 - Use the built-in live session monitor to see which active sessions currently match your rules.
 - Enable **Message of the Day** (off by default) to send an announcement to everyone at login. Its options stay collapsed until the toggle is on, and it has its own message, its own **Manage Excluded Users (MOTD)** list, and its own client include/exclude filters, all independent of the nag settings.
+- Enable **GPU resource guard** (off by default) to set a free-VRAM floor, the GPU index to watch, the nvidia-smi timeout and path, and the popup a refused client sees.
+
+## GPU Resource Guard
+
+When a GPU is shared with another workload, a second 4K hardware transcode can fail to allocate
+VRAM. Jellyfin's response is to launch FFmpeg, watch it die, and retry - several dead processes and
+a generic playback error for the user.
+
+With the guard enabled, Transcode Nag checks free VRAM at the moment Jellyfin is about to start
+FFmpeg and refuses the job if it is below your threshold. No FFmpeg process is created, the
+requesting client gets a **Transcoding unavailable** popup, and the server log carries one clear
+line naming the session, user, device, item, free VRAM, and threshold.
+
+**What is guarded.** Only jobs that both encode video (not a stream copy) and use the NVIDIA path -
+`-hwaccel cuda`, `*_nvenc`, `*_cuvid`, or CUDA/NPP filters. Direct Play, Direct Stream, container
+remuxing, audio-only transcodes, and CPU-only video transcodes are never refused. This is read from
+the FFmpeg command line Jellyfin has already built, so the plugin does not second-guess Jellyfin's
+own playback decision.
+
+**Fail-open.** If `nvidia-smi` is missing, times out, returns malformed output, or does not know the
+configured GPU index, the guard logs a warning and allows playback. It never denies on ignorance.
+
+**Requirements.** `nvidia-smi` must be runnable by the Jellyfin server process. In a container that
+means the NVIDIA container runtime. Set an explicit path in the settings if it is not on `PATH`.
+
+**Scope.** This is admission control, not a GPU scheduler. It never kills running transcodes,
+touches other GPU workloads, or changes transcoding quality. There is an unavoidable race between
+reading free VRAM and FFmpeg allocating it, so clearing the threshold is not a guarantee - the point
+is to refuse the failures that are predictable because VRAM is plainly exhausted.
 
 ## Behavior Notes
 
@@ -94,3 +124,6 @@ Open **Dashboard** → **Plugins** → **Transcode Nag**.
 - If a user returns to direct play after a bad transcode, login nags are suppressed until they regress again.
 - The MOTD is sent once per session at login and is unrelated to transcode history. Sessions that were already signed in when you enabled it receive nothing until they sign in again.
 - If a user qualifies for both the MOTD and a login nag, the nag waits for the MOTD to time out first, so clients that show one message at a time still display both.
+- A guard refusal returns HTTP 400 to the stream request - the same terminal answer Jellyfin gives when a user lacks video transcoding permission - so clients stop rather than retry.
+- Repeated attempts at the same refused stream are each refused, but the client popup and the warning log are de-duplicated for 10 seconds.
+- Freeing GPU memory restores normal playback on the next attempt. No setting change or restart is needed.

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/ClientMessageServiceTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/ClientMessageServiceTests.cs
@@ -1,0 +1,108 @@
+using Jellyfin.Plugin.TranscodeNag.Messaging;
+using MediaBrowser.Controller.Session;
+
+namespace Jellyfin.Plugin.TranscodeNag.Tests;
+
+public class ClientMessageServiceTests
+{
+    private static readonly Guid AliceId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid BobId = Guid.Parse("33333333-3333-3333-3333-333333333333");
+
+    [Fact]
+    public void SelectSession_MatchesOnDeviceId()
+    {
+        var target = TestSessions.Create("session-2", "device-2", AliceId);
+        var sessions = new List<SessionInfo>
+        {
+            TestSessions.Create("session-1", "device-1", AliceId),
+            target
+        };
+
+        Assert.Same(target, ClientMessageService.SelectSession(sessions, "device-2", AliceId, Guid.Empty));
+    }
+
+    [Fact]
+    public void SelectSession_KeepsParallelSessionsOfOneUserApart()
+    {
+        var first = TestSessions.Create("session-1", "device-1", AliceId);
+        var second = TestSessions.Create("session-2", "device-2", AliceId);
+        var sessions = new List<SessionInfo> { first, second };
+
+        Assert.Same(first, ClientMessageService.SelectSession(sessions, "device-1", AliceId, Guid.Empty));
+        Assert.Same(second, ClientMessageService.SelectSession(sessions, "device-2", AliceId, Guid.Empty));
+    }
+
+    [Fact]
+    public void SelectSession_NarrowsASharedDeviceToTheRequestingUser()
+    {
+        var alice = TestSessions.Create("session-a", "shared-device", AliceId, "alice");
+        var bob = TestSessions.Create("session-b", "shared-device", BobId, "bob");
+        var sessions = new List<SessionInfo> { alice, bob };
+
+        Assert.Same(bob, ClientMessageService.SelectSession(sessions, "shared-device", BobId, Guid.Empty));
+    }
+
+    [Fact]
+    public void SelectSession_RefusesAStaleSessionBelongingToAnotherUser()
+    {
+        // The device's only live session is somebody else's sign-in. Messaging it would show
+        // one user's refusal to another, so nothing is sent.
+        var sessions = new List<SessionInfo> { TestSessions.Create("session-a", "device-1", AliceId, "alice") };
+
+        Assert.Null(ClientMessageService.SelectSession(sessions, "device-1", BobId, Guid.Empty));
+    }
+
+    [Fact]
+    public void SelectSession_MatchesOnDeviceIdWhenTheRequestHasNoUser()
+    {
+        var only = TestSessions.Create("session-a", "device-1", AliceId, "alice");
+        var sessions = new List<SessionInfo> { only };
+
+        Assert.Same(only, ClientMessageService.SelectSession(sessions, "device-1", Guid.Empty, Guid.Empty));
+    }
+
+    [Fact]
+    public void SelectSession_ReturnsNullWhenTheDeviceIsUnknown()
+    {
+        var sessions = new List<SessionInfo> { TestSessions.Create("session-1", "device-1", AliceId) };
+
+        Assert.Null(ClientMessageService.SelectSession(sessions, "device-9", AliceId, Guid.Empty));
+    }
+
+    [Fact]
+    public void SelectSession_WithoutADeviceIdUsesAUniqueUserMatch()
+    {
+        var only = TestSessions.Create("session-1", "device-1", AliceId);
+        var sessions = new List<SessionInfo> { only, TestSessions.Create("session-b", "device-b", BobId, "bob") };
+
+        Assert.Same(only, ClientMessageService.SelectSession(sessions, null, AliceId, Guid.Empty));
+    }
+
+    [Fact]
+    public void SelectSession_WithoutADeviceIdRefusesToGuessBetweenUserSessions()
+    {
+        var sessions = new List<SessionInfo>
+        {
+            TestSessions.Create("session-1", "device-1", AliceId),
+            TestSessions.Create("session-2", "device-2", AliceId)
+        };
+
+        // Messaging either one could warn the wrong playback, so nothing is sent.
+        Assert.Null(ClientMessageService.SelectSession(sessions, null, AliceId, Guid.Empty));
+    }
+
+    [Fact]
+    public void SelectSession_WithoutADeviceIdOrUserReturnsNull()
+    {
+        var sessions = new List<SessionInfo> { TestSessions.Create("session-1", "device-1", AliceId) };
+
+        Assert.Null(ClientMessageService.SelectSession(sessions, null, Guid.Empty, Guid.Empty));
+    }
+
+    [Fact]
+    public void SelectSession_HandlesNoSessions()
+    {
+        Assert.Null(ClientMessageService.SelectSession(null, "device-1", AliceId, Guid.Empty));
+        Assert.Null(ClientMessageService.SelectSession(new List<SessionInfo>(), "device-1", AliceId, Guid.Empty));
+    }
+}

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuAdmissionPolicyTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuAdmissionPolicyTests.cs
@@ -1,0 +1,153 @@
+using Jellyfin.Plugin.TranscodeNag.Configuration;
+using Jellyfin.Plugin.TranscodeNag.Gpu;
+
+namespace Jellyfin.Plugin.TranscodeNag.Tests;
+
+public class GpuAdmissionPolicyTests
+{
+    private const string CudaNvencArguments =
+        "-init_hw_device cuda=cu:0 -hwaccel cuda -hwaccel_output_format cuda -i \"/media/movie.mkv\" " +
+        "-codec:v:0 av1_nvenc -codec:a:0 libfdk_aac";
+
+    private static PluginConfiguration EnabledConfig(int thresholdMiB = 1500) => new()
+    {
+        EnableGpuResourceGuard = true,
+        MinimumFreeGpuMemoryMiB = thresholdMiB,
+        GpuIndex = 0
+    };
+
+    [Fact]
+    public void Evaluate_GuardDisabled_AllowsWithoutNeedingAGpuReading()
+    {
+        var config = new PluginConfiguration { EnableGpuResourceGuard = false };
+
+        Assert.False(GpuAdmissionPolicy.RequiresGpuQuery(config, requiresGpuVideoTranscode: true));
+        Assert.Equal(
+            GpuAdmissionOutcome.AllowedGuardDisabled,
+            GpuAdmissionPolicy.Evaluate(config, requiresGpuVideoTranscode: true, memory: null));
+    }
+
+    [Fact]
+    public void RequiresGpuVideoTranscode_DirectPlayHasNoFfmpegJobToJudge()
+    {
+        // Direct Play never reaches StartFfMpeg at all; the closest analogue here is a request
+        // that carries neither a video encode nor GPU flags.
+        Assert.False(GpuAdmissionPolicy.RequiresGpuVideoTranscode(
+            isVideoRequest: false,
+            outputVideoCodec: null,
+            commandLineArguments: null));
+    }
+
+    [Fact]
+    public void RequiresGpuVideoTranscode_RemuxIsAllowedEvenWithGpuFlagsPresent()
+    {
+        Assert.False(GpuAdmissionPolicy.RequiresGpuVideoTranscode(
+            isVideoRequest: true,
+            outputVideoCodec: "copy",
+            commandLineArguments: CudaNvencArguments));
+    }
+
+    [Fact]
+    public void RequiresGpuVideoTranscode_AudioOnlyTranscodeIsAllowed()
+    {
+        Assert.False(GpuAdmissionPolicy.RequiresGpuVideoTranscode(
+            isVideoRequest: false,
+            outputVideoCodec: null,
+            commandLineArguments: "-i \"/media/song.flac\" -codec:a:0 libmp3lame -f mp3 out.mp3"));
+    }
+
+    [Fact]
+    public void RequiresGpuVideoTranscode_CpuVideoTranscodeIsAllowed()
+    {
+        Assert.False(GpuAdmissionPolicy.RequiresGpuVideoTranscode(
+            isVideoRequest: true,
+            outputVideoCodec: "h264",
+            commandLineArguments: "-i \"/media/movie.mkv\" -codec:v:0 libx264 -codec:a:0 libfdk_aac"));
+    }
+
+    [Fact]
+    public void RequiresGpuVideoTranscode_HardwareVideoTranscodeIsGuarded()
+    {
+        Assert.True(GpuAdmissionPolicy.RequiresGpuVideoTranscode(
+            isVideoRequest: true,
+            outputVideoCodec: "av1",
+            commandLineArguments: CudaNvencArguments));
+    }
+
+    [Fact]
+    public void Evaluate_NonGpuTranscodeIsAllowedRegardlessOfFreeMemory()
+    {
+        var outcome = GpuAdmissionPolicy.Evaluate(
+            EnabledConfig(),
+            requiresGpuVideoTranscode: false,
+            memory: GpuMemoryQueryResult.FromFreeMiB(1));
+
+        Assert.Equal(GpuAdmissionOutcome.AllowedNotGpuTranscode, outcome);
+    }
+
+    [Fact]
+    public void Evaluate_SufficientVramAllows()
+    {
+        var outcome = GpuAdmissionPolicy.Evaluate(
+            EnabledConfig(1500),
+            requiresGpuVideoTranscode: true,
+            memory: GpuMemoryQueryResult.FromFreeMiB(2500));
+
+        Assert.Equal(GpuAdmissionOutcome.AllowedSufficientMemory, outcome);
+    }
+
+    [Fact]
+    public void Evaluate_InsufficientVramDenies()
+    {
+        var outcome = GpuAdmissionPolicy.Evaluate(
+            EnabledConfig(1500),
+            requiresGpuVideoTranscode: true,
+            memory: GpuMemoryQueryResult.FromFreeMiB(700));
+
+        Assert.Equal(GpuAdmissionOutcome.Denied, outcome);
+    }
+
+    [Fact]
+    public void Evaluate_ExactlyAtThresholdAllows()
+    {
+        var outcome = GpuAdmissionPolicy.Evaluate(
+            EnabledConfig(1500),
+            requiresGpuVideoTranscode: true,
+            memory: GpuMemoryQueryResult.FromFreeMiB(1500));
+
+        Assert.Equal(GpuAdmissionOutcome.AllowedSufficientMemory, outcome);
+    }
+
+    [Fact]
+    public void Evaluate_FailedQueryFailsOpen()
+    {
+        var outcome = GpuAdmissionPolicy.Evaluate(
+            EnabledConfig(),
+            requiresGpuVideoTranscode: true,
+            memory: GpuMemoryQueryResult.Failed("nvidia-smi is not available"));
+
+        Assert.Equal(GpuAdmissionOutcome.AllowedQueryFailed, outcome);
+    }
+
+    [Fact]
+    public void Evaluate_MissingReadingFailsOpen()
+    {
+        var outcome = GpuAdmissionPolicy.Evaluate(
+            EnabledConfig(),
+            requiresGpuVideoTranscode: true,
+            memory: null);
+
+        Assert.Equal(GpuAdmissionOutcome.AllowedQueryFailed, outcome);
+    }
+
+    [Fact]
+    public void DefaultConfiguration_LeavesTheGuardOff()
+    {
+        var config = new PluginConfiguration();
+
+        Assert.False(config.EnableGpuResourceGuard);
+        Assert.Equal(0, config.GpuIndex);
+        Assert.Equal(1500, config.MinimumFreeGpuMemoryMiB);
+        Assert.Equal(1000, config.GpuCheckTimeoutMilliseconds);
+    }
+}

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
@@ -23,7 +23,7 @@ public class GpuResourceGuardTests
 
     private static GpuResourceGuard CreateGuard(
         PluginConfiguration config,
-        FakeGpuMemoryProvider provider,
+        IGpuMemoryProvider provider,
         RecordingClientMessageService messages)
     {
         return new GpuResourceGuard(
@@ -253,6 +253,59 @@ public class GpuResourceGuardTests
         await guard.IsAdmittedAsync(HardwareTranscodeRequest("device-2", "play-3"), CancellationToken.None);
 
         Assert.Equal(2, messages.SentMessages.Count);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_StillDeniesWhenTheClientNotificationThrows()
+    {
+        // Jellyfin ultimately calls raw WebSocket.SendAsync for this path, which can raise an
+        // exception ClientMessageService does not catch. A failed popup must never become an
+        // admission for a transcode already judged unsafe.
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
+        var messages = new ThrowingClientMessageService(TestSessions.Create("session-2", "device-2", AliceId));
+
+        var guard = new GpuResourceGuard(
+            provider,
+            messages,
+            NullLogger<GpuResourceGuard>.Instance,
+            () => EnabledConfig(1500));
+
+        Assert.False(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_TakesAFreshReadingForEveryAdmission()
+    {
+        // Two transcodes arriving close together must not share one pre-allocation reading:
+        // the second sees the memory the first consumed and is refused.
+        var provider = new SequencedGpuMemoryProvider(2500, 700);
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-1", "device-1", AliceId));
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+
+        var first = await guard.IsAdmittedAsync(HardwareTranscodeRequest("device-1", "play-1"), CancellationToken.None);
+        var second = await guard.IsAdmittedAsync(HardwareTranscodeRequest("device-2", "play-2"), CancellationToken.None);
+
+        Assert.True(first);
+        Assert.False(second);
+        Assert.Equal(2, provider.QueryCount);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_ConcurrentAdmissionsEachQueryTheGpu()
+    {
+        var provider = new SequencedGpuMemoryProvider(2500, 2500, 700, 700);
+        var messages = new RecordingClientMessageService();
+        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+
+        var results = await Task.WhenAll(Enumerable.Range(0, 4)
+            .Select(index => guard.IsAdmittedAsync(
+                HardwareTranscodeRequest("device-" + index, "play-" + index),
+                CancellationToken.None)));
+
+        Assert.Equal(4, provider.QueryCount);
+        Assert.Equal(2, results.Count(admitted => admitted));
     }
 
     [Fact]

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
@@ -1,0 +1,272 @@
+using Jellyfin.Plugin.TranscodeNag.Configuration;
+using Jellyfin.Plugin.TranscodeNag.Gpu;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Jellyfin.Plugin.TranscodeNag.Tests;
+
+public class GpuResourceGuardTests
+{
+    private const string CudaNvencArguments =
+        "-init_hw_device cuda=cu:0 -filter_hw_device cu -hwaccel cuda -hwaccel_output_format cuda " +
+        "-i \"/media/movie.mkv\" -codec:v:0 av1_nvenc -codec:a:0 libfdk_aac";
+
+    private static readonly Guid AliceId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid MovieTwoId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private static PluginConfiguration EnabledConfig(int thresholdMiB = 1500) => new()
+    {
+        EnableGpuResourceGuard = true,
+        MinimumFreeGpuMemoryMiB = thresholdMiB,
+        GpuIndex = 0,
+        GpuCheckTimeoutMilliseconds = 1000
+    };
+
+    private static GpuResourceGuard CreateGuard(
+        PluginConfiguration config,
+        FakeGpuMemoryProvider provider,
+        RecordingClientMessageService messages)
+    {
+        return new GpuResourceGuard(
+            provider,
+            messages,
+            NullLogger<GpuResourceGuard>.Instance,
+            () => config);
+    }
+
+    private static GpuTranscodeRequest HardwareTranscodeRequest(
+        string deviceId = "device-2",
+        string playSessionId = "play-2")
+    {
+        return new GpuTranscodeRequest
+        {
+            IsVideoRequest = true,
+            OutputVideoCodec = "av1",
+            CommandLineArguments = CudaNvencArguments,
+            DeviceId = deviceId,
+            PlaySessionId = playSessionId,
+            UserId = AliceId,
+            ItemId = MovieTwoId,
+            ItemName = "Movie Two"
+        };
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_GuardDisabled_AllowsWithoutQueryingTheGpu()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(10);
+        var messages = new RecordingClientMessageService();
+        var guard = CreateGuard(new PluginConfiguration { EnableGpuResourceGuard = false }, provider, messages);
+
+        Assert.True(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
+        Assert.Equal(0, provider.QueryCount);
+        Assert.Empty(messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_RemuxIsAllowedWithoutQueryingTheGpu()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(10);
+        var messages = new RecordingClientMessageService();
+        var guard = CreateGuard(EnabledConfig(), provider, messages);
+
+        var request = HardwareTranscodeRequest();
+        request.OutputVideoCodec = "copy";
+
+        Assert.True(await guard.IsAdmittedAsync(request, CancellationToken.None));
+        Assert.Equal(0, provider.QueryCount);
+        Assert.Empty(messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_AudioOnlyIsAllowedWithoutQueryingTheGpu()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(10);
+        var messages = new RecordingClientMessageService();
+        var guard = CreateGuard(EnabledConfig(), provider, messages);
+
+        var request = HardwareTranscodeRequest();
+        request.IsVideoRequest = false;
+        request.OutputVideoCodec = null;
+        request.CommandLineArguments = "-i \"/media/song.flac\" -codec:a:0 libmp3lame out.mp3";
+
+        Assert.True(await guard.IsAdmittedAsync(request, CancellationToken.None));
+        Assert.Equal(0, provider.QueryCount);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_SufficientVramAllowsAndSendsNothing()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(2500);
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+
+        Assert.True(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
+        Assert.Equal(1, provider.QueryCount);
+        Assert.Equal(0, provider.LastGpuIndex);
+        Assert.Empty(messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_InsufficientVramDeniesAndMessagesTheRequestingClientOnce()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
+        var messages = new RecordingClientMessageService();
+        var session = TestSessions.Create("session-2", "device-2", AliceId);
+        messages.AddSession(session);
+
+        var config = EnabledConfig(1500);
+        var guard = CreateGuard(config, provider, messages);
+
+        Assert.False(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
+
+        var sent = Assert.Single(messages.SentMessages);
+        Assert.Same(session, sent.Session);
+        Assert.Equal(config.GpuGuardDeniedHeader, sent.Command.Header);
+        Assert.Equal(config.GpuGuardDeniedMessage, sent.Command.Text);
+    }
+
+    [Fact]
+    public async Task DenialMessage_LeaksNoServerSideDetail()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+
+        await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None);
+
+        var text = Assert.Single(messages.SentMessages).Command.Text + Assert.Single(messages.SentMessages).Command.Header;
+
+        foreach (var forbidden in new[] { "700", "1500", "nvenc", "cuda", "VRAM", "187", "nvidia-smi" })
+        {
+            Assert.DoesNotContain(forbidden, text, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_RepeatedDenialsOfTheSameStreamSendOneNotification()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+
+        // Jellyfin retries the same segment several times within a second or two.
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            Assert.False(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
+        }
+
+        // Every attempt is still refused; only the client popup is de-duplicated.
+        Assert.Single(messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_ParallelSessionsEachReceiveOnlyTheirOwnDenial()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
+        var messages = new RecordingClientMessageService();
+        var sessionOne = TestSessions.Create("session-1", "device-1", AliceId, "alice");
+        var sessionTwo = TestSessions.Create("session-2", "device-2", AliceId, "alice");
+        messages.AddSession(sessionOne);
+        messages.AddSession(sessionTwo);
+
+        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+
+        await guard.IsAdmittedAsync(HardwareTranscodeRequest("device-1", "play-1"), CancellationToken.None);
+        await guard.IsAdmittedAsync(HardwareTranscodeRequest("device-2", "play-2"), CancellationToken.None);
+
+        Assert.Equal(2, messages.SentMessages.Count);
+        Assert.Same(sessionOne, messages.SentMessages[0].Session);
+        Assert.Same(sessionTwo, messages.SentMessages[1].Session);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_QueryFailureFailsOpen()
+    {
+        var provider = FakeGpuMemoryProvider.Failing("nvidia-smi is not available");
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+
+        Assert.True(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
+        Assert.Empty(messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_AbsentGpuIndexFailsOpen()
+    {
+        var provider = FakeGpuMemoryProvider.Failing("nvidia-smi did not report a usable value for GPU 3");
+        var messages = new RecordingClientMessageService();
+        var config = EnabledConfig(1500);
+        config.GpuIndex = 3;
+        var guard = CreateGuard(config, provider, messages);
+
+        Assert.True(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
+        Assert.Equal(3, provider.LastGpuIndex);
+        Assert.Empty(messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_DeniesEvenWhenNoSessionCanBeCorrelated()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
+        var messages = new RecordingClientMessageService();
+        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+
+        // No session registered for this device: the popup cannot be delivered, the refusal stands.
+        Assert.False(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
+        Assert.Empty(messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task DenialMessage_FallsBackToDefaultsWhenTheAdminBlanksTheText()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+
+        var config = EnabledConfig(1500);
+        config.GpuGuardDeniedHeader = string.Empty;
+        config.GpuGuardDeniedMessage = "   ";
+
+        var guard = CreateGuard(config, provider, messages);
+
+        Assert.False(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
+
+        var sent = Assert.Single(messages.SentMessages);
+        Assert.False(string.IsNullOrWhiteSpace(sent.Command.Header));
+        Assert.False(string.IsNullOrWhiteSpace(sent.Command.Text));
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_DeniesAgainOnceTheSuppressionWindowHasNoEntry()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+
+        // A different play session is a different playback attempt, so it gets its own popup.
+        await guard.IsAdmittedAsync(HardwareTranscodeRequest("device-2", "play-2"), CancellationToken.None);
+        await guard.IsAdmittedAsync(HardwareTranscodeRequest("device-2", "play-3"), CancellationToken.None);
+
+        Assert.Equal(2, messages.SentMessages.Count);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_AllowsWhenConfigurationIsUnavailable()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(0);
+        var messages = new RecordingClientMessageService();
+        var guard = new GpuResourceGuard(
+            provider,
+            messages,
+            NullLogger<GpuResourceGuard>.Instance,
+            () => null);
+
+        Assert.True(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
+        Assert.Equal(0, provider.QueryCount);
+    }
+}

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
@@ -295,7 +295,9 @@ public class GpuResourceGuardTests
     [Fact]
     public async Task IsAdmittedAsync_ConcurrentAdmissionsEachQueryTheGpu()
     {
-        var provider = new SequencedGpuMemoryProvider(2500, 2500, 700, 700);
+        // The gate holds every admission inside its query until all four are in flight, so this
+        // is real overlap rather than four calls completing as Task.WhenAll enumerates them.
+        var provider = new GatedGpuMemoryProvider(4, 2500, 2500, 700, 700);
         var messages = new RecordingClientMessageService();
         var guard = CreateGuard(EnabledConfig(1500), provider, messages);
 

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GuardedTranscodeManagerTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GuardedTranscodeManagerTests.cs
@@ -1,0 +1,326 @@
+using Jellyfin.Plugin.TranscodeNag.Configuration;
+using Jellyfin.Plugin.TranscodeNag.Gpu;
+using Jellyfin.Plugin.TranscodeNag.Messaging;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Streaming;
+using MediaBrowser.Model.Dto;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Jellyfin.Plugin.TranscodeNag.Tests;
+
+public class GuardedTranscodeManagerTests
+{
+    private const string CudaNvencArguments =
+        "-init_hw_device cuda=cu:0 -filter_hw_device cu -hwaccel cuda -hwaccel_output_format cuda " +
+        "-i \"/media/movie.mkv\" -codec:v:0 av1_nvenc -codec:a:0 libfdk_aac";
+
+    private static readonly Guid AliceId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid MovieTwoId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    /// <summary>
+    /// Stands in for Jellyfin's TranscodeManager: records whether FFmpeg would have been launched.
+    /// </summary>
+    private sealed class SpyTranscodeManager : ITranscodeManager, IDisposable
+    {
+        public int StartFfMpegCallCount { get; private set; }
+
+        public int DisposeCallCount { get; private set; }
+
+        public bool Disposed => DisposeCallCount > 0;
+
+        public Task<TranscodingJob> StartFfMpeg(
+            StreamState state,
+            string outputPath,
+            string commandLineArguments,
+            Guid userId,
+            TranscodingJobType transcodingJobType,
+            CancellationTokenSource cancellationTokenSource,
+            string? workingDirectory = null)
+        {
+            StartFfMpegCallCount++;
+            return Task.FromResult(new TranscodingJob(NullLogger<TranscodingJob>.Instance));
+        }
+
+        public TranscodingJob? GetTranscodingJob(string playSessionId) => null;
+
+        public TranscodingJob? GetTranscodingJob(string path, TranscodingJobType type) => null;
+
+        public void PingTranscodingJob(string playSessionId, bool? isUserPaused)
+        {
+        }
+
+        public Task KillTranscodingJobs(string deviceId, string? playSessionId, Func<string, bool> deleteFiles)
+            => Task.CompletedTask;
+
+        public void ReportTranscodingProgress(
+            TranscodingJob job,
+            StreamState state,
+            TimeSpan? transcodingPosition,
+            float? framerate,
+            double? percentComplete,
+            long? bytesTranscoded,
+            int? bitRate)
+        {
+        }
+
+        public TranscodingJob? OnTranscodeBeginRequest(string path, TranscodingJobType type) => null;
+
+        public void OnTranscodeEndRequest(TranscodingJob job)
+        {
+        }
+
+        public ValueTask<IDisposable> LockAsync(string outputPath, CancellationToken cancellationToken)
+            => ValueTask.FromResult<IDisposable>(new MemoryStream());
+
+        public void Dispose() => DisposeCallCount++;
+    }
+
+    private sealed class ThrowingGpuMemoryProvider : IGpuMemoryProvider
+    {
+        public Task<GpuMemoryQueryResult> GetFreeMemoryAsync(
+            int gpuIndex,
+            int timeoutMilliseconds,
+            CancellationToken cancellationToken)
+            => throw new InvalidOperationException("boom");
+    }
+
+    private static StreamState CreateHardwareVideoState(string outputVideoCodec = "av1")
+    {
+        var state = new StreamState(null!, TranscodingJobType.Hls, null!)
+        {
+            Request = new VideoRequestDto
+            {
+                Id = MovieTwoId,
+                DeviceId = "device-2",
+                PlaySessionId = "play-2"
+            },
+            OutputVideoCodec = outputVideoCodec,
+            MediaSource = new MediaSourceInfo { Name = "Movie Two" }
+        };
+
+        return state;
+    }
+
+    private static (GuardedTranscodeManager Decorator, SpyTranscodeManager Inner, RecordingClientMessageService Messages)
+        CreateDecorator(int freeMiB, int thresholdMiB, bool guardEnabled = true)
+    {
+        var config = new PluginConfiguration
+        {
+            EnableGpuResourceGuard = guardEnabled,
+            MinimumFreeGpuMemoryMiB = thresholdMiB,
+            GpuIndex = 0
+        };
+
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+
+        var guard = new GpuResourceGuard(
+            FakeGpuMemoryProvider.WithFreeMiB(freeMiB),
+            messages,
+            NullLogger<GpuResourceGuard>.Instance,
+            () => config);
+
+        var inner = new SpyTranscodeManager();
+        var decorator = new GuardedTranscodeManager(inner, guard, NullLogger<GuardedTranscodeManager>.Instance);
+
+        return (decorator, inner, messages);
+    }
+
+    [Fact]
+    public async Task StartFfMpeg_LowVramRefusesWithoutEverLaunchingFfmpeg()
+    {
+        var (decorator, inner, messages) = CreateDecorator(freeMiB: 700, thresholdMiB: 1500);
+        using var cts = new CancellationTokenSource();
+
+        var ex = await Assert.ThrowsAsync<ArgumentException>(() => decorator.StartFfMpeg(
+            CreateHardwareVideoState(),
+            "/config/transcodes/abc.m3u8",
+            CudaNvencArguments,
+            AliceId,
+            TranscodingJobType.Hls,
+            cts));
+
+        // ArgumentException is what Jellyfin's exception middleware maps to HTTP 400, the same
+        // terminal answer it gives when a user lacks video transcoding permission.
+        Assert.Contains("free GPU memory", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(0, inner.StartFfMpegCallCount);
+        Assert.Single(messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task StartFfMpeg_SufficientVramLaunchesNormally()
+    {
+        var (decorator, inner, messages) = CreateDecorator(freeMiB: 2500, thresholdMiB: 1500);
+        using var cts = new CancellationTokenSource();
+
+        var job = await decorator.StartFfMpeg(
+            CreateHardwareVideoState(),
+            "/config/transcodes/abc.m3u8",
+            CudaNvencArguments,
+            AliceId,
+            TranscodingJobType.Hls,
+            cts);
+
+        Assert.NotNull(job);
+        Assert.Equal(1, inner.StartFfMpegCallCount);
+        Assert.Empty(messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task StartFfMpeg_RemuxLaunchesEvenWhenVramIsExhausted()
+    {
+        var (decorator, inner, messages) = CreateDecorator(freeMiB: 10, thresholdMiB: 1500);
+        using var cts = new CancellationTokenSource();
+
+        await decorator.StartFfMpeg(
+            CreateHardwareVideoState("copy"),
+            "/config/transcodes/abc.m3u8",
+            "-i \"/media/movie.mkv\" -codec:v:0 copy -codec:a:0 libfdk_aac",
+            AliceId,
+            TranscodingJobType.Hls,
+            cts);
+
+        Assert.Equal(1, inner.StartFfMpegCallCount);
+        Assert.Empty(messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task StartFfMpeg_GuardDisabledLeavesBehaviourUnchanged()
+    {
+        var (decorator, inner, _) = CreateDecorator(freeMiB: 10, thresholdMiB: 1500, guardEnabled: false);
+        using var cts = new CancellationTokenSource();
+
+        await decorator.StartFfMpeg(
+            CreateHardwareVideoState(),
+            "/config/transcodes/abc.m3u8",
+            CudaNvencArguments,
+            AliceId,
+            TranscodingJobType.Hls,
+            cts);
+
+        Assert.Equal(1, inner.StartFfMpegCallCount);
+    }
+
+    [Fact]
+    public async Task StartFfMpeg_AllowsPlaybackWhenTheGuardItselfFails()
+    {
+        // A guard that throws must never become an outage.
+        var guard = new GpuResourceGuard(
+            new ThrowingGpuMemoryProvider(),
+            new RecordingClientMessageService(),
+            NullLogger<GpuResourceGuard>.Instance,
+            () => new PluginConfiguration { EnableGpuResourceGuard = true, MinimumFreeGpuMemoryMiB = 1500 });
+
+        var inner = new SpyTranscodeManager();
+        var decorator = new GuardedTranscodeManager(inner, guard, NullLogger<GuardedTranscodeManager>.Instance);
+        using var cts = new CancellationTokenSource();
+
+        await decorator.StartFfMpeg(
+            CreateHardwareVideoState(),
+            "/config/transcodes/abc.m3u8",
+            CudaNvencArguments,
+            AliceId,
+            TranscodingJobType.Hls,
+            cts);
+
+        Assert.Equal(1, inner.StartFfMpegCallCount);
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var (decorator, inner, _) = CreateDecorator(freeMiB: 2500, thresholdMiB: 1500);
+
+        decorator.Dispose();
+        decorator.Dispose();
+
+        Assert.Equal(1, inner.DisposeCallCount);
+    }
+
+    [Fact]
+    public void Dispose_DisposesTheInnerManager()
+    {
+        var (decorator, inner, _) = CreateDecorator(freeMiB: 2500, thresholdMiB: 1500);
+
+        decorator.Dispose();
+
+        Assert.True(inner.Disposed);
+    }
+
+    private static ServiceCollection BuildDecoratableCollection()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ITranscodeManager, SpyTranscodeManager>();
+        services.AddSingleton<IGpuMemoryProvider>(FakeGpuMemoryProvider.WithFreeMiB(2500));
+        services.AddSingleton<IClientMessageService>(new RecordingClientMessageService());
+        services.AddSingleton(new GpuResourceGuard(
+            FakeGpuMemoryProvider.WithFreeMiB(2500),
+            new RecordingClientMessageService(),
+            NullLogger<GpuResourceGuard>.Instance,
+            () => new PluginConfiguration()));
+        services.AddSingleton<ILogger<GuardedTranscodeManager>>(NullLogger<GuardedTranscodeManager>.Instance);
+        return services;
+    }
+
+    [Fact]
+    public void DecorateTranscodeManager_ReplacesJellyfinsRegistrationInPlace()
+    {
+        var services = BuildDecoratableCollection();
+
+        PluginServiceRegistrator.TryDecorateTranscodeManager(services);
+
+        Assert.Null(PluginServiceRegistrator.DecorationFailure);
+
+        // Exactly one registration must remain, or Jellyfin would resolve an unguarded manager.
+        Assert.Single(services.Where(service => service.ServiceType == typeof(ITranscodeManager)));
+
+        using var provider = services.BuildServiceProvider();
+        var resolved = provider.GetRequiredService<ITranscodeManager>();
+
+        var decorator = Assert.IsType<GuardedTranscodeManager>(resolved);
+        Assert.Same(decorator, provider.GetRequiredService<ITranscodeManager>());
+    }
+
+    [Fact]
+    public void DecorateTranscodeManager_LeavesAFactoryRegistrationAlone()
+    {
+        // Only a concrete implementation type can be rebuilt safely; anything else is left as-is.
+        var services = new ServiceCollection();
+        services.AddSingleton<ITranscodeManager>(_ => new SpyTranscodeManager());
+
+        PluginServiceRegistrator.TryDecorateTranscodeManager(services);
+
+        using var provider = services.BuildServiceProvider();
+        Assert.IsType<SpyTranscodeManager>(provider.GetRequiredService<ITranscodeManager>());
+        Assert.NotNull(PluginServiceRegistrator.DecorationFailure);
+    }
+
+    [Fact]
+    public void DecorateTranscodeManager_IsANoOpWhenNothingRegisteredTheService()
+    {
+        var services = new ServiceCollection();
+
+        PluginServiceRegistrator.TryDecorateTranscodeManager(services);
+
+        Assert.Empty(services);
+        Assert.NotNull(PluginServiceRegistrator.DecorationFailure);
+    }
+
+    [Fact]
+    public void DecorateTranscodeManager_RunTwiceDoesNotDoubleWrap()
+    {
+        // Guards against a reload path registering the plugin's services more than once.
+        var services = BuildDecoratableCollection();
+
+        PluginServiceRegistrator.TryDecorateTranscodeManager(services);
+        PluginServiceRegistrator.TryDecorateTranscodeManager(services);
+
+        Assert.Single(services.Where(service => service.ServiceType == typeof(ITranscodeManager)));
+
+        using var provider = services.BuildServiceProvider();
+        var decorator = Assert.IsType<GuardedTranscodeManager>(provider.GetRequiredService<ITranscodeManager>());
+        Assert.NotNull(decorator);
+    }
+}

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/Jellyfin.Plugin.TranscodeNag.Tests.csproj
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/Jellyfin.Plugin.TranscodeNag.Tests.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.0" />

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/NvidiaSmiGpuMemoryProviderTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/NvidiaSmiGpuMemoryProviderTests.cs
@@ -116,15 +116,30 @@ public class NvidiaSmiGpuMemoryProviderTests
     }
 
     [UnixFact]
-    public async Task GetFreeMemoryAsync_ASuccessfulReadingClearsAnEarlierCachedFailure()
+    public async Task GetFreeMemoryAsync_DoesNotCacheACancelledRequestAsAGpuFailure()
     {
-        var script = ScriptedNvidiaSmi("0, 2500");
+        // A cancelled streaming request says nothing about the GPU. If its result were cached,
+        // the next admission would be handed a failure, fail open, and launch without ever
+        // reading VRAM. The long failure window makes that leak visible if it regresses.
+        var script = ScriptedNvidiaSmi("0, 2500", sleepSeconds: 1);
         try
         {
             using var provider = Create(script, TimeSpan.FromMinutes(5));
 
-            Assert.True((await provider.GetFreeMemoryAsync(0, 5000, CancellationToken.None)).Success);
-            Assert.True((await provider.GetFreeMemoryAsync(0, 5000, CancellationToken.None)).Success);
+            using var cancelled = new CancellationTokenSource();
+            var inFlight = provider.GetFreeMemoryAsync(0, 30000, cancelled.Token);
+            await Task.Delay(150);
+            await cancelled.CancelAsync();
+
+            var first = await inFlight;
+            Assert.False(first.Success);
+
+            // A different request must still get a real lookup.
+            var second = await provider.GetFreeMemoryAsync(0, 30000, CancellationToken.None);
+
+            Assert.True(second.Success);
+            Assert.Equal(2500, second.FreeMiB);
+            Assert.Equal(2, File.ReadAllLines(script + ".calls").Length);
         }
         finally
         {
@@ -138,11 +153,13 @@ public class NvidiaSmiGpuMemoryProviderTests
     /// each invocation, so "was this a real lookup?" can be asserted.
     /// </summary>
     /// <param name="csvOutput">The line to emit on stdout.</param>
+    /// <param name="sleepSeconds">How long to stall before answering, so a query can be cancelled mid-flight.</param>
     /// <returns>Path to the stand-in executable.</returns>
-    private static string ScriptedNvidiaSmi(string csvOutput)
+    private static string ScriptedNvidiaSmi(string csvOutput, int sleepSeconds = 0)
     {
         var path = Path.Combine(Path.GetTempPath(), "fake-nvidia-smi-" + Guid.NewGuid().ToString("N") + ".sh");
-        File.WriteAllText(path, $"#!/bin/sh\necho called >> \"{path}.calls\"\necho '{csvOutput}'\n");
+        var stall = sleepSeconds > 0 ? $"sleep {sleepSeconds}\n" : string.Empty;
+        File.WriteAllText(path, $"#!/bin/sh\necho called >> \"{path}.calls\"\n{stall}echo '{csvOutput}'\n");
         if (!OperatingSystem.IsWindows())
         {
             File.SetUnixFileMode(

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/NvidiaSmiGpuMemoryProviderTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/NvidiaSmiGpuMemoryProviderTests.cs
@@ -1,0 +1,99 @@
+using Jellyfin.Plugin.TranscodeNag.Gpu;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Jellyfin.Plugin.TranscodeNag.Tests;
+
+/// <summary>
+/// Exercises the real process path against stand-in executables, so the fail-open behaviour is
+/// verified rather than assumed.
+/// </summary>
+public class NvidiaSmiGpuMemoryProviderTests
+{
+    private static NvidiaSmiGpuMemoryProvider Create(string executablePath, TimeSpan? cacheWindow = null)
+    {
+        return new NvidiaSmiGpuMemoryProvider(
+            NullLogger<NvidiaSmiGpuMemoryProvider>.Instance,
+            () => executablePath,
+            cacheWindow ?? TimeSpan.Zero);
+    }
+
+    [Fact]
+    public async Task GetFreeMemoryAsync_MissingExecutableFailsWithoutThrowing()
+    {
+        using var provider = Create(Path.Combine(Path.GetTempPath(), "definitely-not-nvidia-smi-" + Guid.NewGuid().ToString("N")));
+
+        var result = await provider.GetFreeMemoryAsync(0, 1000, CancellationToken.None);
+
+        Assert.False(result.Success);
+        Assert.False(string.IsNullOrWhiteSpace(result.FailureReason));
+    }
+
+    [Fact]
+    public async Task GetFreeMemoryAsync_NonZeroExitFailsWithoutThrowing()
+    {
+        using var provider = Create("false");
+
+        var result = await provider.GetFreeMemoryAsync(0, 5000, CancellationToken.None);
+
+        // Fail-open holds on every platform. The exit-code wording only applies where the
+        // stand-in "false" binary actually exists.
+        Assert.False(result.Success);
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Contains("exited with code", result.FailureReason);
+        }
+    }
+
+    [Fact]
+    public async Task GetFreeMemoryAsync_UnparseableOutputFails()
+    {
+        // "true" exits 0 with no output at all - the closest stand-in for a driver that answers
+        // successfully but tells us nothing usable.
+        using var provider = Create("true");
+
+        var result = await provider.GetFreeMemoryAsync(0, 5000, CancellationToken.None);
+
+        Assert.False(result.Success);
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Contains("did not report a usable value", result.FailureReason);
+        }
+    }
+
+    [Fact]
+    public async Task GetFreeMemoryAsync_AlreadyCancelledRequestFailsOpenRatherThanThrowing()
+    {
+        using var provider = Create("true");
+        using var cancelled = new CancellationTokenSource();
+        await cancelled.CancelAsync();
+
+        var result = await provider.GetFreeMemoryAsync(0, 5000, cancelled.Token);
+
+        Assert.False(result.Success);
+    }
+
+    [Fact]
+    public async Task GetFreeMemoryAsync_CachesWithinTheWindowAndReQueriesForAnotherGpu()
+    {
+        using var provider = Create("false", TimeSpan.FromMinutes(5));
+
+        var first = await provider.GetFreeMemoryAsync(0, 5000, CancellationToken.None);
+        var second = await provider.GetFreeMemoryAsync(0, 5000, CancellationToken.None);
+        var otherGpu = await provider.GetFreeMemoryAsync(1, 5000, CancellationToken.None);
+
+        Assert.False(first.Success);
+        Assert.Equal(first.FailureReason, second.FailureReason);
+        Assert.False(otherGpu.Success);
+    }
+
+    [Fact]
+    public async Task GetFreeMemoryAsync_ConcurrentCallsDoNotDeadlock()
+    {
+        using var provider = Create("true", TimeSpan.FromSeconds(1));
+
+        var results = await Task.WhenAll(Enumerable.Range(0, 8)
+            .Select(_ => provider.GetFreeMemoryAsync(0, 5000, CancellationToken.None)));
+
+        Assert.All(results, result => Assert.False(result.Success));
+    }
+}

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/NvidiaSmiGpuMemoryProviderTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/NvidiaSmiGpuMemoryProviderTests.cs
@@ -73,8 +73,10 @@ public class NvidiaSmiGpuMemoryProviderTests
     }
 
     [Fact]
-    public async Task GetFreeMemoryAsync_CachesWithinTheWindowAndReQueriesForAnotherGpu()
+    public async Task GetFreeMemoryAsync_ReusesAFailureWithinTheWindow()
     {
+        // Failures cannot change a decision - the guard is fail-open either way - so reusing one
+        // only spares a queued admission from repeating a slow, doomed lookup.
         using var provider = Create("false", TimeSpan.FromMinutes(5));
 
         var first = await provider.GetFreeMemoryAsync(0, 5000, CancellationToken.None);
@@ -84,6 +86,71 @@ public class NvidiaSmiGpuMemoryProviderTests
         Assert.False(first.Success);
         Assert.Equal(first.FailureReason, second.FailureReason);
         Assert.False(otherGpu.Success);
+    }
+
+    [UnixFact]
+    public async Task GetFreeMemoryAsync_NeverServesASuccessfulReadingTwice()
+    {
+        // A successful reading decides whether a transcode launches. Reusing one would hand two
+        // transcodes arriving close together the same pre-allocation number and admit both.
+        var script = ScriptedNvidiaSmi("0, 2500");
+        try
+        {
+            using var provider = Create(script, TimeSpan.FromMinutes(5));
+
+            var first = await provider.GetFreeMemoryAsync(0, 5000, CancellationToken.None);
+            var second = await provider.GetFreeMemoryAsync(0, 5000, CancellationToken.None);
+
+            Assert.True(first.Success);
+            Assert.Equal(2500, first.FreeMiB);
+            Assert.True(second.Success);
+
+            // Two invocations of the stand-in binary, i.e. two real lookups.
+            Assert.Equal(2, File.ReadAllLines(script + ".calls").Length);
+        }
+        finally
+        {
+            File.Delete(script);
+            File.Delete(script + ".calls");
+        }
+    }
+
+    [UnixFact]
+    public async Task GetFreeMemoryAsync_ASuccessfulReadingClearsAnEarlierCachedFailure()
+    {
+        var script = ScriptedNvidiaSmi("0, 2500");
+        try
+        {
+            using var provider = Create(script, TimeSpan.FromMinutes(5));
+
+            Assert.True((await provider.GetFreeMemoryAsync(0, 5000, CancellationToken.None)).Success);
+            Assert.True((await provider.GetFreeMemoryAsync(0, 5000, CancellationToken.None)).Success);
+        }
+        finally
+        {
+            File.Delete(script);
+            File.Delete(script + ".calls");
+        }
+    }
+
+    /// <summary>
+    /// Writes an executable stand-in for nvidia-smi that prints fixed csv output and records
+    /// each invocation, so "was this a real lookup?" can be asserted.
+    /// </summary>
+    /// <param name="csvOutput">The line to emit on stdout.</param>
+    /// <returns>Path to the stand-in executable.</returns>
+    private static string ScriptedNvidiaSmi(string csvOutput)
+    {
+        var path = Path.Combine(Path.GetTempPath(), "fake-nvidia-smi-" + Guid.NewGuid().ToString("N") + ".sh");
+        File.WriteAllText(path, $"#!/bin/sh\necho called >> \"{path}.calls\"\necho '{csvOutput}'\n");
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+
+        return path;
     }
 
     [Fact]

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/NvidiaSmiOutputParserTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/NvidiaSmiOutputParserTests.cs
@@ -1,0 +1,53 @@
+using Jellyfin.Plugin.TranscodeNag.Gpu;
+
+namespace Jellyfin.Plugin.TranscodeNag.Tests;
+
+public class NvidiaSmiOutputParserTests
+{
+    private const string TwoGpuOutput = "0, 2318\n1, 20044\n";
+
+    [Fact]
+    public void TryGetFreeMiB_ReadsTheRequestedGpu()
+    {
+        Assert.True(NvidiaSmiOutputParser.TryGetFreeMiB(TwoGpuOutput, 0, out var gpu0));
+        Assert.Equal(2318, gpu0);
+
+        Assert.True(NvidiaSmiOutputParser.TryGetFreeMiB(TwoGpuOutput, 1, out var gpu1));
+        Assert.Equal(20044, gpu1);
+    }
+
+    [Fact]
+    public void TryGetFreeMiB_ToleratesCarriageReturnsAndPadding()
+    {
+        Assert.True(NvidiaSmiOutputParser.TryGetFreeMiB("  0 ,  2318  \r\n", 0, out var free));
+        Assert.Equal(2318, free);
+    }
+
+    [Fact]
+    public void TryGetFreeMiB_ReturnsFalseForAnAbsentGpuIndex()
+    {
+        Assert.False(NvidiaSmiOutputParser.TryGetFreeMiB(TwoGpuOutput, 3, out _));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   \n  \n")]
+    [InlineData("Failed to initialize NVML: Driver/library version mismatch")]
+    [InlineData("0, [N/A]")]
+    [InlineData("0, -5")]
+    [InlineData("not-a-number, 2318")]
+    public void TryGetFreeMiB_ReturnsFalseForUnusableOutput(string? output)
+    {
+        Assert.False(NvidiaSmiOutputParser.TryGetFreeMiB(output, 0, out var free));
+        Assert.Equal(0, free);
+    }
+
+    [Fact]
+    public void TryGetFreeMiB_IgnoresExtraTrailingColumns()
+    {
+        // Guards against a future query string picking up more fields than the parser expects.
+        Assert.True(NvidiaSmiOutputParser.TryGetFreeMiB("0, 2318, 24576", 0, out var free));
+        Assert.Equal(2318, free);
+    }
+}

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/NvidiaTranscodeDetectorTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/NvidiaTranscodeDetectorTests.cs
@@ -1,0 +1,99 @@
+using Jellyfin.Plugin.TranscodeNag.Gpu;
+
+namespace Jellyfin.Plugin.TranscodeNag.Tests;
+
+public class NvidiaTranscodeDetectorTests
+{
+    // Trimmed from the 2160p HDR -> AV1 NVENC job in the reported reproduction.
+    private const string CudaAv1NvencArguments =
+        "-analyzeduration 200M -init_hw_device cuda=cu:0 -filter_hw_device cu -hwaccel cuda " +
+        "-hwaccel_output_format cuda -noautorotate -i \"/media/movies/Some Movie (2019)/Some Movie.mkv\" " +
+        "-map 0:0 -map 0:1 -codec:v:0 av1_nvenc -preset p1 " +
+        "-vf \"setparams=color_primaries=bt2020,tonemap_cuda=format=yuv420p:p=bt709,scale_cuda=w=1920:h=1080\" " +
+        "-codec:a:0 libfdk_aac -f hls \"/config/transcodes/abc.m3u8\"";
+
+    private const string CpuLibx264Arguments =
+        "-analyzeduration 200M -noautorotate -i \"/media/movies/Some Movie.mkv\" -map 0:0 -map 0:1 " +
+        "-codec:v:0 libx264 -preset veryfast -crf 23 -vf \"scale=trunc(min(max(iw\\,ih*dar)\\,1920)/2)*2:-2\" " +
+        "-codec:a:0 libfdk_aac -f hls \"/config/transcodes/abc.m3u8\"";
+
+    private const string RemuxArguments =
+        "-i \"/media/movies/Some Movie.mkv\" -map 0:0 -map 0:1 -codec:v:0 copy -codec:a:0 libfdk_aac " +
+        "-f hls \"/config/transcodes/abc.m3u8\"";
+
+    [Fact]
+    public void UsesNvidiaGpu_DetectsCudaAv1NvencJob()
+    {
+        Assert.True(NvidiaTranscodeDetector.UsesNvidiaGpu(CudaAv1NvencArguments));
+    }
+
+    [Fact]
+    public void UsesNvidiaGpu_IgnoresCpuOnlyTranscode()
+    {
+        Assert.False(NvidiaTranscodeDetector.UsesNvidiaGpu(CpuLibx264Arguments));
+    }
+
+    [Fact]
+    public void UsesNvidiaGpu_IgnoresStreamCopy()
+    {
+        Assert.False(NvidiaTranscodeDetector.UsesNvidiaGpu(RemuxArguments));
+    }
+
+    [Theory]
+    [InlineData("-hwaccel cuda -i in.mkv -c:v h264_nvenc out.ts")]
+    [InlineData("-hwaccel nvdec -i in.mkv -c:v libx264 out.ts")]
+    [InlineData("-i in.mkv -codec:v:0 hevc_nvenc out.ts")]
+    [InlineData("-c:v h264_cuvid -i in.mkv -c:v libx264 out.ts")]
+    [InlineData("-init_hw_device cuda -i in.mkv -c:v libx264 out.ts")]
+    [InlineData("-hwaccel_output_format cuda -i in.mkv -c:v libx264 out.ts")]
+    [InlineData("-i in.mkv -vf \"hwupload_cuda,scale_npp=w=1920:h=1080\" -c:v libx264 out.ts")]
+    public void UsesNvidiaGpu_DetectsEachNvidiaMarker(string arguments)
+    {
+        Assert.True(NvidiaTranscodeDetector.UsesNvidiaGpu(arguments));
+    }
+
+    [Theory]
+    [InlineData("-hwaccel qsv -i in.mkv -c:v h264_qsv out.ts")]
+    [InlineData("-hwaccel vaapi -i in.mkv -c:v h264_vaapi out.ts")]
+    [InlineData("-hwaccel videotoolbox -i in.mkv -c:v h264_videotoolbox out.ts")]
+    public void UsesNvidiaGpu_IgnoresOtherVendorsHardwarePaths(string arguments)
+    {
+        // Only the protected NVIDIA path is guarded; other accelerators are out of scope.
+        Assert.False(NvidiaTranscodeDetector.UsesNvidiaGpu(arguments));
+    }
+
+    [Fact]
+    public void UsesNvidiaGpu_IsNotTrippedByMediaFileNames()
+    {
+        const string arguments =
+            "-i \"/media/movies/Cuda (2019)/Cuda nvenc _cuda scale_npp.mkv\" -c:v libx264 -f hls \"/config/cuda.m3u8\"";
+
+        Assert.False(NvidiaTranscodeDetector.UsesNvidiaGpu(arguments));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("-hwaccel")]
+    public void UsesNvidiaGpu_HandlesEmptyAndTruncatedInput(string? arguments)
+    {
+        Assert.False(NvidiaTranscodeDetector.UsesNvidiaGpu(arguments));
+    }
+
+    [Fact]
+    public void Tokenize_KeepsQuotedValuesTogetherAndStripsQuotes()
+    {
+        var tokens = NvidiaTranscodeDetector.Tokenize("-i \"/media/Some Movie.mkv\" -vf \"a=1,b=2\" -y");
+
+        Assert.Equal(new[] { "-i", "/media/Some Movie.mkv", "-vf", "a=1,b=2", "-y" }, tokens);
+    }
+
+    [Fact]
+    public void Tokenize_KeepsEmptyQuotedArgument()
+    {
+        var tokens = NvidiaTranscodeDetector.Tokenize("-metadata \"\" -y");
+
+        Assert.Equal(new[] { "-metadata", string.Empty, "-y" }, tokens);
+    }
+}

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/TestDoubles.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/TestDoubles.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Jellyfin.Plugin.TranscodeNag.Gpu;
 using Jellyfin.Plugin.TranscodeNag.Messaging;
 using MediaBrowser.Controller.Session;
@@ -76,6 +77,62 @@ internal sealed class RecordingClientMessageService : IClientMessageService
         SentMessages.Add((session, command));
         return Task.FromResult(true);
     }
+}
+
+/// <summary>
+/// Returns a scripted sequence of readings, one per call, so concurrent admissions can be shown
+/// to each take their own reading rather than sharing one.
+/// </summary>
+internal sealed class SequencedGpuMemoryProvider : IGpuMemoryProvider
+{
+    private readonly Queue<GpuMemoryQueryResult> _readings;
+    private readonly GpuMemoryQueryResult _exhausted;
+
+    public SequencedGpuMemoryProvider(params int[] freeMiBReadings)
+    {
+        _readings = new Queue<GpuMemoryQueryResult>(freeMiBReadings.Select(GpuMemoryQueryResult.FromFreeMiB));
+        _exhausted = GpuMemoryQueryResult.Failed("no scripted reading left");
+    }
+
+    public int QueryCount { get; private set; }
+
+    public Task<GpuMemoryQueryResult> GetFreeMemoryAsync(
+        int gpuIndex,
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken)
+    {
+        QueryCount++;
+        lock (_readings)
+        {
+            return Task.FromResult(_readings.Count > 0 ? _readings.Dequeue() : _exhausted);
+        }
+    }
+}
+
+/// <summary>
+/// Fails the way Jellyfin's raw WebSocket send path can: with an exception
+/// <see cref="ClientMessageService"/> does not catch.
+/// </summary>
+internal sealed class ThrowingClientMessageService : IClientMessageService
+{
+    private readonly SessionInfo _session;
+
+    public ThrowingClientMessageService(SessionInfo session)
+    {
+        _session = session;
+    }
+
+    public SessionInfo? ResolveSession(string? deviceId, Guid userId, Guid itemId) => _session;
+
+    public Task<bool> SendMessageAsync(
+        SessionInfo session,
+        MessageCommand command,
+        string context,
+        string detail,
+        bool enableLogging,
+        ILogger logger,
+        CancellationToken cancellationToken)
+        => throw new System.Net.WebSockets.WebSocketException("the remote party closed the connection");
 }
 
 internal static class TestSessions

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/TestDoubles.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/TestDoubles.cs
@@ -1,0 +1,103 @@
+using Jellyfin.Plugin.TranscodeNag.Gpu;
+using Jellyfin.Plugin.TranscodeNag.Messaging;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Session;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Jellyfin.Plugin.TranscodeNag.Tests;
+
+/// <summary>
+/// A canned free-VRAM reading, plus a count of how often it was asked for.
+/// </summary>
+internal sealed class FakeGpuMemoryProvider : IGpuMemoryProvider
+{
+    private readonly GpuMemoryQueryResult _result;
+
+    public FakeGpuMemoryProvider(GpuMemoryQueryResult result)
+    {
+        _result = result;
+    }
+
+    public int QueryCount { get; private set; }
+
+    public int? LastGpuIndex { get; private set; }
+
+    public Task<GpuMemoryQueryResult> GetFreeMemoryAsync(
+        int gpuIndex,
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken)
+    {
+        QueryCount++;
+        LastGpuIndex = gpuIndex;
+        return Task.FromResult(_result);
+    }
+
+    public static FakeGpuMemoryProvider WithFreeMiB(int freeMiB)
+        => new(GpuMemoryQueryResult.FromFreeMiB(freeMiB));
+
+    public static FakeGpuMemoryProvider Failing(string reason)
+        => new(GpuMemoryQueryResult.Failed(reason));
+}
+
+/// <summary>
+/// Records the messages the guard tries to deliver and to which session.
+/// </summary>
+internal sealed class RecordingClientMessageService : IClientMessageService
+{
+    private readonly Dictionary<string, SessionInfo> _sessionsByDeviceId = new(StringComparer.Ordinal);
+
+    public List<(SessionInfo Session, MessageCommand Command)> SentMessages { get; } = new();
+
+    public void AddSession(SessionInfo session)
+    {
+        _sessionsByDeviceId[session.DeviceId] = session;
+    }
+
+    public SessionInfo? ResolveSession(string? deviceId, Guid userId, Guid itemId)
+    {
+        if (deviceId == null)
+        {
+            return null;
+        }
+
+        return _sessionsByDeviceId.TryGetValue(deviceId, out var session) ? session : null;
+    }
+
+    public Task<bool> SendMessageAsync(
+        SessionInfo session,
+        MessageCommand command,
+        string context,
+        string detail,
+        bool enableLogging,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        SentMessages.Add((session, command));
+        return Task.FromResult(true);
+    }
+}
+
+internal static class TestSessions
+{
+    /// <summary>
+    /// Builds a SessionInfo good enough for selection and messaging assertions.
+    /// </summary>
+    /// <param name="id">Session ID.</param>
+    /// <param name="deviceId">Device ID.</param>
+    /// <param name="userId">Owning user.</param>
+    /// <param name="userName">Display name for logs.</param>
+    /// <returns>The session.</returns>
+    internal static SessionInfo Create(string id, string deviceId, Guid userId, string userName = "tester")
+    {
+        return new SessionInfo(null!, NullLogger.Instance)
+        {
+            Id = id,
+            DeviceId = deviceId,
+            DeviceName = "device-" + id,
+            UserId = userId,
+            UserName = userName,
+            Client = "Jellyfin Web"
+        };
+    }
+}

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/TestDoubles.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/TestDoubles.cs
@@ -135,6 +135,52 @@ internal sealed class ThrowingClientMessageService : IClientMessageService
         => throw new System.Net.WebSockets.WebSocketException("the remote party closed the connection");
 }
 
+/// <summary>
+/// Holds every caller inside the query until all of them have arrived, so admissions genuinely
+/// overlap instead of completing one at a time as the test enumerates them.
+/// </summary>
+internal sealed class GatedGpuMemoryProvider : IGpuMemoryProvider
+{
+    private readonly int _expectedCallers;
+    private readonly Queue<GpuMemoryQueryResult> _readings;
+    private readonly TaskCompletionSource _allArrived = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _arrived;
+
+    public GatedGpuMemoryProvider(int expectedCallers, params int[] freeMiBReadings)
+    {
+        _expectedCallers = expectedCallers;
+        _readings = new Queue<GpuMemoryQueryResult>(freeMiBReadings.Select(GpuMemoryQueryResult.FromFreeMiB));
+    }
+
+    public int QueryCount { get; private set; }
+
+    public async Task<GpuMemoryQueryResult> GetFreeMemoryAsync(
+        int gpuIndex,
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken)
+    {
+        GpuMemoryQueryResult reading;
+
+        lock (_readings)
+        {
+            QueryCount++;
+            _arrived++;
+            reading = _readings.Count > 0
+                ? _readings.Dequeue()
+                : GpuMemoryQueryResult.Failed("no scripted reading left");
+
+            if (_arrived == _expectedCallers)
+            {
+                _allArrived.TrySetResult();
+            }
+        }
+
+        // Times out rather than hanging if the guard ever serialises admissions.
+        await _allArrived.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken).ConfigureAwait(false);
+        return reading;
+    }
+}
+
 internal static class TestSessions
 {
     /// <summary>

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/UnixFactAttribute.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/UnixFactAttribute.cs
@@ -1,0 +1,16 @@
+namespace Jellyfin.Plugin.TranscodeNag.Tests;
+
+/// <summary>
+/// A fact that is reported as skipped on Windows, for tests that need a POSIX shell to stand in
+/// for an external tool. Skipping keeps them visible rather than silently passing.
+/// </summary>
+public sealed class UnixFactAttribute : FactAttribute
+{
+    public UnixFactAttribute()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            Skip = "Requires a POSIX shell to stand in for nvidia-smi.";
+        }
+    }
+}


### PR DESCRIPTION
## Problem

When the GPU is shared with another workload, a second 4K HDR hardware transcode can fail to allocate VRAM. Jellyfin launches FFmpeg, it exits 187, Jellyfin retries, and the user gets a generic playback error after several dead processes.

This adds opt-in admission control: check free VRAM immediately before Jellyfin starts FFmpeg, and refuse the job if it is below a configured floor. **Off by default.**

## Interception point (the part worth reviewing hardest)

A plugin *can* veto pre-FFmpeg on 10.10/10.11, via DI decoration of `ITranscodeManager`:

- `ApplicationHost.cs:575` registers `AddSingleton<ITranscodeManager, TranscodeManager>()`, and `ApplicationHost.cs:460-462` runs core `RegisterServices` **before** `_pluginManager.RegisterServices`. The core `ServiceDescriptor` is therefore already in the collection when our registrator runs, and can be replaced with one that wraps it.
- All three streaming FFmpeg launch sites — `DynamicHlsController:312`, `DynamicHlsController:1539`, `FileStreamResponseHelpers:151` — funnel through `ITranscodeManager.StartFfMpeg`. Nothing resolves the concrete `TranscodeManager`.
- `StartFfMpeg` hands us the **finished FFmpeg command line**, so GPU detection reads Jellyfin's own playback decision rather than re-deriving codec compatibility. It also carries `userId`, and `StreamState.Request` carries `DeviceId` / `PlaySessionId` / item id.
- No DI cycle: `SessionManager` has no `ITranscodeManager` dependency.

`PlaybackMonitor`'s existing `PlaybackStart` hook is ~10s too late and was never a candidate.

**Refusal mechanism:** `throw new ArgumentException(...)` — precisely how Jellyfin itself refuses a transcode at `TranscodeManager.cs:392` when a user lacks `EnableVideoPlaybackTranscoding`. `ExceptionMiddleware` maps it to **HTTP 400**, a terminal answer rather than the retryable 500 the exit-187 path produces today.

## Scope of the guard

Refuses only when **both** hold, read from Jellyfin's own output:

1. `IsVideoRequest && OutputVideoCodec != "copy"` — a real video encode, not remux/Direct Stream/audio-only.
2. NVIDIA markers in the command line — `-hwaccel cuda|nvdec`, `-init_hw_device cuda=…`, `-c:v *_nvenc|*_cuvid`, CUDA/NPP filters.

Direct Play, Direct Stream, remux, audio-only, CPU-only video transcodes, and QSV/VAAPI/VideoToolbox are never refused. Marker matching is token-positional, not substring, so a file named `Cuda nvenc.mkv` can't trip it (there's a test).

`StartFfMpeg` runs once per transcode job, not per segment, so there's no per-request `nvidia-smi` cost.

## Behaviour

- **Fail-open** on every query failure: missing/absent `nvidia-smi`, timeout, nonzero exit, malformed output, absent GPU index. Logged, never denied.
- **Session correlation** by `DeviceId` narrowed to the requesting user, so parallel sessions never receive each other's warnings, and a stale session from a previous sign-in on the same device is not messaged.
- **Suppression**: duplicate popups and warnings de-duplicated for 10s; the refusal itself is never suppressed.
- **Client message** carries no VRAM figures, encoder names, or FFmpeg detail. Refusal works whether or not the client supports `DisplayMessage`.
- A failed DI hookup degrades to "no guard" and logs a warning at startup, rather than letting Jellyfin mark the whole plugin malfunctioned and cost the user the nag/MOTD features. `ITranscodeManager` doesn't exist before 10.10, so the decoration is isolated behind a `[MethodImpl(NoInlining)]` call — the plugin keeps its net8.0 / Jellyfin.Controller 10.10.7 target and `targetAbi 10.9.0.0`.

## Existing behaviour

`PlaybackMonitor`'s session-resolution and `DisplayMessage` plumbing moved to a shared `ClientMessageService` used by both features. Pure extraction — the caller's own `ILogger` is passed through so the `Jellyfin.Plugin.TranscodeNag.PlaybackMonitor` log category and every existing log line stay byte-identical. See the `PlaybackMonitor.cs` diff.

## Configuration

`EnableGpuResourceGuard` (default off), `GpuIndex`, `MinimumFreeGpuMemoryMiB` (1500), `GpuCheckTimeoutMilliseconds` (1000), plus two beyond the original spec: `NvidiaSmiPath` (escape hatch for containers where it isn't on `PATH`) and the refusal popup header/body. The 10s suppression window is a constant.

## Verification

- Release build clean, both `dotnet format` gates pass, output still a single DLL with no assembly references Jellyfin doesn't already ship.
- 103 tests: policy matrix, command-line detection, nvidia-smi parsing, real-process failure modes, session correlation, DI decoration, and resilience (a guard that throws must not become an outage).
- **Not verified:** the manual acceptance test. That needs a live server with a real GPU under load.

## Notes for review

- The test project targets `net10.0` while CI pins `dotnet-version: 8.0.x` and never runs tests, so it can't build there. Pre-existing; I ran the suite locally by temporarily retargeting to `net9.0`. Worth fixing separately.
- `ArgumentException` → 400 means Jellyfin's `ExceptionMiddleware` logs a stack trace per refused request. Cosmetic, and identical to what happens today when a user lacks transcode permission. `SecurityException` → 403 would avoid the trace (it's in the middleware's `ignoreStackTrace` list) but I couldn't verify client behaviour on a 403 for a stream URL, so I stayed on Jellyfin's proven path.
- The check-then-launch race is inherent and documented in `GpuResourceGuard`'s remarks. Clearing the threshold is not a guarantee; the point is refusing the predictable failures.
