### PR TITLE
fix(gpu): announce every re-open, suppress only the client's retry burst

### DIFF
--- a/Gpu/GpuResourceGuard.cs
+++ b/Gpu/GpuResourceGuard.cs
@@ -22,12 +22,16 @@ namespace Jellyfin.Plugin.TranscodeNag.Gpu;
 /// </remarks>
 public sealed class GpuResourceGuard
 {
-    // A refused client does not simply retry the stream URL: it renegotiates from
-    // /Items/{id}/PlaybackInfo, and Jellyfin mints a fresh PlaySessionId on every one of those
-    // calls. A window keyed on the play session therefore suppresses nothing, which is why a
-    // single refused playback produced a popup per renegotiation. Key on device plus item, and
-    // keep the window wide enough to span a client's whole give-up sequence.
-    private static readonly TimeSpan NotificationSuppressionWindow = TimeSpan.FromSeconds(30);
+    // One press of play can produce several refusals: the client renegotiates from
+    // /Items/{id}/PlaybackInfo on failure, and Jellyfin mints a fresh PlaySessionId each time, so
+    // those retries are indistinguishable from a new request except by timing. They arrive
+    // back-to-back; a person who dismisses the error and presses play again does not.
+    //
+    // So this is a debounce on the gap between refusals, not a window from the first one. A burst
+    // collapses to a single popup however long it runs, and the moment the client stops hammering,
+    // the next refusal is announced again. A fixed window cannot do both: it either spams during
+    // the burst or goes silent on someone genuinely retrying.
+    private static readonly TimeSpan DefaultNotificationQuietPeriod = TimeSpan.FromSeconds(5);
 
     private const string DefaultDeniedHeader = "Transcoding unavailable";
     private const string DefaultDeniedMessage = "GPU resources are currently busy. Please try again later or use Direct Play.";
@@ -37,7 +41,9 @@ public sealed class GpuResourceGuard
     private readonly ILogger<GpuResourceGuard> _logger;
     private readonly Func<PluginConfiguration?> _configurationAccessor;
 
-    private readonly Dictionary<string, DateTimeOffset> _lastNotifiedUtc = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, DateTimeOffset> _lastRefusalUtc = new(StringComparer.Ordinal);
+    private readonly TimeSpan _notificationQuietPeriod;
+    private readonly Func<DateTimeOffset> _clock;
     private readonly object _suppressionLock = new();
 
     public GpuResourceGuard(
@@ -53,11 +59,30 @@ public sealed class GpuResourceGuard
         IClientMessageService clientMessageService,
         ILogger<GpuResourceGuard> logger,
         Func<PluginConfiguration?> configurationAccessor)
+        : this(
+            gpuMemoryProvider,
+            clientMessageService,
+            logger,
+            configurationAccessor,
+            DefaultNotificationQuietPeriod,
+            () => DateTimeOffset.UtcNow)
+    {
+    }
+
+    internal GpuResourceGuard(
+        IGpuMemoryProvider gpuMemoryProvider,
+        IClientMessageService clientMessageService,
+        ILogger<GpuResourceGuard> logger,
+        Func<PluginConfiguration?> configurationAccessor,
+        TimeSpan notificationQuietPeriod,
+        Func<DateTimeOffset> clock)
     {
         _gpuMemoryProvider = gpuMemoryProvider;
         _clientMessageService = clientMessageService;
         _logger = logger;
         _configurationAccessor = configurationAccessor;
+        _notificationQuietPeriod = notificationQuietPeriod;
+        _clock = clock;
     }
 
     /// <summary>
@@ -232,37 +257,37 @@ public sealed class GpuResourceGuard
 
     private bool ShouldNotify(string key)
     {
-        var now = DateTimeOffset.UtcNow;
+        var now = _clock();
 
         lock (_suppressionLock)
         {
-            if (_lastNotifiedUtc.TryGetValue(key, out var previous)
-                && now - previous < NotificationSuppressionWindow)
-            {
-                return false;
-            }
+            var notify = !_lastRefusalUtc.TryGetValue(key, out var previousRefusal)
+                || now - previousRefusal >= _notificationQuietPeriod;
 
+            // Recorded on every refusal, not just the announced ones: this measures the gap since
+            // the last attempt, so an ongoing burst keeps extending and a lull always resets.
             PruneExpired(now);
-            _lastNotifiedUtc[key] = now;
-            return true;
+            _lastRefusalUtc[key] = now;
+
+            return notify;
         }
     }
 
     private void PruneExpired(DateTimeOffset now)
     {
-        if (_lastNotifiedUtc.Count == 0)
+        if (_lastRefusalUtc.Count == 0)
         {
             return;
         }
 
-        var expired = _lastNotifiedUtc
-            .Where(entry => now - entry.Value >= NotificationSuppressionWindow)
+        var expired = _lastRefusalUtc
+            .Where(entry => now - entry.Value >= _notificationQuietPeriod)
             .Select(entry => entry.Key)
             .ToList();
 
         foreach (var key in expired)
         {
-            _lastNotifiedUtc.Remove(key);
+            _lastRefusalUtc.Remove(key);
         }
     }
 }

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
@@ -33,6 +33,22 @@ public class GpuResourceGuardTests
             () => config);
     }
 
+    private static GpuResourceGuard CreateGuard(
+        PluginConfiguration config,
+        IGpuMemoryProvider provider,
+        RecordingClientMessageService messages,
+        Func<DateTimeOffset> clock,
+        TimeSpan? quietPeriod = null)
+    {
+        return new GpuResourceGuard(
+            provider,
+            messages,
+            NullLogger<GpuResourceGuard>.Instance,
+            () => config,
+            quietPeriod ?? TimeSpan.FromSeconds(5),
+            clock);
+    }
+
     private static GpuTranscodeRequest HardwareTranscodeRequest(
         string deviceId = "device-2",
         string playSessionId = "play-2")
@@ -247,18 +263,68 @@ public class GpuResourceGuardTests
         var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
         var messages = new RecordingClientMessageService();
         messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
-        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
 
-        // A refused client renegotiates from /Items/{id}/PlaybackInfo, and Jellyfin mints a new
-        // PlaySessionId every time. Same device, same item, so it is still one refused playback.
-        foreach (var playSessionId in new[] { "play-2", "play-3", "play-4" })
+        // hls.js backs off roughly 1s, 2s, 4s between manifest retries, so the whole burst from
+        // one press of play arrives inside the quiet period.
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var guard = CreateGuard(EnabledConfig(1500), provider, messages, () => now);
+
+        foreach (var (playSessionId, afterSeconds) in new[] { ("play-2", 0), ("play-3", 1), ("play-4", 4) })
         {
+            now = now.AddSeconds(afterSeconds);
             Assert.False(await guard.IsAdmittedAsync(
                 HardwareTranscodeRequest("device-2", playSessionId),
                 CancellationToken.None));
         }
 
         Assert.Single(messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_ReopeningTheVideoIsAnnouncedEveryTime()
+    {
+        // The complaint this replaces: nine deliberate re-opens produced one popup, because a
+        // fixed window swallowed everything after the first.
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var guard = CreateGuard(EnabledConfig(1500), provider, messages, () => now);
+
+        for (var attempt = 0; attempt < 9; attempt++)
+        {
+            now = now.AddSeconds(20);
+            Assert.False(await guard.IsAdmittedAsync(
+                HardwareTranscodeRequest("device-2", "play-" + attempt),
+                CancellationToken.None));
+        }
+
+        Assert.Equal(9, messages.SentMessages.Count);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_ABurstFollowedByAReopenGetsExactlyTwoPopups()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var guard = CreateGuard(EnabledConfig(1500), provider, messages, () => now);
+
+        // Press play: one popup, and the client's two renegotiations stay quiet.
+        foreach (var afterSeconds in new[] { 0, 1, 4 })
+        {
+            now = now.AddSeconds(afterSeconds);
+            await guard.IsAdmittedAsync(HardwareTranscodeRequest("device-2", "burst"), CancellationToken.None);
+        }
+
+        // Dismiss the error, press play again.
+        now = now.AddSeconds(10);
+        await guard.IsAdmittedAsync(HardwareTranscodeRequest("device-2", "reopen"), CancellationToken.None);
+
+        Assert.Equal(2, messages.SentMessages.Count);
     }
 
     [Fact]


### PR DESCRIPTION
Follow-up to #25, from live testing. Opening the same video nine times produced one popup.

## What was wrong

The 30s window in #25 was too blunt. It could not tell a client's automatic retries apart from a person pressing play again, so it swallowed both. I traded "three popups per press" for "silence on eight of nine presses" — the wrong trade. A user who gets no explanation assumes the plugin is broken.

## Fix

A debounce on the **gap between refusals**, not a window from the first one.

One press of play produces a burst: the client renegotiates `/Items/{id}/PlaybackInfo` on failure and Jellyfin mints a new `PlaySessionId` each time, so those retries are structurally indistinguishable from a fresh request — timing is the only signal. They arrive back-to-back (hls.js backs off ~1s, 2s, 4s), well inside a 5s quiet period. A person who dismisses the error dialog and presses play again does not.

The key change is that the last-refusal time is recorded on **every** refusal, not just announced ones, so an ongoing burst keeps extending itself and any lull resets it.

## Behaviour

| Scenario | Popups |
|---|---|
| One press of play (3 renegotiations at 0s, 1s, 4s) | 1 |
| Nine re-opens, 20s apart | 9 |
| A burst, then a re-open 10s later | 2 |

Each is a test. The quiet period and clock are injectable, so this is asserted exactly rather than by sleeping.

111 tests pass, Release build clean, both lint gates pass.
