### PR TITLE
fix(gpu): one refusal popup per playback, not one per renegotiation

### DIFF
--- a/Gpu/GpuResourceGuard.cs
+++ b/Gpu/GpuResourceGuard.cs
@@ -22,9 +22,12 @@ namespace Jellyfin.Plugin.TranscodeNag.Gpu;
 /// </remarks>
 public sealed class GpuResourceGuard
 {
-    // Jellyfin (and clients) re-request a failed stream within seconds. Every attempt is still
-    // refused; this only stops the client popup and the warning log repeating.
-    private static readonly TimeSpan NotificationSuppressionWindow = TimeSpan.FromSeconds(10);
+    // A refused client does not simply retry the stream URL: it renegotiates from
+    // /Items/{id}/PlaybackInfo, and Jellyfin mints a fresh PlaySessionId on every one of those
+    // calls. A window keyed on the play session therefore suppresses nothing, which is why a
+    // single refused playback produced a popup per renegotiation. Key on device plus item, and
+    // keep the window wide enough to span a client's whole give-up sequence.
+    private static readonly TimeSpan NotificationSuppressionWindow = TimeSpan.FromSeconds(30);
 
     private const string DefaultDeniedHeader = "Transcoding unavailable";
     private const string DefaultDeniedMessage = "GPU resources are currently busy. Please try again later or use Direct Play.";
@@ -212,12 +215,18 @@ public sealed class GpuResourceGuard
     private static string Fallback(string? configured, string defaultText)
         => string.IsNullOrWhiteSpace(configured) ? defaultText : configured;
 
+    /// <summary>
+    /// Identifies "this client, this item" across renegotiation. Deliberately excludes
+    /// PlaySessionId: Jellyfin issues a new one per PlaybackInfo call, so including it would make
+    /// every renegotiated retry look like a first refusal.
+    /// </summary>
+    /// <param name="request">The refused transcode.</param>
+    /// <returns>The suppression key.</returns>
     private static string BuildSuppressionKey(GpuTranscodeRequest request)
     {
         return string.Join(
             '|',
             request.DeviceId ?? string.Empty,
-            request.PlaySessionId ?? string.Empty,
             request.ItemId.ToString("N", CultureInfo.InvariantCulture));
     }
 

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
@@ -158,6 +158,7 @@ public class GpuResourceGuardTests
             Assert.False(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
         }
 
+
         // Every attempt is still refused; only the client popup is de-duplicated.
         Assert.Single(messages.SentMessages);
     }
@@ -241,16 +242,39 @@ public class GpuResourceGuardTests
     }
 
     [Fact]
-    public async Task IsAdmittedAsync_DeniesAgainOnceTheSuppressionWindowHasNoEntry()
+    public async Task IsAdmittedAsync_RenegotiatedRetriesDoNotEachGetAPopup()
     {
         var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
         var messages = new RecordingClientMessageService();
         messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
         var guard = CreateGuard(EnabledConfig(1500), provider, messages);
 
-        // A different play session is a different playback attempt, so it gets its own popup.
-        await guard.IsAdmittedAsync(HardwareTranscodeRequest("device-2", "play-2"), CancellationToken.None);
-        await guard.IsAdmittedAsync(HardwareTranscodeRequest("device-2", "play-3"), CancellationToken.None);
+        // A refused client renegotiates from /Items/{id}/PlaybackInfo, and Jellyfin mints a new
+        // PlaySessionId every time. Same device, same item, so it is still one refused playback.
+        foreach (var playSessionId in new[] { "play-2", "play-3", "play-4" })
+        {
+            Assert.False(await guard.IsAdmittedAsync(
+                HardwareTranscodeRequest("device-2", playSessionId),
+                CancellationToken.None));
+        }
+
+        Assert.Single(messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_ADifferentItemOnTheSameDeviceStillGetsItsOwnPopup()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+
+        var firstItem = HardwareTranscodeRequest("device-2", "play-2");
+        var secondItem = HardwareTranscodeRequest("device-2", "play-3");
+        secondItem.ItemId = Guid.Parse("44444444-4444-4444-4444-444444444444");
+
+        await guard.IsAdmittedAsync(firstItem, CancellationToken.None);
+        await guard.IsAdmittedAsync(secondItem, CancellationToken.None);
 
         Assert.Equal(2, messages.SentMessages.Count);
     }


### PR DESCRIPTION
Follow-up to #24, from live testing on a real GPU.

## Symptom

One refused transcode produced **three** "GPU resources are currently busy" popups.

## Cause

The suppression key was `device | playSessionId | item`, taken from the original handoff spec. But a refused client does not retry the stream URL — it renegotiates from `/Items/{id}/PlaybackInfo`, and `MediaInfoHelper.cs:142` mints a fresh `PlaySessionId` on **every** such call:

```csharp
result.PlaySessionId = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
```

So every renegotiation produced a new key and looked like a first refusal. The window suppressed nothing in exactly the case it was written for.

## Fix

Key on `device | item`, which is stable across renegotiation, and widen the window to 30s so it spans a client's whole give-up sequence. A different item on the same device still gets its own popup, and the refusal itself is still never suppressed — only the popup and the warning log.

## Tests

`IsAdmittedAsync_RenegotiatedRetriesDoNotEachGetAPopup` reproduces the report and fails against the old key with `Assert.Single() Failure: The collection contained 3 items`. `IsAdmittedAsync_ADifferentItemOnTheSameDeviceStillGetsItsOwnPopup` pins the boundary so the wider key does not over-suppress.

109 tests pass, Release build clean, both lint gates pass.

## Not fixed here

The client's own "playback failed" dialog still appears after the popup. That is unavoidable from a plugin: the guard genuinely fails the request, so the client reports a failed playback. What changes here is that the user now gets **one** explanation instead of three, followed by the client's generic error.
