### PR TITLE
fix(gpu): stop logging a stack trace for every refusal

### DIFF
--- a/Gpu/GuardedTranscodeManager.cs
+++ b/Gpu/GuardedTranscodeManager.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Net;
 using MediaBrowser.Controller.Streaming;
 using Microsoft.Extensions.Logging;
 
@@ -71,7 +72,13 @@ public sealed class GuardedTranscodeManager : ITranscodeManager, IDisposable
 
         if (!admitted)
         {
-            throw new ArgumentException(_guard.BuildRefusalReason());
+            // MediaBrowser.Controller.Net.SecurityException, specifically - NOT the BCL type of
+            // the same name. Jellyfin's ExceptionMiddleware has no "using System.Security", so the
+            // SecurityException in its switch is Jellyfin's own; throwing the BCL one falls through
+            // to 500 with a full stack trace. This one maps to HTTP 403 and is logged as a single
+            // line, which is what a policy refusal deserves - the guard has already logged the
+            // detail, and a 40-line trace per attempt made a working guard read as a crash.
+            throw new SecurityException(_guard.BuildRefusalReason());
         }
 
         return await _inner.StartFfMpeg(

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GuardedTranscodeManagerTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GuardedTranscodeManagerTests.cs
@@ -2,6 +2,7 @@ using Jellyfin.Plugin.TranscodeNag.Configuration;
 using Jellyfin.Plugin.TranscodeNag.Gpu;
 using Jellyfin.Plugin.TranscodeNag.Messaging;
 using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Net;
 using MediaBrowser.Controller.Streaming;
 using MediaBrowser.Model.Dto;
 using Microsoft.Extensions.DependencyInjection;
@@ -134,7 +135,11 @@ public class GuardedTranscodeManagerTests
         var (decorator, inner, messages) = CreateDecorator(freeMiB: 700, thresholdMiB: 1500);
         using var cts = new CancellationTokenSource();
 
-        var ex = await Assert.ThrowsAsync<ArgumentException>(() => decorator.StartFfMpeg(
+        // Jellyfin's own SecurityException, not the BCL type of the same name: its exception
+        // middleware resolves the name against MediaBrowser.Controller.Net, maps this to HTTP 403,
+        // and logs it without a stack trace. Verified against a live 10.11.11 server - the BCL
+        // type falls through to 500 with a full trace.
+        var ex = await Assert.ThrowsAsync<SecurityException>(() => decorator.StartFfMpeg(
             CreateHardwareVideoState(),
             "/config/transcodes/abc.m3u8",
             CudaNvencArguments,
@@ -142,8 +147,7 @@ public class GuardedTranscodeManagerTests
             TranscodingJobType.Hls,
             cts));
 
-        // ArgumentException is what Jellyfin's exception middleware maps to HTTP 400, the same
-        // terminal answer it gives when a user lacks video transcoding permission.
+        Assert.Equal("MediaBrowser.Controller.Net.SecurityException", ex.GetType().FullName);
         Assert.Contains("free GPU memory", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Equal(0, inner.StartFfMpegCallCount);
         Assert.Single(messages.SentMessages);


### PR DESCRIPTION
Found by standing up Jellyfin 10.11.11 in Docker with the plugin installed and a fake `nvidia-smi` reporting 10 MiB free, then driving playback over a real WebSocket session. Not by reading source.

## What the reported log actually showed

The pasted fragment was a refusal with **no** `GPU transcode blocked` warning above it. Reproduced exactly — one press of play makes **two** `StartFfMpeg` calls (the fMP4 init segment `-1.mp4` and the first media segment):

```
[WRN] GpuResourceGuard: GPU transcode blocked for session ... free VRAM 10 MiB below ...
[INF] GpuResourceGuard: Sending gpu guard denial message to session ...
[INF] GpuResourceGuard: Completed gpu guard denial message send to session ...
[ERR] ExceptionMiddleware: ... System.ArgumentException ... (~40 lines)
[ERR] ExceptionMiddleware: ... System.ArgumentException ... (~40 lines)   <- no warning above it
```

The guard was working: the popup was delivered, and no FFmpeg started. The second trace is the sibling whose popup the debounce correctly suppresses. But it appears as a bare, unexplained 40-line stack trace, so a working guard reads as a crash.

## Fix

Throw `MediaBrowser.Controller.Net.SecurityException` instead of `ArgumentException`.

The subtlety: `ExceptionMiddleware.cs` has **no `using System.Security`**, so the `SecurityException` in its switch resolves to Jellyfin's own type via `using MediaBrowser.Controller.Net`. I got this wrong first and measured it:

| Thrown | HTTP | Log |
|---|---|---|
| `ArgumentException` (shipped today) | 400 | ~40 line trace, per refusal |
| `System.Security.SecurityException` | **500** | ~40 line trace — the BCL type matches nothing |
| `MediaBrowser.Controller.Net.SecurityException` | **403** | **one line** |

Jellyfin's own summary for that type is *"The exception that is thrown when a user is authenticated, but not authorized to access a requested resource"* — the case exactly. It exists in both 10.10.7 (our compile ABI) and 10.11.11.

## Client impact: none

jellyfin-web special-cases a 403 only when it carries `errorCode === 'ParentalControl'` (`appRouter.js:200`); 401 is only special-cased on the login screen. Our body is plain text, so a 403 fails a stream exactly like the 400 did — no logout, no redirect.

## Unchanged, confirmed live

Popup delivery over a real WebSocket, the debounce, and the guarantee that no FFmpeg process starts. 111 tests pass, Release build clean, both lint gates pass.
