### PR TITLE
fix(gpu): calibrate the quiet period to jellyfin-web's actual retry timing

### DIFF
--- a/Gpu/GpuResourceGuard.cs
+++ b/Gpu/GpuResourceGuard.cs
@@ -22,16 +22,22 @@ namespace Jellyfin.Plugin.TranscodeNag.Gpu;
 /// </remarks>
 public sealed class GpuResourceGuard
 {
-    // One press of play can produce several refusals: the client renegotiates from
-    // /Items/{id}/PlaybackInfo on failure, and Jellyfin mints a fresh PlaySessionId each time, so
-    // those retries are indistinguishable from a new request except by timing. They arrive
-    // back-to-back; a person who dismisses the error and presses play again does not.
+    // One press of play can produce several refusals. On a playback error jellyfin-web's
+    // playbackmanager falls back to progressively stricter transcode options, and each fallback
+    // is a fresh /Items/{id}/PlaybackInfo call, so Jellyfin mints a new PlaySessionId every time.
+    // Those retries are indistinguishable from a new request except by timing.
     //
-    // So this is a debounce on the gap between refusals, not a window from the first one. A burst
-    // collapses to a single popup however long it runs, and the moment the client stops hammering,
-    // the next refusal is announced again. A fixed window cannot do both: it either spams during
-    // the burst or goes silent on someone genuinely retrying.
-    private static readonly TimeSpan DefaultNotificationQuietPeriod = TimeSpan.FromSeconds(5);
+    // Timing separates them well, because the fallback delay is setTimeout(..., 100) and the
+    // chain is bounded - enablePlaybackRetryWithTranscoding stops once video and audio stream
+    // copy are both disallowed. A whole burst is therefore around three hops of ~100ms plus two
+    // round trips: comfortably under a second. A person dismissing the error dialog and pressing
+    // play again takes far longer.
+    //
+    // So this is a debounce on the gap between refusals, not a window from the first one: a burst
+    // collapses to one popup however long it runs, and any lull announces the next refusal. Three
+    // seconds leaves several times the headroom a real burst needs while still announcing a
+    // deliberate re-open.
+    private static readonly TimeSpan DefaultNotificationQuietPeriod = TimeSpan.FromSeconds(3);
 
     private const string DefaultDeniedHeader = "Transcoding unavailable";
     private const string DefaultDeniedMessage = "GPU resources are currently busy. Please try again later or use Direct Play.";

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
@@ -264,17 +264,39 @@ public class GpuResourceGuardTests
         var messages = new RecordingClientMessageService();
         messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
 
-        // hls.js backs off roughly 1s, 2s, 4s between manifest retries, so the whole burst from
-        // one press of play arrives inside the quiet period.
+        // jellyfin-web falls back with setTimeout(..., 100) per hop, so a real burst from one
+        // press of play is a few hundred milliseconds end to end.
         var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
         var guard = CreateGuard(EnabledConfig(1500), provider, messages, () => now);
 
-        foreach (var (playSessionId, afterSeconds) in new[] { ("play-2", 0), ("play-3", 1), ("play-4", 4) })
+        foreach (var (playSessionId, afterMs) in new[] { ("play-2", 0), ("play-3", 250), ("play-4", 400) })
         {
-            now = now.AddSeconds(afterSeconds);
+            now = now.AddMilliseconds(afterMs);
             Assert.False(await guard.IsAdmittedAsync(
                 HardwareTranscodeRequest("device-2", playSessionId),
                 CancellationToken.None));
+        }
+
+        Assert.Single(messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_ASlowBurstStillCollapsesToOnePopup()
+    {
+        // Headroom check: even at four times the measured fallback delay, a burst is one popup.
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var guard = CreateGuard(EnabledConfig(1500), provider, messages, () => now);
+
+        for (var hop = 0; hop < 4; hop++)
+        {
+            now = now.AddMilliseconds(hop == 0 ? 0 : 1200);
+            await guard.IsAdmittedAsync(
+                HardwareTranscodeRequest("device-2", "hop-" + hop),
+                CancellationToken.None);
         }
 
         Assert.Single(messages.SentMessages);
@@ -314,9 +336,9 @@ public class GpuResourceGuardTests
         var guard = CreateGuard(EnabledConfig(1500), provider, messages, () => now);
 
         // Press play: one popup, and the client's two renegotiations stay quiet.
-        foreach (var afterSeconds in new[] { 0, 1, 4 })
+        foreach (var afterMs in new[] { 0, 250, 400 })
         {
-            now = now.AddSeconds(afterSeconds);
+            now = now.AddMilliseconds(afterMs);
             await guard.IsAdmittedAsync(HardwareTranscodeRequest("device-2", "burst"), CancellationToken.None);
         }
 


### PR DESCRIPTION
Follow-up to #26. Not a bug report — I went and checked the assumption behind the 5s number instead of waiting to be wrong a third time.

## What I had assumed

That the retry burst was hls.js manifest backoff at roughly 1s, 2s, 4s, so I picked 5s to cover it.

## What jellyfin-web actually does

On a playback error, `playbackmanager.js` falls back to progressively stricter transcode options — one `PlaybackInfo` call per fallback, hence a new `PlaySessionId` each time. Two measurements from the v10.11.11 source:

**The delay per hop is 100ms**, not seconds:
```js
setTimeout(function () {
    onPlaybackError.call(player, err, { type: getMediaError(err), streamInfo });
}, 100);
```

**The chain is bounded**, which is why one press of play produced about three refusals:
```js
function enablePlaybackRetryWithTranscoding(streamInfo, errorType, currentlyPreventsVideoStreamCopy, currentlyPreventsAudioStreamCopy) {
    return streamInfo.mediaSource.SupportsTranscoding
        && (!currentlyPreventsVideoStreamCopy || !currentlyPreventsAudioStreamCopy);
}
```

So a real burst is ~3 hops of 100ms plus two round trips — comfortably under a second, not several.

## Change

Quiet period 5s → **3s**. That is still several times the headroom a burst needs, and it stops swallowing deliberate re-opens that happen 3–5s apart. The code comment now cites the real mechanism rather than my wrong one.

Tests use the measured hop timing (0ms, 250ms, 400ms) instead of invented intervals, and a new case pins the headroom explicitly: **four hops at 1.2s apart — four times the real delay — still collapse to one popup.**

112 tests pass, Release build clean, both lint gates pass.
