### PR TITLE
feat(gpu): admit transcodes using live VRAM headroom

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,19 @@ jobs:
         dotnet-version: 8.0.x
 
     - name: Restore dependencies
-      run: dotnet restore
+      run: dotnet restore tests/Jellyfin.Plugin.TranscodeNag.Tests/Jellyfin.Plugin.TranscodeNag.Tests.csproj
+
+    - name: Run unit tests
+      run: dotnet test tests/Jellyfin.Plugin.TranscodeNag.Tests/Jellyfin.Plugin.TranscodeNag.Tests.csproj --configuration Release --no-restore
 
     - name: Check whitespace formatting
       run: dotnet format whitespace --verify-no-changes --verbosity minimal
 
     - name: Check C# style formatting
       run: dotnet format style --verify-no-changes --severity warn --verbosity minimal
+
+    - name: Check test whitespace formatting
+      run: dotnet format tests/Jellyfin.Plugin.TranscodeNag.Tests/Jellyfin.Plugin.TranscodeNag.Tests.csproj whitespace --verify-no-changes --verbosity minimal
+
+    - name: Check test C# style formatting
+      run: dotnet format tests/Jellyfin.Plugin.TranscodeNag.Tests/Jellyfin.Plugin.TranscodeNag.Tests.csproj style --verify-no-changes --severity warn --verbosity minimal

--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -78,14 +78,9 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool EnableGpuResourceGuard { get; set; } = false;
 
     /// <summary>
-    /// Gets or sets the zero-based NVIDIA GPU index the guard watches.
+    /// Gets or sets the fallback zero-based NVIDIA GPU index. An explicit FFmpeg selection wins.
     /// </summary>
     public int GpuIndex { get; set; } = 0;
-
-    /// <summary>
-    /// Gets or sets the free-VRAM floor, in MiB. Hardware video transcodes are refused below this value.
-    /// </summary>
-    public int MinimumFreeGpuMemoryMiB { get; set; } = 1500;
 
     /// <summary>
     /// Gets or sets how long the nvidia-smi query may run before it is abandoned.

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -179,8 +179,10 @@
 
                     <h2>GPU Resource Guard</h2>
                     <div class="fieldDescription" style="margin-bottom: 12px;">
-                        Refuses an NVIDIA hardware video transcode before FFmpeg is launched when the GPU is short
-                        on memory, so a doomed transcode fails once and clearly instead of retrying. NVIDIA only:
+                        Gives each NVIDIA hardware video transcode a conservative VRAM budget based on its source,
+                        filters, and output, then refuses it before FFmpeg launches when that budget will not fit.
+                        This allows small jobs to use gaps that a fixed free-memory threshold would waste while
+                        keeping expensive 4K/HDR jobs out when they are unlikely to fit. NVIDIA only:
                         QSV, VAAPI, and VideoToolbox transcodes are never refused. Requires <code>nvidia-smi</code>
                         to be reachable from the Jellyfin server process.
                     </div>
@@ -190,20 +192,14 @@
                             <input type="checkbox" is="emby-checkbox" id="chkEnableGpuResourceGuard" name="chkEnableGpuResourceGuard" />
                             <span>Enable GPU resource guard</span>
                         </label>
-                        <div class="fieldDescription checkboxFieldDescription">Off by default. If free GPU memory cannot be read, playback is always allowed.</div>
+                        <div class="fieldDescription checkboxFieldDescription">Off by default. The budget is automatic; if free GPU memory cannot be read, playback is always allowed.</div>
                     </div>
 
                     <div id="gpuGuardOptions" style="display: none;">
                         <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="txtGpuIndex">GPU index:</label>
                             <input type="number" id="txtGpuIndex" name="txtGpuIndex" min="0" max="15" class="emby-input" />
-                            <div class="fieldDescription">Zero-based index of the NVIDIA GPU to watch, as reported by nvidia-smi.</div>
-                        </div>
-
-                        <div class="inputContainer">
-                            <label class="inputLabel inputLabelUnfocused" for="txtMinimumFreeGpuMemoryMiB">Minimum free GPU memory (MiB):</label>
-                            <input type="number" id="txtMinimumFreeGpuMemoryMiB" name="txtMinimumFreeGpuMemoryMiB" min="0" max="131072" class="emby-input" />
-                            <div class="fieldDescription">NVIDIA hardware video transcoding is refused when available GPU memory is below this value. Direct Play and other non-GPU playback are unaffected.</div>
+                            <div class="fieldDescription">Fallback zero-based NVIDIA GPU index. When FFmpeg explicitly selects a GPU, the guard automatically checks that device instead.</div>
                         </div>
 
                         <div class="inputContainer">
@@ -951,7 +947,6 @@
                     document.getElementById('txtMotdExcludedClientPatterns').value = ClientPatternEditor.formatPatterns(config.MotdExcludedClientPatterns);
                     document.getElementById('chkEnableGpuResourceGuard').checked = config.EnableGpuResourceGuard === true;
                     document.getElementById('txtGpuIndex').value = GpuGuardSection.numberOrDefault(config.GpuIndex, 0);
-                    document.getElementById('txtMinimumFreeGpuMemoryMiB').value = GpuGuardSection.numberOrDefault(config.MinimumFreeGpuMemoryMiB, 1500);
                     document.getElementById('txtGpuCheckTimeoutMs').value = GpuGuardSection.numberOrDefault(config.GpuCheckTimeoutMilliseconds, 1000);
                     document.getElementById('txtNvidiaSmiPath').value = config.NvidiaSmiPath || '';
                     document.getElementById('txtGpuGuardDeniedHeader').value = config.GpuGuardDeniedHeader || '';
@@ -987,7 +982,6 @@
                     config.MotdExcludedClientPatterns = ClientPatternEditor.splitPatterns(document.getElementById('txtMotdExcludedClientPatterns').value);
                     config.EnableGpuResourceGuard = document.getElementById('chkEnableGpuResourceGuard').checked;
                     config.GpuIndex = GpuGuardSection.readNumber('txtGpuIndex', 0);
-                    config.MinimumFreeGpuMemoryMiB = GpuGuardSection.readNumber('txtMinimumFreeGpuMemoryMiB', 1500);
                     config.GpuCheckTimeoutMilliseconds = GpuGuardSection.readNumber('txtGpuCheckTimeoutMs', 1000);
                     config.NvidiaSmiPath = document.getElementById('txtNvidiaSmiPath').value.trim();
                     config.GpuGuardDeniedHeader = document.getElementById('txtGpuGuardDeniedHeader').value;

--- a/Gpu/GpuAdmissionAttempt.cs
+++ b/Gpu/GpuAdmissionAttempt.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+
+/// <summary>
+/// One admission result and, when needed, its temporary in-flight VRAM reservation.
+/// </summary>
+internal readonly record struct GpuAdmissionAttempt(bool IsAdmitted, GpuAdmissionReservation? Reservation)
+{
+    internal static GpuAdmissionAttempt AllowedWithoutReservation => new(true, null);
+
+    internal static GpuAdmissionAttempt Denied => new(false, null);
+}
+
+/// <summary>
+/// Holds a conservative VRAM requirement until a launched FFmpeg process has allocated it.
+/// </summary>
+internal sealed class GpuAdmissionReservation : IDisposable
+{
+    private GpuResourceGuard? _owner;
+    private readonly string _key;
+    private readonly long _reservationId;
+
+    internal GpuAdmissionReservation(GpuResourceGuard owner, string key, long reservationId)
+    {
+        _owner = owner;
+        _key = key;
+        _reservationId = reservationId;
+    }
+
+    /// <summary>
+    /// Marks FFmpeg as launched. The budget remains reserved briefly while nvidia-smi catches up.
+    /// </summary>
+    internal Task MarkLaunched(int? processId = null, GpuTranscodeRequest? request = null)
+    {
+        var owner = Interlocked.Exchange(ref _owner, null);
+        if (owner == null)
+        {
+            return Task.CompletedTask;
+        }
+
+        owner.CompleteReservation(_key, _reservationId, launched: true);
+        if (processId is > 0 && request != null)
+        {
+            return owner.BeginProcessObservation(_key, _reservationId, processId.Value, request);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        var owner = Interlocked.Exchange(ref _owner, null);
+        owner?.CompleteReservation(_key, _reservationId, launched: false);
+    }
+}

--- a/Gpu/GpuAdmissionPolicy.cs
+++ b/Gpu/GpuAdmissionPolicy.cs
@@ -14,13 +14,13 @@ internal enum GpuAdmissionOutcome
     /// <summary>Direct Play, remux/stream copy, or audio-only - no GPU video encode involved.</summary>
     AllowedNotGpuTranscode,
 
-    /// <summary>Free VRAM is at or above the configured floor.</summary>
+    /// <summary>The pending job's conservative VRAM requirement fits in the currently free memory.</summary>
     AllowedSufficientMemory,
 
     /// <summary>Free VRAM could not be determined; the guard is fail-open.</summary>
     AllowedQueryFailed,
 
-    /// <summary>Free VRAM is below the configured floor.</summary>
+    /// <summary>The pending job's VRAM budget does not fit in the currently free memory.</summary>
     Denied
 }
 
@@ -57,7 +57,7 @@ internal static class GpuAdmissionPolicy
     }
 
     /// <summary>
-    /// Applies the configured threshold to a free-VRAM reading.
+    /// Checks whether the pending job and any admitted-but-not-yet-visible jobs fit in free VRAM.
     /// </summary>
     /// <param name="config">Plugin configuration.</param>
     /// <param name="requiresGpuVideoTranscode">Result of <see cref="RequiresGpuVideoTranscode"/>.</param>
@@ -66,7 +66,9 @@ internal static class GpuAdmissionPolicy
     internal static GpuAdmissionOutcome Evaluate(
         PluginConfiguration config,
         bool requiresGpuVideoTranscode,
-        GpuMemoryQueryResult? memory)
+        GpuMemoryQueryResult? memory,
+        int jobBudgetMiB,
+        int inFlightBudgetMiB = 0)
     {
         ArgumentNullException.ThrowIfNull(config);
 
@@ -86,9 +88,23 @@ internal static class GpuAdmissionPolicy
             return GpuAdmissionOutcome.AllowedQueryFailed;
         }
 
-        return reading.FreeMiB >= config.MinimumFreeGpuMemoryMiB
+        var requiredMiB = RequiredMemoryMiB(jobBudgetMiB, inFlightBudgetMiB);
+
+        return reading.FreeMiB >= requiredMiB
             ? GpuAdmissionOutcome.AllowedSufficientMemory
             : GpuAdmissionOutcome.Denied;
+    }
+
+    /// <summary>
+    /// Gets the free VRAM required to admit a job, including pending jobs.
+    /// Each individual budget already contains margin and is rounded up to 256 MiB.
+    /// </summary>
+    internal static int RequiredMemoryMiB(int jobBudgetMiB, int inFlightBudgetMiB = 0)
+    {
+        var required = (long)Math.Max(0, jobBudgetMiB)
+            + Math.Max(0, inFlightBudgetMiB);
+
+        return (int)Math.Min(int.MaxValue, required);
     }
 
     /// <summary>

--- a/Gpu/GpuProcessMemoryQueryResult.cs
+++ b/Gpu/GpuProcessMemoryQueryResult.cs
@@ -1,0 +1,16 @@
+namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+
+/// <summary>
+/// Outcome of attributing NVIDIA memory to one operating-system process.
+/// </summary>
+internal readonly record struct GpuProcessMemoryQueryResult(
+    bool Success,
+    int UsedMiB,
+    string? FailureReason)
+{
+    internal static GpuProcessMemoryQueryResult FromUsedMiB(int usedMiB)
+        => new(true, usedMiB, null);
+
+    internal static GpuProcessMemoryQueryResult Failed(string reason)
+        => new(false, 0, reason);
+}

--- a/Gpu/GpuResourceGuard.cs
+++ b/Gpu/GpuResourceGuard.cs
@@ -15,10 +15,11 @@ namespace Jellyfin.Plugin.TranscodeNag.Gpu;
 /// Admission control for GPU-backed video transcodes.
 /// </summary>
 /// <remarks>
-/// This is admission control, not a GPU scheduler. A reading is taken immediately before Jellyfin
-/// is allowed to launch FFmpeg, and there is inherently a race between that reading and the
-/// allocation FFmpeg goes on to make. Clearing the threshold does not guarantee the allocation
-/// succeeds; the point is to refuse the predictable failures when VRAM is plainly exhausted.
+/// This is admission control, not a GPU scheduler. A fresh reading is taken immediately before
+/// Jellyfin launches FFmpeg and compared with a conservative budget for that job. Short-lived in-flight
+/// reservations cover the gap before a new process's allocation appears in nvidia-smi. Admission
+/// cannot guarantee every driver allocation succeeds; it rejects the predictable failures while
+/// allowing smaller jobs to use the VRAM that is genuinely left.
 /// </remarks>
 public sealed class GpuResourceGuard
 {
@@ -38,6 +39,9 @@ public sealed class GpuResourceGuard
     // seconds leaves several times the headroom a real burst needs while still announcing a
     // deliberate re-open.
     private static readonly TimeSpan DefaultNotificationQuietPeriod = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan DefaultInFlightReservationLifetime = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan ProcessObservationInterval = TimeSpan.FromMilliseconds(250);
+    private const int ProcessObservationSampleCount = 3;
 
     private const string DefaultDeniedHeader = "Transcoding unavailable";
     private const string DefaultDeniedMessage = "GPU resources are currently busy. Please try again later or use Direct Play.";
@@ -48,9 +52,13 @@ public sealed class GpuResourceGuard
     private readonly Func<PluginConfiguration?> _configurationAccessor;
 
     private readonly Dictionary<string, DateTimeOffset> _lastRefusalUtc = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, InFlightReservation> _inFlightReservations = new(StringComparer.Ordinal);
     private readonly TimeSpan _notificationQuietPeriod;
     private readonly Func<DateTimeOffset> _clock;
     private readonly object _suppressionLock = new();
+    private readonly object _reservationLock = new();
+    private readonly SemaphoreSlim _admissionGate = new(1, 1);
+    private long _nextReservationId;
 
     public GpuResourceGuard(
         IGpuMemoryProvider gpuMemoryProvider,
@@ -99,13 +107,30 @@ public sealed class GpuResourceGuard
     /// <returns>True when the transcode may proceed.</returns>
     public async Task<bool> IsAdmittedAsync(GpuTranscodeRequest request, CancellationToken cancellationToken)
     {
+        var attempt = await AssessAsync(request, reserveInFlight: false, cancellationToken).ConfigureAwait(false);
+        return attempt.IsAdmitted;
+    }
+
+    /// <summary>
+    /// Decides whether Jellyfin may launch and reserves the job's budget until FFmpeg allocates it.
+    /// </summary>
+    internal Task<GpuAdmissionAttempt> TryReserveAsync(
+        GpuTranscodeRequest request,
+        CancellationToken cancellationToken)
+        => AssessAsync(request, reserveInFlight: true, cancellationToken);
+
+    private async Task<GpuAdmissionAttempt> AssessAsync(
+        GpuTranscodeRequest request,
+        bool reserveInFlight,
+        CancellationToken cancellationToken)
+    {
         ArgumentNullException.ThrowIfNull(request);
 
         var config = _configurationAccessor();
         if (config == null)
         {
             // The plugin is not fully loaded; never stand between Jellyfin and playback.
-            return true;
+            return GpuAdmissionAttempt.AllowedWithoutReservation;
         }
 
         var requiresGpu = GpuAdmissionPolicy.RequiresGpuVideoTranscode(
@@ -113,29 +138,124 @@ public sealed class GpuResourceGuard
             request.OutputVideoCodec,
             request.CommandLineArguments);
 
+        var features = requiresGpu
+            ? NvidiaTranscodeDetector.Analyze(request.CommandLineArguments)
+            : default;
+        var gpuIndex = features.GpuIndex ?? config.GpuIndex;
+        int? reservationGpuIndex = features.HasConflictingGpuIndices ? null : gpuIndex;
+        var estimate = requiresGpu ? GpuVramEstimator.Estimate(request) : GpuVramEstimate.Zero;
+        var reservationKey = BuildReservationKey(reservationGpuIndex, request);
+        var inFlightBudgetMiB = 0;
+        var decisionJobBudgetMiB = estimate.BudgetMiB;
+        var currentJobAlreadyTracked = false;
         GpuMemoryQueryResult? memory = null;
-        if (GpuAdmissionPolicy.RequiresGpuQuery(config, requiresGpu))
-        {
-            memory = await _gpuMemoryProvider.GetFreeMemoryAsync(
-                config.GpuIndex,
-                config.GpuCheckTimeoutMilliseconds,
-                cancellationToken).ConfigureAwait(false);
-        }
+        GpuAdmissionOutcome outcome;
+        GpuAdmissionReservation? reservation = null;
 
-        var outcome = GpuAdmissionPolicy.Evaluate(config, requiresGpu, memory);
+        if (!GpuAdmissionPolicy.RequiresGpuQuery(config, requiresGpu))
+        {
+            outcome = GpuAdmissionPolicy.Evaluate(
+                config,
+                requiresGpu,
+                memory,
+                estimate.BudgetMiB);
+        }
+        else
+        {
+            // Query, decide, and record the temporary budget as one serial operation. Otherwise
+            // simultaneous starts can all spend the same pre-allocation free-memory reading.
+            await _admissionGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (features.HasConflictingGpuIndices)
+                {
+                    // A contradictory FFmpeg command does not identify which GPU will allocate.
+                    // Treat that telemetry as unavailable instead of querying the wrong device.
+                    memory = GpuMemoryQueryResult.Failed("FFmpeg selected conflicting GPU indices");
+                }
+                else
+                {
+                    try
+                    {
+                        memory = await _gpuMemoryProvider.GetFreeMemoryAsync(
+                            gpuIndex,
+                            config.GpuCheckTimeoutMilliseconds,
+                            cancellationToken).ConfigureAwait(false);
+                    }
+                    catch (Exception ex) when (ex is not OutOfMemoryException && ex is not OperationCanceledException)
+                    {
+                        // Providers are expected to return a failed result, but a provider bug must
+                        // still preserve fail-open behaviour. Keep a reservation for the launch below
+                        // so the next successful query cannot spend the same pre-allocation memory.
+                        memory = GpuMemoryQueryResult.Failed(
+                            string.Format(
+                                CultureInfo.InvariantCulture,
+                                "GPU memory provider threw {0}",
+                                ex.GetType().Name));
+                    }
+                }
+
+                inFlightBudgetMiB = GetInFlightBudgetMiB(
+                    gpuIndex,
+                    reservationKey,
+                    out currentJobAlreadyTracked);
+                if (currentJobAlreadyTracked)
+                {
+                    // Repeated StartFfMpeg calls for one server output path reuse one process.
+                    // Neither this job nor unrelated pending jobs need to be charged again merely
+                    // to let Jellyfin retrieve another segment from that existing job.
+                    decisionJobBudgetMiB = 0;
+                    inFlightBudgetMiB = 0;
+                }
+
+                outcome = GpuAdmissionPolicy.Evaluate(
+                    config,
+                    requiresGpu,
+                    memory,
+                    decisionJobBudgetMiB,
+                    inFlightBudgetMiB);
+
+                if (reserveInFlight
+                    && outcome is GpuAdmissionOutcome.AllowedSufficientMemory
+                        or GpuAdmissionOutcome.AllowedQueryFailed)
+                {
+                    reservation = AddReservation(reservationGpuIndex, reservationKey, estimate.BudgetMiB);
+                }
+            }
+            finally
+            {
+                _admissionGate.Release();
+            }
+        }
 
         if (outcome == GpuAdmissionOutcome.AllowedQueryFailed)
         {
-            LogQueryFailure(config, memory);
+            BestEffort(() => LogQueryFailure(gpuIndex, memory));
         }
 
         if (outcome != GpuAdmissionOutcome.Denied)
         {
-            _logger.LogDebug(
-                "GPU resource guard allowed transcode of {ItemName}: {Outcome}",
-                request.ItemName ?? "Unknown",
-                outcome);
-            return true;
+            if (outcome == GpuAdmissionOutcome.AllowedSufficientMemory)
+            {
+                BestEffort(() => _logger.LogDebug(
+                    "GPU resource guard allowed transcode of {ItemName}: free VRAM {FreeMiB} MiB fits decision budget {DecisionBudgetMiB} MiB plus in-flight budget {InFlightBudgetMiB} MiB on GPU {GpuIndex}; profile budget {ProfileBudgetMiB} MiB, existing output job {ExistingOutputJob}",
+                    request.ItemName ?? "Unknown",
+                    memory!.Value.FreeMiB,
+                    decisionJobBudgetMiB,
+                    inFlightBudgetMiB,
+                    gpuIndex,
+                    estimate.BudgetMiB,
+                    currentJobAlreadyTracked));
+            }
+            else
+            {
+                BestEffort(() => _logger.LogDebug(
+                    "GPU resource guard allowed transcode of {ItemName}: {Outcome}",
+                    request.ItemName ?? "Unknown",
+                    outcome));
+            }
+
+            return new GpuAdmissionAttempt(true, reservation);
         }
 
         // The decision is made. Everything past this point is notification and logging, and none
@@ -144,17 +264,24 @@ public sealed class GpuResourceGuard
         // does not catch every failure Jellyfin's WebSocket send path can raise.
         try
         {
-            await DenyAsync(request, config, memory!.Value, cancellationToken).ConfigureAwait(false);
+            await DenyAsync(
+                request,
+                config,
+                memory!.Value,
+                estimate,
+                inFlightBudgetMiB,
+                gpuIndex,
+                cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) when (ex is not OutOfMemoryException)
         {
-            _logger.LogError(
+            BestEffort(() => _logger.LogError(
                 ex,
                 "Failed to notify the client about the refused GPU transcode of {ItemName}; the refusal still stands",
-                request.ItemName ?? "Unknown");
+                request.ItemName ?? "Unknown"));
         }
 
-        return false;
+        return GpuAdmissionAttempt.Denied;
     }
 
     /// <summary>
@@ -162,25 +289,33 @@ public sealed class GpuResourceGuard
     /// Jellyfin only returns exception messages to callers in a Development environment.
     /// </summary>
     /// <returns>The server-side refusal reason.</returns>
-    public string BuildRefusalReason()
+    public string BuildRefusalReason(GpuTranscodeRequest request)
     {
+        ArgumentNullException.ThrowIfNull(request);
+
         var config = _configurationAccessor();
         if (config == null)
         {
             return "Transcode Nag refused this hardware transcode: insufficient free GPU memory.";
         }
 
+        var estimate = GpuVramEstimator.Estimate(request);
+        var selectedGpuIndex = NvidiaTranscodeDetector.Analyze(request.CommandLineArguments).GpuIndex;
+
         return string.Format(
             CultureInfo.InvariantCulture,
-            "Transcode Nag refused this hardware transcode: free GPU memory on GPU {0} is below the configured minimum of {1} MiB.",
-            config.GpuIndex,
-            config.MinimumFreeGpuMemoryMiB);
+            "Transcode Nag refused this hardware transcode: its conservative {1} MiB VRAM budget does not fit in the memory currently free on GPU {0}.",
+            selectedGpuIndex ?? config.GpuIndex,
+            estimate.BudgetMiB);
     }
 
     private async Task DenyAsync(
         GpuTranscodeRequest request,
         PluginConfiguration config,
         GpuMemoryQueryResult memory,
+        GpuVramEstimate estimate,
+        int inFlightBudgetMiB,
+        int gpuIndex,
         CancellationToken cancellationToken)
     {
         var session = _clientMessageService.ResolveSession(request.DeviceId, request.UserId, request.ItemId);
@@ -189,27 +324,38 @@ public sealed class GpuResourceGuard
         if (!notify)
         {
             // Still refused - only the popup and the warning are de-duplicated.
-            _logger.LogDebug(
+            BestEffort(() => _logger.LogDebug(
                 "GPU transcode blocked again for item {ItemName} within the notification suppression window",
-                request.ItemName ?? "Unknown");
+                request.ItemName ?? "Unknown"));
             return;
         }
 
-        _logger.LogWarning(
-            "GPU transcode blocked for session {SessionId}, user {UserName}, device {DeviceName}, item {ItemName}: free VRAM {FreeMiB} MiB below configured threshold {ThresholdMiB} MiB on GPU {GpuIndex}",
+        BestEffort(() => _logger.LogWarning(
+            "GPU transcode blocked for session {SessionId}, user {UserName}, device {DeviceName}, item {ItemName}: free VRAM {FreeMiB} MiB cannot fit conservative job budget {JobBudgetMiB} MiB plus in-flight budget {InFlightBudgetMiB} MiB on GPU {GpuIndex}; shape {SourceWidth}x{SourceHeight} {SourceBitDepth}-bit {SourceCodec} to {OutputWidth}x{OutputHeight} {OutputBitDepth}-bit {OutputCodec}, CUDA tonemap {UsesTonemap}, metadata fallback {UsedFallbackMetadata}",
             session?.Id ?? "Unknown",
             session?.UserName ?? "Unknown",
             session?.DeviceName ?? "Unknown",
             request.ItemName ?? "Unknown",
             memory.FreeMiB,
-            config.MinimumFreeGpuMemoryMiB,
-            config.GpuIndex);
+            estimate.BudgetMiB,
+            inFlightBudgetMiB,
+            gpuIndex,
+            estimate.SourceWidth,
+            estimate.SourceHeight,
+            estimate.SourceBitDepth,
+            request.SourceCodec ?? "unknown",
+            estimate.OutputWidth,
+            estimate.OutputHeight,
+            estimate.OutputBitDepth,
+            request.OutputVideoCodec ?? "unknown",
+            estimate.UsesTonemap,
+            estimate.UsedFallbackMetadata));
 
         if (session == null)
         {
-            _logger.LogDebug(
+            BestEffort(() => _logger.LogDebug(
                 "No session could be correlated to the refused transcode of {ItemName}; the refusal still stands",
-                request.ItemName ?? "Unknown");
+                request.ItemName ?? "Unknown"));
             return;
         }
 
@@ -230,16 +376,16 @@ public sealed class GpuResourceGuard
             cancellationToken).ConfigureAwait(false);
     }
 
-    private void LogQueryFailure(PluginConfiguration config, GpuMemoryQueryResult? memory)
+    private void LogQueryFailure(int gpuIndex, GpuMemoryQueryResult? memory)
     {
-        if (!ShouldNotify("query-failure|" + config.GpuIndex.ToString(CultureInfo.InvariantCulture)))
+        if (!ShouldNotify("query-failure|" + gpuIndex.ToString(CultureInfo.InvariantCulture)))
         {
             return;
         }
 
         _logger.LogWarning(
             "Unable to query free VRAM for GPU {GpuIndex}; allowing playback because GPU resource guard is fail-open ({Reason})",
-            config.GpuIndex,
+            gpuIndex,
             memory?.FailureReason ?? "no result");
     }
 
@@ -259,6 +405,259 @@ public sealed class GpuResourceGuard
             '|',
             request.DeviceId ?? string.Empty,
             request.ItemId.ToString("N", CultureInfo.InvariantCulture));
+    }
+
+    private static string BuildReservationKey(int? gpuIndex, GpuTranscodeRequest request)
+    {
+        // Jellyfin's output path identifies the FFmpeg job. PlaySessionId is client supplied and
+        // can be reused across distinct jobs, so using it here could merge two real allocations
+        // and admit more memory than is available.
+        if (!string.IsNullOrWhiteSpace(request.OutputPath))
+        {
+            return string.Join(
+                '|',
+                gpuIndex?.ToString(CultureInfo.InvariantCulture) ?? "any",
+                "path",
+                request.OutputPath);
+        }
+
+        // The decorator always supplies an output path. If another caller does not, never merge
+        // identities on weaker client metadata: temporary over-reservation is safer than treating
+        // two different FFmpeg processes as one.
+        return string.Join(
+            '|',
+            gpuIndex?.ToString(CultureInfo.InvariantCulture) ?? "any",
+            "unknown",
+            Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture));
+    }
+
+    private static void BestEffort(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            // Logging and notification bookkeeping are diagnostic only. In particular, a logger
+            // implementation must not reverse a denial or strand an admitted reservation.
+        }
+    }
+
+    private int GetInFlightBudgetMiB(
+        int gpuIndex,
+        string currentReservationKey,
+        out bool currentJobAlreadyTracked)
+    {
+        lock (_reservationLock)
+        {
+            PruneExpiredReservations(_clock());
+            currentJobAlreadyTracked = _inFlightReservations.ContainsKey(currentReservationKey);
+
+            var total = _inFlightReservations
+                .Where(entry => !entry.Value.AllocationVisible
+                    && (!entry.Value.GpuIndex.HasValue || entry.Value.GpuIndex.Value == gpuIndex)
+                    && !string.Equals(entry.Key, currentReservationKey, StringComparison.Ordinal))
+                .Sum(entry => (long)entry.Value.BudgetMiB);
+
+            return (int)Math.Min(int.MaxValue, total);
+        }
+    }
+
+    private GpuAdmissionReservation AddReservation(int? gpuIndex, string key, int budgetMiB)
+    {
+        long reservationId;
+        lock (_reservationLock)
+        {
+            if (!_inFlightReservations.TryGetValue(key, out var reservation))
+            {
+                reservation = new InFlightReservation
+                {
+                    GpuIndex = gpuIndex,
+                    Id = Interlocked.Increment(ref _nextReservationId)
+                };
+                _inFlightReservations.Add(key, reservation);
+            }
+
+            reservation.BudgetMiB = Math.Max(reservation.BudgetMiB, budgetMiB);
+            reservation.ActiveHolders++;
+            reservationId = reservation.Id;
+        }
+
+        return new GpuAdmissionReservation(this, key, reservationId);
+    }
+
+    internal void CompleteReservation(string key, long reservationId, bool launched)
+    {
+        lock (_reservationLock)
+        {
+            if (!_inFlightReservations.TryGetValue(key, out var reservation)
+                || reservation.Id != reservationId)
+            {
+                return;
+            }
+
+            reservation.ActiveHolders = Math.Max(0, reservation.ActiveHolders - 1);
+            if (launched)
+            {
+                reservation.WasLaunched = true;
+                reservation.ExpiresUtc = _clock() + DefaultInFlightReservationLifetime;
+            }
+
+            if (reservation.ActiveHolders == 0 && !reservation.WasLaunched)
+            {
+                _inFlightReservations.Remove(key);
+            }
+        }
+    }
+
+    internal Task BeginProcessObservation(
+        string key,
+        long reservationId,
+        int processId,
+        GpuTranscodeRequest request)
+    {
+        if (_gpuMemoryProvider is not IGpuProcessMemoryProvider processMemoryProvider)
+        {
+            return Task.CompletedTask;
+        }
+
+        PluginConfiguration? config;
+        try
+        {
+            config = _configurationAccessor();
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            return Task.CompletedTask;
+        }
+
+        if (config == null)
+        {
+            return Task.CompletedTask;
+        }
+
+        lock (_reservationLock)
+        {
+            if (!_inFlightReservations.TryGetValue(key, out var reservation)
+                || reservation.Id != reservationId
+                || reservation.ObservationStarted)
+            {
+                return Task.CompletedTask;
+            }
+
+            reservation.ObservationStarted = true;
+        }
+
+        return ObserveProcessMemoryAsync(
+            key,
+            reservationId,
+            processId,
+            request,
+            config.GpuCheckTimeoutMilliseconds,
+            processMemoryProvider);
+    }
+
+    private async Task ObserveProcessMemoryAsync(
+        string reservationKey,
+        long reservationId,
+        int processId,
+        GpuTranscodeRequest request,
+        int timeoutMilliseconds,
+        IGpuProcessMemoryProvider processMemoryProvider)
+    {
+        try
+        {
+            var maxUsedMiB = -1;
+            string? lastFailure = null;
+            for (var sample = 0; sample < ProcessObservationSampleCount; sample++)
+            {
+                if (sample > 0)
+                {
+                    await Task.Delay(ProcessObservationInterval).ConfigureAwait(false);
+                }
+
+                var result = await processMemoryProvider.GetUsedMemoryAsync(
+                    processId,
+                    timeoutMilliseconds,
+                    CancellationToken.None).ConfigureAwait(false);
+
+                if (!result.Success)
+                {
+                    lastFailure = result.FailureReason;
+                    continue;
+                }
+
+                maxUsedMiB = Math.Max(maxUsedMiB, result.UsedMiB);
+                if (result.UsedMiB > 0)
+                {
+                    MarkAllocationVisible(reservationKey, reservationId);
+                }
+            }
+
+            if (maxUsedMiB >= 0)
+            {
+                var estimate = GpuVramEstimator.Estimate(request);
+                BestEffort(() => _logger.LogInformation(
+                    "GPU VRAM calibration for FFmpeg PID {ProcessId}: observed {ActualMiB} MiB maximum across {SampleCount} samples versus {BudgetMiB} MiB budget; shape {SourceWidth}x{SourceHeight} {SourceBitDepth}-bit {SourcePixelFormat} {SourceCodec} at {SourceFramerate} fps to {OutputWidth}x{OutputHeight} {OutputBitDepth}-bit {OutputCodec}, CUDA tonemap {UsesTonemap}",
+                    processId,
+                    maxUsedMiB,
+                    ProcessObservationSampleCount,
+                    estimate.BudgetMiB,
+                    estimate.SourceWidth,
+                    estimate.SourceHeight,
+                    estimate.SourceBitDepth,
+                    request.SourcePixelFormat ?? "unknown",
+                    request.SourceCodec ?? "unknown",
+                    request.SourceFramerate,
+                    estimate.OutputWidth,
+                    estimate.OutputHeight,
+                    estimate.OutputBitDepth,
+                    request.OutputVideoCodec ?? "unknown",
+                    estimate.UsesTonemap));
+            }
+            else
+            {
+                BestEffort(() => _logger.LogDebug(
+                    "Could not attribute GPU memory to FFmpeg PID {ProcessId}; retaining the timed reservation ({Reason})",
+                    processId,
+                    lastFailure ?? "no process-memory result"));
+            }
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            // Calibration is observational. It must never affect a process that already launched.
+            BestEffort(() => _logger.LogDebug(ex, "GPU process-memory observation failed for PID {ProcessId}", processId));
+        }
+    }
+
+    private void MarkAllocationVisible(string key, long reservationId)
+    {
+        lock (_reservationLock)
+        {
+            if (!_inFlightReservations.TryGetValue(key, out var reservation)
+                || reservation.Id != reservationId)
+            {
+                return;
+            }
+
+            reservation.AllocationVisible = true;
+        }
+    }
+
+    private void PruneExpiredReservations(DateTimeOffset now)
+    {
+        var expired = _inFlightReservations
+            .Where(entry => entry.Value.ActiveHolders == 0
+                && entry.Value.WasLaunched
+                && entry.Value.ExpiresUtc <= now)
+            .Select(entry => entry.Key)
+            .ToList();
+
+        foreach (var key in expired)
+        {
+            _inFlightReservations.Remove(key);
+        }
     }
 
     private bool ShouldNotify(string key)
@@ -295,5 +694,24 @@ public sealed class GpuResourceGuard
         {
             _lastRefusalUtc.Remove(key);
         }
+    }
+
+    private sealed class InFlightReservation
+    {
+        internal long Id { get; init; }
+
+        internal int? GpuIndex { get; init; }
+
+        internal int BudgetMiB { get; set; }
+
+        internal int ActiveHolders { get; set; }
+
+        internal bool WasLaunched { get; set; }
+
+        internal DateTimeOffset ExpiresUtc { get; set; }
+
+        internal bool ObservationStarted { get; set; }
+
+        internal bool AllocationVisible { get; set; }
     }
 }

--- a/Gpu/GpuTranscodeRequest.cs
+++ b/Gpu/GpuTranscodeRequest.cs
@@ -25,12 +25,83 @@ public sealed class GpuTranscodeRequest
     public string? CommandLineArguments { get; set; }
 
     /// <summary>
+    /// Gets or sets the source video width in pixels.
+    /// </summary>
+    public int? SourceWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source video height in pixels.
+    /// </summary>
+    public int? SourceHeight { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source video bit depth.
+    /// </summary>
+    public int? SourceBitDepth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source video codec.
+    /// </summary>
+    public string? SourceCodec { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source codec reference-frame count.
+    /// </summary>
+    public int? SourceRefFrames { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source frame rate.
+    /// </summary>
+    public float? SourceFramerate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source pixel format, for calibration logs and future profile refinement.
+    /// </summary>
+    public string? SourcePixelFormat { get; set; }
+
+    /// <summary>
+    /// Gets or sets the source dynamic-range classification, for calibration logs.
+    /// </summary>
+    public string? SourceVideoRangeType { get; set; }
+
+    /// <summary>
+    /// Gets or sets the output video width in pixels.
+    /// </summary>
+    public int? OutputWidth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the output video height in pixels.
+    /// </summary>
+    public int? OutputHeight { get; set; }
+
+    /// <summary>
+    /// Gets or sets the output video bit depth.
+    /// </summary>
+    public int? OutputBitDepth { get; set; }
+
+    /// <summary>
+    /// Gets or sets the output frame rate.
+    /// </summary>
+    public float? OutputFramerate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the output codec reference-frame count.
+    /// </summary>
+    public int? OutputRefFrames { get; set; }
+
+    /// <summary>
+    /// Gets or sets a stable path identifying duplicate starts for the same FFmpeg job.
+    /// </summary>
+    public string? OutputPath { get; set; }
+
+    /// <summary>
     /// Gets or sets the requesting device ID. The correlation key for the client message.
     /// </summary>
     public string? DeviceId { get; set; }
 
     /// <summary>
-    /// Gets or sets the play session ID, used to keep repeated attempts at one playback together.
+    /// Gets or sets the play session ID. The init and first media-segment starts share it, while
+    /// a client renegotiation receives a new one.
     /// </summary>
     public string? PlaySessionId { get; set; }
 

--- a/Gpu/GpuVramEstimate.cs
+++ b/Gpu/GpuVramEstimate.cs
@@ -1,0 +1,21 @@
+namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+
+/// <summary>
+/// A conservative, quarter-GiB budget for the video memory one FFmpeg job will allocate.
+/// </summary>
+internal readonly record struct GpuVramEstimate(
+    int BudgetMiB,
+    int SourceWidth,
+    int SourceHeight,
+    int SourceBitDepth,
+    int OutputWidth,
+    int OutputHeight,
+    int OutputBitDepth,
+    bool UsesTonemap,
+    bool UsedFallbackMetadata)
+{
+    /// <summary>
+    /// Gets the zero budget for a request that allocates no NVIDIA video memory.
+    /// </summary>
+    internal static GpuVramEstimate Zero => default;
+}

--- a/Gpu/GpuVramEstimator.cs
+++ b/Gpu/GpuVramEstimator.cs
@@ -1,0 +1,313 @@
+using System;
+using System.Linq;
+
+namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+
+/// <summary>
+/// Assigns a conservative NVIDIA video-memory requirement to one FFmpeg transcode.
+/// </summary>
+/// <remarks>
+/// The bands are calibrated against observed jobs on an RTX 4000 Ada: about 390 MiB for a small
+/// show transcode, 824 MiB for a 4K Main10 HDR transcode without tone mapping, and 1339-1496 MiB
+/// for a filter-heavier 4K job. The result deliberately has 256 MiB granularity.
+/// </remarks>
+internal static class GpuVramEstimator
+{
+    private const int DefaultWidth = 3840;
+    private const int DefaultHeight = 2160;
+    private const int DefaultBitDepth = 10;
+    private const long FullHdPixels = 1920L * 1080;
+    private const long QuadHdPixels = 2560L * 1440;
+    private const long UltraHdPixels = 3840L * 2160;
+
+    /// <summary>
+    /// Budgets VRAM for a job from Jellyfin's completed transcode description.
+    /// </summary>
+    /// <param name="request">The pending transcode.</param>
+    /// <returns>The conservative budget and normalized job shape.</returns>
+    internal static GpuVramEstimate Estimate(GpuTranscodeRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        if (!request.IsVideoRequest || GpuAdmissionPolicy.IsCopyCodec(request.OutputVideoCodec))
+        {
+            return GpuVramEstimate.Zero;
+        }
+
+        var features = NvidiaTranscodeDetector.Analyze(request.CommandLineArguments);
+        if (!features.UsesGpu)
+        {
+            return GpuVramEstimate.Zero;
+        }
+
+        var inferredSourceBitDepth = InferPixelFormatBitDepth(request.SourcePixelFormat);
+        var inferredOutputBitDepth = InferOutputBitDepth(request.CommandLineArguments);
+        var usedFallback = !IsDimension(request.SourceWidth)
+            || !IsDimension(request.SourceHeight)
+            || !IsDimension(request.OutputWidth)
+            || !IsDimension(request.OutputHeight)
+            || (!IsBitDepth(request.SourceBitDepth) && !inferredSourceBitDepth.HasValue);
+
+        var sourceWidth = ValidDimension(request.SourceWidth, DefaultWidth);
+        var sourceHeight = ValidDimension(request.SourceHeight, DefaultHeight);
+        var sourceBitDepth = ValidBitDepth(request.SourceBitDepth, inferredSourceBitDepth ?? DefaultBitDepth);
+        var outputWidth = ValidDimension(request.OutputWidth, sourceWidth);
+        var outputHeight = ValidDimension(request.OutputHeight, sourceHeight);
+        var outputBitDepth = ValidBitDepth(
+            request.OutputBitDepth,
+            inferredOutputBitDepth ?? sourceBitDepth);
+        var outputRefFrames = request.OutputRefFrames
+            ?? InferIntegerVideoOption(request.CommandLineArguments, "-refs");
+        var outputFramerate = Math.Max(
+            request.OutputFramerate ?? 0,
+            InferFrameRate(request.CommandLineArguments) ?? 0);
+
+        var largestFramePixels = Math.Max(
+            sourceWidth * (long)sourceHeight,
+            outputWidth * (long)outputHeight);
+        var largestBitDepth = Math.Max(sourceBitDepth, outputBitDepth);
+
+        var budgetMiB = BaseBudgetMiB(largestFramePixels, largestBitDepth, usedFallback);
+
+        // Tone mapping is the observed distinction between a roughly 1 GiB 4K HDR job and a
+        // roughly 1.5 GiB one. Merely being HDR does not incur this band: Jellyfin must actually
+        // have placed tonemap_cuda in the command line.
+        if (features.UsesTonemap)
+        {
+            budgetMiB += largestFramePixels > UltraHdPixels
+                ? ScaleAndRoundUp(512, largestFramePixels, UltraHdPixels)
+                : largestFramePixels > QuadHdPixels ? 512 : 256;
+        }
+
+        if (features.UsesOtherFilters)
+        {
+            budgetMiB += ScaleSurcharge(256, largestFramePixels);
+        }
+
+        if (string.Equals(request.OutputVideoCodec, "av1", StringComparison.OrdinalIgnoreCase))
+        {
+            budgetMiB += ScaleSurcharge(256, largestFramePixels);
+        }
+
+        if (request.SourceRefFrames > 8
+            || outputRefFrames > 8
+            || request.SourceFramerate > 60
+            || outputFramerate > 60)
+        {
+            budgetMiB += ScaleSurcharge(256, largestFramePixels);
+        }
+
+        budgetMiB = Math.Clamp(budgetMiB, 512, int.MaxValue);
+
+        return new GpuVramEstimate(
+            (int)budgetMiB,
+            sourceWidth,
+            sourceHeight,
+            sourceBitDepth,
+            outputWidth,
+            outputHeight,
+            outputBitDepth,
+            features.UsesTonemap,
+            usedFallback);
+    }
+
+    private static long BaseBudgetMiB(long largestFramePixels, int largestBitDepth, bool usedFallback)
+    {
+        long budgetMiB;
+        if (largestFramePixels <= FullHdPixels)
+        {
+            budgetMiB = 512;
+        }
+        else if (largestFramePixels <= QuadHdPixels)
+        {
+            budgetMiB = 768;
+        }
+        else if (largestFramePixels <= UltraHdPixels)
+        {
+            budgetMiB = largestBitDepth > 8 ? 1024 : 768;
+        }
+        else
+        {
+            var ultraHdBudgetMiB = largestBitDepth > 8 ? 1024 : 768;
+            budgetMiB = ScaleAndRoundUp(ultraHdBudgetMiB, largestFramePixels, UltraHdPixels);
+        }
+
+        // Missing fields must not silently turn an unknown job into the cheapest class, but known
+        // dimensions above 4K must still scale beyond this fallback floor.
+        return usedFallback ? Math.Max(1536, budgetMiB) : budgetMiB;
+    }
+
+    private static long ScaleAndRoundUp(int referenceMiB, long pixels, long referencePixels)
+    {
+        var scaledMiB = (decimal)referenceMiB * pixels / referencePixels;
+        if (scaledMiB >= int.MaxValue)
+        {
+            return int.MaxValue;
+        }
+
+        var wholeMiB = (long)Math.Ceiling(scaledMiB);
+        return Math.Min(int.MaxValue, ((wholeMiB + 255) / 256) * 256);
+    }
+
+    private static long ScaleSurcharge(int ultraHdMiB, long pixels)
+        => pixels > UltraHdPixels
+            ? ScaleAndRoundUp(ultraHdMiB, pixels, UltraHdPixels)
+            : ultraHdMiB;
+
+    private static int ValidDimension(int? value, int fallback)
+        => IsDimension(value) ? value!.Value : fallback;
+
+    private static bool IsDimension(int? value)
+        => value is > 0;
+
+    private static int ValidBitDepth(int? value, int fallback)
+        => IsBitDepth(value) ? value!.Value : fallback;
+
+    private static bool IsBitDepth(int? value)
+        => value is >= 8 and <= 16;
+
+    private static int? InferOutputBitDepth(string? arguments)
+    {
+        if (string.IsNullOrWhiteSpace(arguments))
+        {
+            return null;
+        }
+
+        var tokens = NvidiaTranscodeDetector.Tokenize(arguments);
+        int? inferredBitDepth = null;
+        for (var i = 0; i + 1 < tokens.Count; i++)
+        {
+            var flag = tokens[i];
+            var value = tokens[i + 1];
+            if (flag.StartsWith("-pix_fmt", StringComparison.OrdinalIgnoreCase)
+                && (flag.Length == 8 || flag[8] == ':'))
+            {
+                var pixelFormatBitDepth = InferPixelFormatBitDepth(value);
+                if (pixelFormatBitDepth.HasValue)
+                {
+                    inferredBitDepth = Math.Max(inferredBitDepth ?? 0, pixelFormatBitDepth.Value);
+                }
+            }
+
+            if (flag.StartsWith("-profile:v", StringComparison.OrdinalIgnoreCase)
+                && (flag.Length == 10 || flag[10] == ':')
+                && (value.Contains("main10", StringComparison.OrdinalIgnoreCase)
+                    || value.Contains("high10", StringComparison.OrdinalIgnoreCase)))
+            {
+                inferredBitDepth = Math.Max(inferredBitDepth ?? 0, 10);
+            }
+        }
+
+        return inferredBitDepth;
+    }
+
+    private static int? InferPixelFormatBitDepth(string? pixelFormat)
+    {
+        if (string.IsNullOrWhiteSpace(pixelFormat))
+        {
+            return null;
+        }
+
+        var normalized = pixelFormat.Trim();
+        foreach (var bitDepth in new[] { 16, 14, 12, 10, 9 }.Where(bitDepth =>
+            normalized.Contains(
+                bitDepth.ToString(System.Globalization.CultureInfo.InvariantCulture),
+                StringComparison.Ordinal)))
+        {
+            return bitDepth;
+        }
+
+        if (normalized.Equals("nv12", StringComparison.OrdinalIgnoreCase)
+            || normalized.StartsWith("yuv", StringComparison.OrdinalIgnoreCase)
+            || normalized.StartsWith("rgb", StringComparison.OrdinalIgnoreCase)
+            || normalized.StartsWith("bgr", StringComparison.OrdinalIgnoreCase))
+        {
+            return 8;
+        }
+
+        return null;
+    }
+
+    private static int? InferIntegerVideoOption(string? arguments, string option)
+    {
+        if (string.IsNullOrWhiteSpace(arguments))
+        {
+            return null;
+        }
+
+        int? largestValue = null;
+        var tokens = NvidiaTranscodeDetector.Tokenize(arguments);
+        for (var i = 0; i + 1 < tokens.Count; i++)
+        {
+            var flag = tokens[i];
+            if (!flag.StartsWith(option, StringComparison.OrdinalIgnoreCase)
+                || (flag.Length != option.Length && flag[option.Length] != ':')
+                || !int.TryParse(
+                    tokens[i + 1],
+                    System.Globalization.NumberStyles.Integer,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out var parsed)
+                || parsed < 0)
+            {
+                continue;
+            }
+
+            largestValue = Math.Max(largestValue ?? 0, parsed);
+        }
+
+        return largestValue;
+    }
+
+    private static float? InferFrameRate(string? arguments)
+    {
+        if (string.IsNullOrWhiteSpace(arguments))
+        {
+            return null;
+        }
+
+        float? largestRate = null;
+        var tokens = NvidiaTranscodeDetector.Tokenize(arguments);
+        for (var i = 0; i + 1 < tokens.Count; i++)
+        {
+            var flag = tokens[i];
+            if (!flag.StartsWith("-r", StringComparison.OrdinalIgnoreCase)
+                || (flag.Length != 2 && flag[2] != ':')
+                || !TryParseFrameRate(tokens[i + 1], out var rate))
+            {
+                continue;
+            }
+
+            largestRate = Math.Max(largestRate ?? 0, rate);
+        }
+
+        return largestRate;
+    }
+
+    private static bool TryParseFrameRate(string value, out float rate)
+    {
+        var separator = value.IndexOf('/');
+        if (separator > 0
+            && float.TryParse(
+                value.AsSpan(0, separator),
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var numerator)
+            && float.TryParse(
+                value.AsSpan(separator + 1),
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var denominator)
+            && denominator > 0)
+        {
+            rate = numerator / denominator;
+            return rate >= 0;
+        }
+
+        return float.TryParse(
+                value,
+                System.Globalization.NumberStyles.Float,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out rate)
+            && rate >= 0;
+    }
+}

--- a/Gpu/GuardedTranscodeManager.cs
+++ b/Gpu/GuardedTranscodeManager.cs
@@ -21,9 +21,9 @@ namespace Jellyfin.Plugin.TranscodeNag.Gpu;
 /// FFmpeg launches Jellyfin produces when CUDA cannot allocate.
 /// </para>
 /// <para>
-/// The refusal is an <see cref="ArgumentException"/>, which is exactly how Jellyfin itself refuses
-/// a video transcode a user lacks permission for, and which its exception middleware maps to
-/// HTTP 400 - a terminal answer rather than a retryable server error.
+/// The refusal uses Jellyfin's own <see cref="SecurityException"/>, which its exception middleware
+/// maps to HTTP 403 and logs without a stack trace. The BCL type with the same name does not match
+/// Jellyfin's middleware and must not be used here.
 /// </para>
 /// </remarks>
 public sealed class GuardedTranscodeManager : ITranscodeManager, IDisposable
@@ -57,17 +57,22 @@ public sealed class GuardedTranscodeManager : ITranscodeManager, IDisposable
         ArgumentNullException.ThrowIfNull(cancellationTokenSource);
 
         var admitted = true;
+        GpuTranscodeRequest? request = null;
+        GpuAdmissionReservation? reservation = null;
 
         try
         {
-            admitted = await _guard.IsAdmittedAsync(
-                BuildRequest(state, commandLineArguments, userId),
+            request = BuildRequest(state, outputPath, commandLineArguments, userId);
+            var attempt = await _guard.TryReserveAsync(
+                request,
                 cancellationTokenSource.Token).ConfigureAwait(false);
+            admitted = attempt.IsAdmitted;
+            reservation = attempt.Reservation;
         }
         catch (Exception ex) when (ex is not OutOfMemoryException && ex is not OperationCanceledException)
         {
             // A broken guard must never break playback.
-            _logger.LogError(ex, "GPU resource guard failed; allowing the transcode to proceed");
+            BestEffort(() => _logger.LogError(ex, "GPU resource guard failed; allowing the transcode to proceed"));
         }
 
         if (!admitted)
@@ -78,20 +83,68 @@ public sealed class GuardedTranscodeManager : ITranscodeManager, IDisposable
             // to 500 with a full stack trace. This one maps to HTTP 403 and is logged as a single
             // line, which is what a policy refusal deserves - the guard has already logged the
             // detail, and a 40-line trace per attempt made a working guard read as a crash.
-            throw new SecurityException(_guard.BuildRefusalReason());
+            reservation?.Dispose();
+
+            string refusalReason;
+            try
+            {
+                refusalReason = _guard.BuildRefusalReason(request!);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                // The denial is already final. Even configuration/log-message construction must
+                // not change Jellyfin's clean 403 into a noisy 500 or let FFmpeg launch.
+                BestEffort(() => _logger.LogError(ex, "Failed to build the GPU resource guard refusal reason"));
+                refusalReason = "Transcode Nag refused this hardware transcode: insufficient free GPU memory.";
+            }
+
+            throw new SecurityException(refusalReason);
         }
 
-        return await _inner.StartFfMpeg(
-            state,
-            outputPath,
-            commandLineArguments,
-            userId,
-            transcodingJobType,
-            cancellationTokenSource,
-            workingDirectory).ConfigureAwait(false);
+        try
+        {
+            var job = await _inner.StartFfMpeg(
+                state,
+                outputPath,
+                commandLineArguments,
+                userId,
+                transcodingJobType,
+                cancellationTokenSource,
+                workingDirectory).ConfigureAwait(false);
+            int? processId = null;
+            try
+            {
+                processId = job.Process?.Id;
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                BestEffort(() => _logger.LogDebug(ex, "Could not read the launched FFmpeg process ID"));
+            }
+
+            if (reservation != null)
+            {
+                _ = reservation.MarkLaunched(processId, request);
+            }
+            return job;
+        }
+        catch
+        {
+            // StartFfMpeg can throw after it has created and started the process (for example while
+            // waiting for its first output). We cannot prove that no allocation exists, so retain
+            // the short race-window reservation rather than letting the next job spend it.
+            if (reservation != null)
+            {
+                _ = reservation.MarkLaunched();
+            }
+            throw;
+        }
     }
 
-    private static GpuTranscodeRequest BuildRequest(StreamState state, string commandLineArguments, Guid userId)
+    private static GpuTranscodeRequest BuildRequest(
+        StreamState state,
+        string outputPath,
+        string commandLineArguments,
+        Guid userId)
     {
         var request = state.Request;
 
@@ -101,12 +154,52 @@ public sealed class GuardedTranscodeManager : ITranscodeManager, IDisposable
             IsVideoRequest = state.VideoRequest != null,
             OutputVideoCodec = state.OutputVideoCodec,
             CommandLineArguments = commandLineArguments,
+            SourceWidth = state.VideoStream?.Width,
+            SourceHeight = state.VideoStream?.Height,
+            SourceBitDepth = state.VideoStream?.BitDepth,
+            SourceCodec = state.VideoStream?.Codec,
+            SourceRefFrames = state.VideoStream?.RefFrames,
+            SourceFramerate = state.VideoStream?.ReferenceFrameRate
+                ?? state.VideoStream?.RealFrameRate
+                ?? state.VideoStream?.AverageFrameRate,
+            SourcePixelFormat = state.VideoStream?.PixelFormat,
+            SourceVideoRangeType = state.VideoStream?.VideoRangeType.ToString(),
+            // EncodingJobInfo derives these from Request; malformed or partially constructed
+            // states can have no request. Preserve fail-open behaviour by treating them as unknown.
+            OutputWidth = request == null ? null : state.OutputWidth,
+            OutputHeight = request == null ? null : state.OutputHeight,
+            OutputBitDepth = request == null ? null : state.TargetVideoBitDepth,
+            // TargetFramerate is only the requested cap and is often null. In that case the
+            // transcode retains the source rate, which still matters to surface pressure.
+            OutputFramerate = request == null
+                ? state.VideoStream?.ReferenceFrameRate
+                    ?? state.VideoStream?.RealFrameRate
+                    ?? state.VideoStream?.AverageFrameRate
+                : state.TargetFramerate
+                    ?? state.VideoStream?.ReferenceFrameRate
+                    ?? state.VideoStream?.RealFrameRate
+                    ?? state.VideoStream?.AverageFrameRate,
+            OutputRefFrames = request == null ? null : state.TargetRefFrames,
+            OutputPath = outputPath,
             DeviceId = request?.DeviceId,
             PlaySessionId = request?.PlaySessionId,
             UserId = userId,
             ItemId = request?.Id ?? Guid.Empty,
             ItemName = state.MediaSource?.Name
         };
+    }
+
+    private static void BestEffort(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            // A logger is diagnostic infrastructure. It must not change admission or fail-open
+            // semantics if a custom provider throws from ILogger.Log.
+        }
     }
 
     /// <inheritdoc />

--- a/Gpu/IGpuProcessMemoryProvider.cs
+++ b/Gpu/IGpuProcessMemoryProvider.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+
+/// <summary>
+/// Optionally attributes NVIDIA memory to a launched process for calibration and reservation
+/// reconciliation. Admission does not depend on this optional query succeeding.
+/// </summary>
+internal interface IGpuProcessMemoryProvider
+{
+    Task<GpuProcessMemoryQueryResult> GetUsedMemoryAsync(
+        int processId,
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken);
+}

--- a/Gpu/NvidiaSmiGpuMemoryProvider.cs
+++ b/Gpu/NvidiaSmiGpuMemoryProvider.cs
@@ -9,9 +9,9 @@ using Microsoft.Extensions.Logging;
 namespace Jellyfin.Plugin.TranscodeNag.Gpu;
 
 /// <summary>
-/// Reads free VRAM by running nvidia-smi with a narrow machine-readable query.
+/// Reads free and per-process VRAM by running narrow, machine-readable nvidia-smi queries.
 /// </summary>
-public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
+public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IGpuProcessMemoryProvider, IDisposable
 {
     private const string DefaultExecutable = "nvidia-smi";
 
@@ -101,6 +101,43 @@ public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
         }
     }
 
+    async Task<GpuProcessMemoryQueryResult> IGpuProcessMemoryProvider.GetUsedMemoryAsync(
+        int processId,
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken)
+    {
+        if (processId <= 0)
+        {
+            return GpuProcessMemoryQueryResult.Failed("the process ID is invalid");
+        }
+
+        try
+        {
+            await _queryLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return GpuProcessMemoryQueryResult.Failed("the process-memory query was cancelled");
+        }
+        catch (ObjectDisposedException)
+        {
+            return GpuProcessMemoryQueryResult.Failed("the plugin is shutting down");
+        }
+
+        try
+        {
+            return await RunProcessQueryAsync(processId, timeoutMilliseconds, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            return GpuProcessMemoryQueryResult.Failed("the process-memory query was cancelled");
+        }
+        finally
+        {
+            _queryLock.Release();
+        }
+    }
+
     private bool TryReadCachedFailure(int gpuIndex, out GpuMemoryQueryResult result)
     {
         lock (_cacheLock)
@@ -141,8 +178,64 @@ public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
     {
         var configuredPath = _executablePathAccessor();
         var executable = string.IsNullOrWhiteSpace(configuredPath) ? DefaultExecutable : configuredPath.Trim();
+        var startInfo = CreateStartInfo(executable);
 
-        var startInfo = new ProcessStartInfo
+        // ArgumentList avoids any shell or quoting interpretation of these values.
+        startInfo.ArgumentList.Add("--query-gpu=index,memory.free");
+        startInfo.ArgumentList.Add("--format=csv,noheader,nounits");
+
+        var command = await RunCommandAsync(
+            startInfo,
+            executable,
+            timeoutMilliseconds,
+            cancellationToken).ConfigureAwait(false);
+
+        if (!command.Success)
+        {
+            return GpuMemoryQueryResult.Failed(command.FailureReason!);
+        }
+
+        if (!NvidiaSmiOutputParser.TryGetFreeMiB(command.StandardOutput, gpuIndex, out var freeMiB))
+        {
+            return GpuMemoryQueryResult.Failed($"{executable} did not report a usable value for GPU {gpuIndex}");
+        }
+
+        return GpuMemoryQueryResult.FromFreeMiB(freeMiB);
+    }
+
+    private async Task<GpuProcessMemoryQueryResult> RunProcessQueryAsync(
+        int processId,
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken)
+    {
+        var configuredPath = _executablePathAccessor();
+        var executable = string.IsNullOrWhiteSpace(configuredPath) ? DefaultExecutable : configuredPath.Trim();
+        var startInfo = CreateStartInfo(executable);
+        startInfo.ArgumentList.Add("--query-compute-apps=pid,used_gpu_memory");
+        startInfo.ArgumentList.Add("--format=csv,noheader,nounits");
+
+        var command = await RunCommandAsync(
+            startInfo,
+            executable,
+            timeoutMilliseconds,
+            cancellationToken).ConfigureAwait(false);
+
+        if (!command.Success)
+        {
+            return GpuProcessMemoryQueryResult.Failed(command.FailureReason!);
+        }
+
+        if (!NvidiaSmiOutputParser.TryGetProcessUsedMiB(command.StandardOutput, processId, out var usedMiB))
+        {
+            return GpuProcessMemoryQueryResult.Failed(
+                $"{executable} did not report usable GPU memory for process {processId}");
+        }
+
+        return GpuProcessMemoryQueryResult.FromUsedMiB(usedMiB);
+    }
+
+    private static ProcessStartInfo CreateStartInfo(string executable)
+        => new()
         {
             FileName = executable,
             UseShellExecute = false,
@@ -151,9 +244,12 @@ public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
             RedirectStandardError = true
         };
 
-        // ArgumentList avoids any shell or quoting interpretation of these values.
-        startInfo.ArgumentList.Add("--query-gpu=index,memory.free");
-        startInfo.ArgumentList.Add("--format=csv,noheader,nounits");
+    private async Task<NvidiaSmiCommandResult> RunCommandAsync(
+        ProcessStartInfo startInfo,
+        string executable,
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken)
+    {
 
         using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeoutSource.CancelAfter(Math.Max(1, timeoutMilliseconds));
@@ -164,21 +260,21 @@ public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
         {
             if (!process.Start())
             {
-                return GpuMemoryQueryResult.Failed($"{executable} could not be started");
+                return NvidiaSmiCommandResult.Failed($"{executable} could not be started");
             }
         }
         catch (Win32Exception ex)
         {
             // Covers "not found" and "permission denied" for the executable itself.
-            return GpuMemoryQueryResult.Failed($"{executable} is not available ({ex.Message})");
+            return NvidiaSmiCommandResult.Failed($"{executable} is not available ({ex.Message})");
         }
         catch (InvalidOperationException ex)
         {
-            return GpuMemoryQueryResult.Failed($"{executable} could not be started ({ex.Message})");
+            return NvidiaSmiCommandResult.Failed($"{executable} could not be started ({ex.Message})");
         }
         catch (PlatformNotSupportedException ex)
         {
-            return GpuMemoryQueryResult.Failed($"{executable} cannot be started on this platform ({ex.Message})");
+            return NvidiaSmiCommandResult.Failed($"{executable} cannot be started on this platform ({ex.Message})");
         }
 
         // Both pipes must be drained or the child can block on a full buffer. They are started
@@ -199,16 +295,11 @@ public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
 
             if (process.ExitCode != 0)
             {
-                return GpuMemoryQueryResult.Failed(
+                return NvidiaSmiCommandResult.Failed(
                     $"{executable} exited with code {process.ExitCode}{(stderr.Length == 0 ? string.Empty : ": " + FirstLine(stderr))}");
             }
 
-            if (!NvidiaSmiOutputParser.TryGetFreeMiB(stdout, gpuIndex, out var freeMiB))
-            {
-                return GpuMemoryQueryResult.Failed($"{executable} did not report a usable value for GPU {gpuIndex}");
-            }
-
-            return GpuMemoryQueryResult.FromFreeMiB(freeMiB);
+            return NvidiaSmiCommandResult.FromOutput(stdout);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -218,16 +309,17 @@ public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
         }
         catch (OperationCanceledException)
         {
-            // A genuine timeout. This one is worth caching - it is the expensive failure.
-            return GpuMemoryQueryResult.Failed($"{executable} did not respond within {timeoutMilliseconds} ms");
+            // A genuine timeout. The free-memory caller caches this expensive failure; the
+            // optional process-calibration caller simply reports it.
+            return NvidiaSmiCommandResult.Failed($"{executable} did not respond within {timeoutMilliseconds} ms");
         }
         catch (InvalidOperationException ex)
         {
-            return GpuMemoryQueryResult.Failed($"{executable} could not be read ({ex.Message})");
+            return NvidiaSmiCommandResult.Failed($"{executable} could not be read ({ex.Message})");
         }
         catch (IOException ex)
         {
-            return GpuMemoryQueryResult.Failed($"{executable} could not be read ({ex.Message})");
+            return NvidiaSmiCommandResult.Failed($"{executable} could not be read ({ex.Message})");
         }
         finally
         {
@@ -271,11 +363,23 @@ public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
         }
         catch (NotSupportedException ex)
         {
-            _logger.LogDebug(ex, "Unable to terminate {Executable}", executable);
+            BestEffort(() => _logger.LogDebug(ex, "Unable to terminate {Executable}", executable));
         }
         catch (Win32Exception ex)
         {
-            _logger.LogDebug(ex, "Unable to terminate {Executable}", executable);
+            BestEffort(() => _logger.LogDebug(ex, "Unable to terminate {Executable}", executable));
+        }
+    }
+
+    private static void BestEffort(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            // Diagnostic logging cannot make an otherwise handled process failure escape.
         }
     }
 
@@ -295,5 +399,17 @@ public sealed class NvidiaSmiGpuMemoryProvider : IGpuMemoryProvider, IDisposable
 
         _disposed = true;
         _queryLock.Dispose();
+    }
+
+    private readonly record struct NvidiaSmiCommandResult(
+        bool Success,
+        string? StandardOutput,
+        string? FailureReason)
+    {
+        internal static NvidiaSmiCommandResult FromOutput(string output)
+            => new(true, output, null);
+
+        internal static NvidiaSmiCommandResult Failed(string reason)
+            => new(false, null, reason);
     }
 }

--- a/Gpu/NvidiaSmiOutputParser.cs
+++ b/Gpu/NvidiaSmiOutputParser.cs
@@ -54,6 +54,55 @@ internal static class NvidiaSmiOutputParser
         return false;
     }
 
+    /// <summary>
+    /// Sums the used-memory rows attributed to one process. A process can appear once per GPU.
+    /// </summary>
+    internal static bool TryGetProcessUsedMiB(string? output, int processId, out int usedMiB)
+    {
+        usedMiB = 0;
+        if (processId <= 0 || string.IsNullOrWhiteSpace(output))
+        {
+            return false;
+        }
+
+        long totalMiB = 0;
+        var found = false;
+        var rows = output
+            .Split('\n')
+            .Select(rawLine => rawLine.Trim())
+            .Where(line => line.Contains(',', StringComparison.Ordinal));
+
+        foreach (var row in rows)
+        {
+            var separator = row.IndexOf(',', StringComparison.Ordinal);
+            if (!int.TryParse(
+                    row.AsSpan(0, separator).Trim(),
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var parsedProcessId)
+                || parsedProcessId != processId)
+            {
+                continue;
+            }
+
+            if (!TryParseFreeMiB(row.AsSpan(separator + 1), out var processMiB))
+            {
+                return false;
+            }
+
+            found = true;
+            totalMiB += processMiB;
+        }
+
+        if (!found)
+        {
+            return false;
+        }
+
+        usedMiB = (int)Math.Min(int.MaxValue, totalMiB);
+        return true;
+    }
+
     private static bool TryParseFreeMiB(ReadOnlySpan<char> value, out int freeMiB)
     {
         freeMiB = 0;

--- a/Gpu/NvidiaTranscodeDetector.cs
+++ b/Gpu/NvidiaTranscodeDetector.cs
@@ -25,13 +25,30 @@ internal static class NvidiaTranscodeDetector
     /// <param name="commandLineArguments">The FFmpeg arguments Jellyfin built for this job.</param>
     /// <returns>True when the job needs NVIDIA GPU memory.</returns>
     internal static bool UsesNvidiaGpu(string? commandLineArguments)
+        => Analyze(commandLineArguments).UsesGpu;
+
+    /// <summary>
+    /// Describes which parts of an FFmpeg job allocate NVIDIA video memory.
+    /// </summary>
+    /// <param name="commandLineArguments">The FFmpeg arguments Jellyfin built for this job.</param>
+    /// <returns>The NVIDIA features present in the command line.</returns>
+    internal static NvidiaTranscodeFeatures Analyze(string? commandLineArguments)
     {
         if (string.IsNullOrWhiteSpace(commandLineArguments))
         {
-            return false;
+            return default;
         }
 
         var tokens = Tokenize(commandLineArguments);
+        var usesGpu = false;
+        var usesDecoder = false;
+        var usesEncoder = false;
+        var usesFilters = false;
+        var usesTonemap = false;
+        var usesScaling = false;
+        var usesOtherFilters = false;
+        int? gpuIndex = null;
+        var hasConflictingGpuIndices = false;
 
         for (var i = 0; i < tokens.Count; i++)
         {
@@ -53,32 +70,64 @@ internal static class NvidiaTranscodeDetector
             if ((Is(flag, "-hwaccel") || Is(flag, "-hwaccel_output_format"))
                 && (Is(value, "cuda") || Is(value, "nvdec")))
             {
-                return true;
+                usesGpu = true;
+                usesDecoder = true;
+                continue;
             }
 
             // -init_hw_device cuda=cu:0
             if (Is(flag, "-init_hw_device") && StartsWithDeviceType(value, "cuda"))
             {
-                return true;
+                usesGpu = true;
+                RecordGpuIndex(
+                    ParseInitDeviceIndex(value),
+                    ref gpuIndex,
+                    ref hasConflictingGpuIndices);
+                continue;
+            }
+
+            if (Is(flag, "-hwaccel_device") || Is(flag, "-gpu"))
+            {
+                RecordGpuIndex(
+                    ParseInteger(value),
+                    ref gpuIndex,
+                    ref hasConflictingGpuIndices);
+                continue;
             }
 
             // -codec:v:0 av1_nvenc, -c:v h264_cuvid
             if (IsVideoCodecFlag(flag)
                 && (EndsWith(value, "_nvenc") || EndsWith(value, "_cuvid")))
             {
-                return true;
+                usesGpu = true;
+                usesEncoder |= EndsWith(value, "_nvenc");
+                usesDecoder |= EndsWith(value, "_cuvid");
+                continue;
             }
 
-            // -vf "tonemap_cuda=...,scale_cuda=..." - filter graphs never contain file paths,
-            // so a substring match here cannot be tripped by a media file name.
-            if (IsFilterFlag(flag)
-                && (Contains(value, "_cuda") || Contains(value, "_npp") || Contains(value, "cuda=")))
+            // Parse filter identifiers rather than searching the whole graph. Subtitle filters
+            // embed file paths, and a path such as show_cuda.srt is not a CUDA filter.
+            if (IsFilterFlag(flag))
             {
-                return true;
+                var filterFeatures = AnalyzeFilterGraph(value);
+                usesGpu |= filterFeatures.UsesGpu;
+                usesFilters |= filterFeatures.UsesGpu;
+                usesTonemap |= filterFeatures.UsesTonemap;
+                usesScaling |= filterFeatures.UsesScaling;
+                usesOtherFilters |= filterFeatures.UsesOtherFilters;
             }
         }
 
-        return false;
+        return new NvidiaTranscodeFeatures(
+            usesGpu,
+            usesDecoder,
+            usesEncoder,
+            usesFilters,
+            usesTonemap,
+            usesScaling,
+            usesOtherFilters,
+            hasConflictingGpuIndices ? null : gpuIndex,
+            hasConflictingGpuIndices);
     }
 
     /// <summary>
@@ -136,13 +185,153 @@ internal static class NvidiaTranscodeDetector
     }
 
     private static bool IsFilterFlag(string flag)
-        => FilterFlags.Any(filterFlag => Is(flag, filterFlag));
+        => FilterFlags.Any(filterFlag =>
+            flag.StartsWith(filterFlag, StringComparison.OrdinalIgnoreCase)
+            && (flag.Length == filterFlag.Length || flag[filterFlag.Length] == ':'));
 
     private static bool StartsWithDeviceType(string value, string deviceType)
     {
         // "cuda" alone, or "cuda=cu:0".
         return Is(value, deviceType)
-            || value.StartsWith(deviceType + "=", StringComparison.OrdinalIgnoreCase);
+            || value.StartsWith(deviceType + "=", StringComparison.OrdinalIgnoreCase)
+            || value.StartsWith(deviceType + ":", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static int? ParseInitDeviceIndex(string value)
+    {
+        var colon = value.IndexOf(':');
+        if (colon < 0 || colon == value.Length - 1)
+        {
+            return null;
+        }
+
+        var device = value[(colon + 1)..];
+        var comma = device.IndexOf(',');
+        if (comma >= 0)
+        {
+            device = device[..comma];
+        }
+
+        return ParseInteger(device);
+    }
+
+    private static int? ParseInteger(string value)
+        => int.TryParse(value, System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var parsed)
+            && parsed >= 0
+                ? parsed
+                : null;
+
+    private static void RecordGpuIndex(int? candidate, ref int? selected, ref bool conflicting)
+    {
+        if (!candidate.HasValue)
+        {
+            return;
+        }
+
+        if (selected.HasValue && selected.Value != candidate.Value)
+        {
+            conflicting = true;
+            return;
+        }
+
+        selected = candidate;
+    }
+
+    private static NvidiaFilterFeatures AnalyzeFilterGraph(string graph)
+    {
+        var usesGpu = false;
+        var usesTonemap = false;
+        var usesScaling = false;
+        var usesOtherFilters = false;
+        var segmentStart = 0;
+        var escaped = false;
+        var inSingleQuotes = false;
+        var inDoubleQuotes = false;
+
+        for (var i = 0; i <= graph.Length; i++)
+        {
+            var atEnd = i == graph.Length;
+            var c = atEnd ? '\0' : graph[i];
+
+            if (!atEnd && escaped)
+            {
+                escaped = false;
+                continue;
+            }
+
+            if (!atEnd && c == '\\')
+            {
+                escaped = true;
+                continue;
+            }
+
+            if (!atEnd && c == '\'' && !inDoubleQuotes)
+            {
+                inSingleQuotes = !inSingleQuotes;
+                continue;
+            }
+
+            if (!atEnd && c == '"' && !inSingleQuotes)
+            {
+                inDoubleQuotes = !inDoubleQuotes;
+                continue;
+            }
+
+            if (!atEnd && (inSingleQuotes || inDoubleQuotes || (c != ',' && c != ';')))
+            {
+                continue;
+            }
+
+            var segment = graph[segmentStart..i].TrimStart();
+            segmentStart = i + 1;
+
+            while (segment.StartsWith("[", StringComparison.Ordinal))
+            {
+                var closingLabel = segment.IndexOf(']');
+                if (closingLabel < 0)
+                {
+                    segment = string.Empty;
+                    break;
+                }
+
+                segment = segment[(closingLabel + 1)..].TrimStart();
+            }
+
+            var nameLength = 0;
+            while (nameLength < segment.Length
+                && (char.IsLetterOrDigit(segment[nameLength]) || segment[nameLength] == '_'))
+            {
+                nameLength++;
+            }
+
+            if (nameLength == 0)
+            {
+                continue;
+            }
+
+            var name = segment[..nameLength];
+            var isCudaFilter = name.EndsWith("_cuda", StringComparison.OrdinalIgnoreCase)
+                || name.EndsWith("_npp", StringComparison.OrdinalIgnoreCase)
+                || ((Is(name, "hwupload") || Is(name, "hwmap"))
+                    && Contains(segment, "derive_device=cuda"));
+
+            if (!isCudaFilter)
+            {
+                continue;
+            }
+
+            usesGpu = true;
+            usesTonemap |= Is(name, "tonemap_cuda");
+            usesScaling |= Is(name, "scale_cuda") || Is(name, "scale_npp");
+            usesOtherFilters |= !Is(name, "tonemap_cuda")
+                && !Is(name, "scale_cuda")
+                && !Is(name, "scale_npp")
+                && !Is(name, "hwupload_cuda")
+                && !Is(name, "hwupload")
+                && !Is(name, "hwmap");
+        }
+
+        return new NvidiaFilterFeatures(usesGpu, usesTonemap, usesScaling, usesOtherFilters);
     }
 
     private static bool Is(string value, string expected)
@@ -154,3 +343,32 @@ internal static class NvidiaTranscodeDetector
     private static bool Contains(string value, string fragment)
         => value.Contains(fragment, StringComparison.OrdinalIgnoreCase);
 }
+
+/// <summary>
+/// NVIDIA-backed stages found in an FFmpeg command line.
+/// </summary>
+/// <param name="UsesGpu">Whether any NVIDIA stage is present.</param>
+/// <param name="UsesDecoder">Whether decoded frames live on the GPU.</param>
+/// <param name="UsesEncoder">Whether NVENC is used.</param>
+/// <param name="UsesFilters">Whether a CUDA/NPP filter graph is used.</param>
+/// <param name="UsesTonemap">Whether CUDA tone mapping is used.</param>
+/// <param name="UsesScaling">Whether CUDA/NPP scaling is used.</param>
+/// <param name="UsesOtherFilters">Whether additional CUDA/NPP filters need intermediate surfaces.</param>
+/// <param name="GpuIndex">The explicitly selected numeric GPU, when unambiguous.</param>
+/// <param name="HasConflictingGpuIndices">Whether the command contains contradictory GPU selectors.</param>
+internal readonly record struct NvidiaTranscodeFeatures(
+    bool UsesGpu,
+    bool UsesDecoder,
+    bool UsesEncoder,
+    bool UsesFilters,
+    bool UsesTonemap,
+    bool UsesScaling,
+    bool UsesOtherFilters,
+    int? GpuIndex,
+    bool HasConflictingGpuIndices);
+
+internal readonly record struct NvidiaFilterFeatures(
+    bool UsesGpu,
+    bool UsesTonemap,
+    bool UsesScaling,
+    bool UsesOtherFilters);

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <img src="https://img.shields.io/github/v/release/voc0der/jellyfin-transcode-nag?label=stable%20release" alt="Stable release version" />
   </a>
   <a href="https://github.com/voc0der/jellyfin-transcode-nag/tree/main/tests">
-    <img src="https://img.shields.io/badge/coverage-51%25-yellow" alt="Code coverage percentage" />
+    <img src="https://img.shields.io/badge/coverage-65%25-yellowgreen" alt="Code coverage percentage" />
   </a>
   <a href="https://github.com/voc0der/jellyfin-transcode-nag/issues">
     <img src="https://img.shields.io/github/issues/voc0der/jellyfin-transcode-nag?color=DAA520" alt="Open issues" />
@@ -47,7 +47,7 @@ A Jellyfin plugin that intelligently nags users when they're transcoding due to 
 - Lets you exclude users from all nags.
 - Includes a live session monitor in the plugin settings page.
 - Can broadcast an optional Message of the Day to users at login, with its own user exclusions and client filters.
-- Can refuse an NVIDIA hardware transcode before FFmpeg starts when free VRAM is below a threshold.
+- Can refuse an NVIDIA hardware transcode before FFmpeg starts when that job's conservative VRAM budget will not fit.
 
 ## Installation
 
@@ -87,7 +87,7 @@ Open **Dashboard** → **Plugins** → **Transcode Nag**.
 - Use **Manage Excluded Users** to opt users out of both playback and login nags.
 - Use the built-in live session monitor to see which active sessions currently match your rules.
 - Enable **Message of the Day** (off by default) to send an announcement to everyone at login. Its options stay collapsed until the toggle is on, and it has its own message, its own **Manage Excluded Users (MOTD)** list, and its own client include/exclude filters, all independent of the nag settings.
-- Enable **GPU resource guard** (off by default) to set the GPU index, minimum free VRAM, nvidia-smi timeout and path, and the message a refused client sees. `nvidia-smi` must be runnable by the Jellyfin server process.
+- Enable **GPU resource guard** (off by default) to set the fallback GPU index, nvidia-smi timeout and path, and the message a refused client sees. The guard reads current free memory immediately before launch and automatically budgets each job from its source, CUDA filters, and output instead of using a fixed free-VRAM threshold. An explicit GPU selected by FFmpeg overrides the fallback index. `nvidia-smi` must be runnable by the Jellyfin server process.
 
 ## Behavior Notes
 
@@ -97,4 +97,5 @@ Open **Dashboard** → **Plugins** → **Transcode Nag**.
 - The MOTD is sent once per session at login and is unrelated to transcode history. Sessions that were already signed in when you enabled it receive nothing until they sign in again.
 - If a user qualifies for both the MOTD and a login nag, the nag waits for the MOTD to time out first, so clients that show one message at a time still display both.
 - The GPU guard only refuses NVIDIA video transcodes. Direct Play, Direct Stream, remux, audio-only, and CPU transcodes are never refused, and playback is allowed whenever free VRAM cannot be read.
-- A refused stream returns HTTP 400 and starts no FFmpeg process. Freeing GPU memory restores playback on the next attempt, with no setting change or restart.
+- After launch, the guard samples `nvidia-smi`'s per-process memory for the FFmpeg PID. Successful samples are logged with the job shape and budget for MiB-level calibration; if container PID namespaces prevent attribution, admission still works and the temporary reservation simply expires on its timer.
+- A refused stream returns HTTP 403 and starts no FFmpeg process. Freeing GPU memory restores playback on the next attempt, with no setting change or restart.

--- a/docs/HANDOFF-dynamic-vram.md
+++ b/docs/HANDOFF-dynamic-vram.md
@@ -1,0 +1,106 @@
+# Dynamic VRAM Guard — Implementation Handoff
+
+Updated: 2026-08-28
+
+## Status
+
+The fixed `MinimumFreeGpuMemoryMiB` setting has been replaced in the current worktree by automatic,
+per-job admission. The guard reads current free VRAM immediately before launch and asks whether the
+pending FFmpeg job plus short-lived in-flight reservations fit.
+
+PR #28's Jellyfin-specific `MediaBrowser.Controller.Net.SecurityException` change is already present
+locally. A refusal is HTTP 403 and does not launch FFmpeg.
+
+## Important precision boundary
+
+`nvidia-smi` provides the current free-memory reading and launched-process usage in whole MiB. Those
+measurements are exact to the precision exposed by the driver.
+
+A future FFmpeg allocation cannot be measured before that process exists. Pre-launch admission must
+therefore use a conservative requirement derived from the completed command and stream shape. Do not
+describe that requirement as an exact future measurement. The implementation separately samples the
+launched FFmpeg PID so the model can be compared with real MiB usage and refined from evidence.
+
+## Calibration supplied for the RTX 4000 Ada
+
+| Job | Total-used delta | FFmpeg process row | Current requirement |
+| --- | ---: | ---: | ---: |
+| 1080p show forced to 720p | 329 MiB | 323 MiB | 512 MiB |
+| GoT S01E01 4K HEVC Main10 HDR, no CUDA tone map | 829 MiB | 824 MiB | 1024 MiB |
+| Gladiator 4K filter-heavy transcode | 1345 MiB in the supplied snapshot | 1339 MiB | 1536 MiB |
+
+The Gladiator workload was also reported around 1496 MiB and the smaller workload around 390 MiB at
+other points. One snapshot is not a peak measurement, which is why the admission requirements retain
+headroom. The post-launch sampler takes three process-specific readings and logs the maximum alongside
+the source/output shape and requirement.
+
+## Admission model
+
+- No budget and no GPU query for Direct Play, audio-only, stream copy/remux, CPU transcodes, or
+  non-NVIDIA hardware paths.
+- 1080p and below: 512 MiB.
+- 1440p: 768 MiB.
+- 4K 8-bit: 768 MiB.
+- 4K 10-bit: 1024 MiB.
+- CUDA tone mapping: +256 MiB through 1440p, +512 MiB at 4K.
+- AV1 output, high reference-frame pressure, frame rates above 60 fps, and additional CUDA filters
+  add conservative surface allowances.
+- Requirements above 4K scale with pixel count; they are no longer capped at 4096 MiB.
+- Missing metadata has a 1536 MiB floor, while any known larger dimensions still scale above it.
+- Pixel formats and FFmpeg output options are used to recover bit depth when Jellyfin's target fields
+  are null during a normal non-static transcode.
+
+The policy comparison is inclusive: `freeMiB >= jobRequirementMiB + inFlightMiB`.
+
+## Concurrent starts
+
+The free-memory query, decision, and reservation are serialized. This prevents two starts from both
+spending the same pre-allocation reading.
+
+- Reservation identity uses Jellyfin's server-derived output path and GPU index.
+- `PlaySessionId` is not trusted as job identity; it is client supplied and can collide.
+- A failed free-memory query remains fail-open, but that admitted job still receives a temporary
+  reservation so the next successful query cannot spend its not-yet-visible allocation.
+- A successful process-specific query for the exact FFmpeg PID releases that reservation once a
+  positive allocation is visible. Unrelated Gemma growth cannot release it.
+- If PID attribution is unavailable (including container PID namespace mismatches), the reservation
+  expires after three seconds.
+- An exception from Jellyfin's inner `StartFfMpeg` conservatively keeps the three-second reservation,
+  because Jellyfin can throw after starting the process while waiting for output.
+
+## Multi-GPU behavior
+
+The detector reads numeric GPU selectors from `-init_hw_device`, `-hwaccel_device`, and `-gpu`.
+An explicit FFmpeg selection overrides the configured fallback GPU index. Contradictory selectors are
+treated as unknown telemetry and fail open; their temporary reservation counts against every GPU.
+
+## Invariants retained
+
+- GPU telemetry failure allows playback.
+- Successful free-memory readings are never cached.
+- Caller cancellation is never cached as a GPU failure.
+- A notification or logger failure cannot reverse a decided denial.
+- A guard/metadata failure before a decision cannot break playback.
+- Client refusal messages contain no VRAM, encoder, PID, or server-path detail.
+- One playback retry burst produces one popup; a deliberate reopen after a quiet gap is announced.
+
+## Relevant files
+
+```text
+Gpu/GuardedTranscodeManager.cs       Veto point and FFmpeg PID handoff
+Gpu/GpuResourceGuard.cs              Query, decision, reservations, messages, calibration log
+Gpu/GpuAdmissionPolicy.cs            Pure comparison rules
+Gpu/GpuVramEstimator.cs              Pure conservative requirement model
+Gpu/NvidiaTranscodeDetector.cs       Token/graph parsing and selected-GPU detection
+Gpu/NvidiaSmiGpuMemoryProvider.cs    Free and per-process nvidia-smi queries
+Gpu/NvidiaSmiOutputParser.cs         Whole-MiB CSV parsing
+Configuration/configPage.html        Guard settings (no fixed free-memory knob)
+tests/Jellyfin.Plugin.TranscodeNag.Tests/
+```
+
+## Calibration follow-up
+
+Collect `GPU VRAM calibration for FFmpeg PID ...` log lines across repeated examples of each shape.
+Only narrow a requirement after repeated peak observations on the target driver/GPU/FFmpeg stack.
+Do not lower a requirement from a single startup snapshot: an underestimate recreates CUDA OOM exit
+187 and Jellyfin's retry storm, while a modest overestimate only refuses a marginal start cleanly.

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuAdmissionPolicyTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuAdmissionPolicyTests.cs
@@ -9,10 +9,9 @@ public class GpuAdmissionPolicyTests
         "-init_hw_device cuda=cu:0 -hwaccel cuda -hwaccel_output_format cuda -i \"/media/movie.mkv\" " +
         "-codec:v:0 av1_nvenc -codec:a:0 libfdk_aac";
 
-    private static PluginConfiguration EnabledConfig(int thresholdMiB = 1500) => new()
+    private static PluginConfiguration EnabledConfig() => new()
     {
         EnableGpuResourceGuard = true,
-        MinimumFreeGpuMemoryMiB = thresholdMiB,
         GpuIndex = 0
     };
 
@@ -24,7 +23,11 @@ public class GpuAdmissionPolicyTests
         Assert.False(GpuAdmissionPolicy.RequiresGpuQuery(config, requiresGpuVideoTranscode: true));
         Assert.Equal(
             GpuAdmissionOutcome.AllowedGuardDisabled,
-            GpuAdmissionPolicy.Evaluate(config, requiresGpuVideoTranscode: true, memory: null));
+            GpuAdmissionPolicy.Evaluate(
+                config,
+                requiresGpuVideoTranscode: true,
+                memory: null,
+                jobBudgetMiB: 1536));
     }
 
     [Fact]
@@ -80,7 +83,8 @@ public class GpuAdmissionPolicyTests
         var outcome = GpuAdmissionPolicy.Evaluate(
             EnabledConfig(),
             requiresGpuVideoTranscode: false,
-            memory: GpuMemoryQueryResult.FromFreeMiB(1));
+            memory: GpuMemoryQueryResult.FromFreeMiB(1),
+            jobBudgetMiB: 0);
 
         Assert.Equal(GpuAdmissionOutcome.AllowedNotGpuTranscode, outcome);
     }
@@ -89,9 +93,10 @@ public class GpuAdmissionPolicyTests
     public void Evaluate_SufficientVramAllows()
     {
         var outcome = GpuAdmissionPolicy.Evaluate(
-            EnabledConfig(1500),
+            EnabledConfig(),
             requiresGpuVideoTranscode: true,
-            memory: GpuMemoryQueryResult.FromFreeMiB(2500));
+            memory: GpuMemoryQueryResult.FromFreeMiB(1918),
+            jobBudgetMiB: 1536);
 
         Assert.Equal(GpuAdmissionOutcome.AllowedSufficientMemory, outcome);
     }
@@ -100,9 +105,10 @@ public class GpuAdmissionPolicyTests
     public void Evaluate_InsufficientVramDenies()
     {
         var outcome = GpuAdmissionPolicy.Evaluate(
-            EnabledConfig(1500),
+            EnabledConfig(),
             requiresGpuVideoTranscode: true,
-            memory: GpuMemoryQueryResult.FromFreeMiB(700));
+            memory: GpuMemoryQueryResult.FromFreeMiB(1400),
+            jobBudgetMiB: 1536);
 
         Assert.Equal(GpuAdmissionOutcome.Denied, outcome);
     }
@@ -111,9 +117,10 @@ public class GpuAdmissionPolicyTests
     public void Evaluate_ExactlyAtThresholdAllows()
     {
         var outcome = GpuAdmissionPolicy.Evaluate(
-            EnabledConfig(1500),
+            EnabledConfig(),
             requiresGpuVideoTranscode: true,
-            memory: GpuMemoryQueryResult.FromFreeMiB(1500));
+            memory: GpuMemoryQueryResult.FromFreeMiB(1536),
+            jobBudgetMiB: 1536);
 
         Assert.Equal(GpuAdmissionOutcome.AllowedSufficientMemory, outcome);
     }
@@ -124,7 +131,8 @@ public class GpuAdmissionPolicyTests
         var outcome = GpuAdmissionPolicy.Evaluate(
             EnabledConfig(),
             requiresGpuVideoTranscode: true,
-            memory: GpuMemoryQueryResult.Failed("nvidia-smi is not available"));
+            memory: GpuMemoryQueryResult.Failed("nvidia-smi is not available"),
+            jobBudgetMiB: 1536);
 
         Assert.Equal(GpuAdmissionOutcome.AllowedQueryFailed, outcome);
     }
@@ -135,7 +143,8 @@ public class GpuAdmissionPolicyTests
         var outcome = GpuAdmissionPolicy.Evaluate(
             EnabledConfig(),
             requiresGpuVideoTranscode: true,
-            memory: null);
+            memory: null,
+            jobBudgetMiB: 1536);
 
         Assert.Equal(GpuAdmissionOutcome.AllowedQueryFailed, outcome);
     }
@@ -147,7 +156,34 @@ public class GpuAdmissionPolicyTests
 
         Assert.False(config.EnableGpuResourceGuard);
         Assert.Equal(0, config.GpuIndex);
-        Assert.Equal(1500, config.MinimumFreeGpuMemoryMiB);
         Assert.Equal(1000, config.GpuCheckTimeoutMilliseconds);
+    }
+
+    [Fact]
+    public void Evaluate_InFlightBudgetPreventsTwoJobsSpendingTheSameReading()
+    {
+        var outcome = GpuAdmissionPolicy.Evaluate(
+            EnabledConfig(),
+            requiresGpuVideoTranscode: true,
+            memory: GpuMemoryQueryResult.FromFreeMiB(2000),
+            jobBudgetMiB: 1536,
+            inFlightBudgetMiB: 512);
+
+        Assert.Equal(GpuAdmissionOutcome.Denied, outcome);
+    }
+
+    [Theory]
+    [InlineData(1918, 1536)]
+    [InlineData(1089, 1024)]
+    [InlineData(573, 512)]
+    public void Evaluate_CoarseBudgetFitsObservedFreeVram(int freeMiB, int jobBudgetMiB)
+    {
+        var outcome = GpuAdmissionPolicy.Evaluate(
+            EnabledConfig(),
+            requiresGpuVideoTranscode: true,
+            memory: GpuMemoryQueryResult.FromFreeMiB(freeMiB),
+            jobBudgetMiB: jobBudgetMiB);
+
+        Assert.Equal(GpuAdmissionOutcome.AllowedSufficientMemory, outcome);
     }
 }

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
@@ -8,15 +8,15 @@ public class GpuResourceGuardTests
 {
     private const string CudaNvencArguments =
         "-init_hw_device cuda=cu:0 -filter_hw_device cu -hwaccel cuda -hwaccel_output_format cuda " +
-        "-i \"/media/movie.mkv\" -codec:v:0 av1_nvenc -codec:a:0 libfdk_aac";
+        "-i \"/media/movie.mkv\" -vf \"tonemap_cuda=format=yuv420p,scale_cuda=1920:1080\" " +
+        "-codec:v:0 h264_nvenc -codec:a:0 libfdk_aac";
 
     private static readonly Guid AliceId = Guid.Parse("11111111-1111-1111-1111-111111111111");
     private static readonly Guid MovieTwoId = Guid.Parse("22222222-2222-2222-2222-222222222222");
 
-    private static PluginConfiguration EnabledConfig(int thresholdMiB = 1500) => new()
+    private static PluginConfiguration EnabledConfig() => new()
     {
         EnableGpuResourceGuard = true,
-        MinimumFreeGpuMemoryMiB = thresholdMiB,
         GpuIndex = 0,
         GpuCheckTimeoutMilliseconds = 1000
     };
@@ -56,14 +56,43 @@ public class GpuResourceGuardTests
         return new GpuTranscodeRequest
         {
             IsVideoRequest = true,
-            OutputVideoCodec = "av1",
+            OutputVideoCodec = "h264",
             CommandLineArguments = CudaNvencArguments,
+            SourceWidth = 3840,
+            SourceHeight = 2160,
+            SourceBitDepth = 10,
+            SourceCodec = "hevc",
+            SourceRefFrames = 4,
+            SourceVideoRangeType = "HDR10",
+            OutputWidth = 1920,
+            OutputHeight = 1080,
+            OutputBitDepth = 8,
+            OutputFramerate = 24,
+            OutputRefFrames = 4,
             DeviceId = deviceId,
             PlaySessionId = playSessionId,
             UserId = AliceId,
             ItemId = MovieTwoId,
             ItemName = "Movie Two"
         };
+    }
+
+    private static GpuTranscodeRequest SmallHardwareTranscodeRequest(
+        string deviceId = "device-2",
+        string playSessionId = "play-2")
+    {
+        var request = HardwareTranscodeRequest(deviceId, playSessionId);
+        request.CommandLineArguments =
+            "-hwaccel cuda -hwaccel_output_format cuda -i source.mkv " +
+            "-codec:v:0 h264_nvenc output.m3u8";
+        request.SourceWidth = 1920;
+        request.SourceHeight = 1080;
+        request.SourceBitDepth = 8;
+        request.SourceCodec = "h264";
+        request.SourceVideoRangeType = "SDR";
+        request.OutputWidth = 1920;
+        request.OutputHeight = 1080;
+        return request;
     }
 
     [Fact]
@@ -115,7 +144,7 @@ public class GpuResourceGuardTests
         var provider = FakeGpuMemoryProvider.WithFreeMiB(2500);
         var messages = new RecordingClientMessageService();
         messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
-        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+        var guard = CreateGuard(EnabledConfig(), provider, messages);
 
         Assert.True(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
         Assert.Equal(1, provider.QueryCount);
@@ -131,7 +160,7 @@ public class GpuResourceGuardTests
         var session = TestSessions.Create("session-2", "device-2", AliceId);
         messages.AddSession(session);
 
-        var config = EnabledConfig(1500);
+        var config = EnabledConfig();
         var guard = CreateGuard(config, provider, messages);
 
         Assert.False(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
@@ -148,7 +177,7 @@ public class GpuResourceGuardTests
         var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
         var messages = new RecordingClientMessageService();
         messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
-        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+        var guard = CreateGuard(EnabledConfig(), provider, messages);
 
         await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None);
 
@@ -166,7 +195,7 @@ public class GpuResourceGuardTests
         var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
         var messages = new RecordingClientMessageService();
         messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
-        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+        var guard = CreateGuard(EnabledConfig(), provider, messages);
 
         // Jellyfin retries the same segment several times within a second or two.
         for (var attempt = 0; attempt < 5; attempt++)
@@ -189,7 +218,7 @@ public class GpuResourceGuardTests
         messages.AddSession(sessionOne);
         messages.AddSession(sessionTwo);
 
-        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+        var guard = CreateGuard(EnabledConfig(), provider, messages);
 
         await guard.IsAdmittedAsync(HardwareTranscodeRequest("device-1", "play-1"), CancellationToken.None);
         await guard.IsAdmittedAsync(HardwareTranscodeRequest("device-2", "play-2"), CancellationToken.None);
@@ -205,7 +234,7 @@ public class GpuResourceGuardTests
         var provider = FakeGpuMemoryProvider.Failing("nvidia-smi is not available");
         var messages = new RecordingClientMessageService();
         messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
-        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+        var guard = CreateGuard(EnabledConfig(), provider, messages);
 
         Assert.True(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
         Assert.Empty(messages.SentMessages);
@@ -216,13 +245,44 @@ public class GpuResourceGuardTests
     {
         var provider = FakeGpuMemoryProvider.Failing("nvidia-smi did not report a usable value for GPU 3");
         var messages = new RecordingClientMessageService();
-        var config = EnabledConfig(1500);
+        var config = EnabledConfig();
         config.GpuIndex = 3;
         var guard = CreateGuard(config, provider, messages);
+        var request = HardwareTranscodeRequest();
+        request.CommandLineArguments =
+            "-hwaccel cuda -hwaccel_output_format cuda -i source.mkv " +
+            "-codec:v:0 h264_nvenc output.m3u8";
 
-        Assert.True(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
+        Assert.True(await guard.IsAdmittedAsync(request, CancellationToken.None));
         Assert.Equal(3, provider.LastGpuIndex);
         Assert.Empty(messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_QueriesTheGpuSelectedByFfmpeg()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(2500);
+        var config = EnabledConfig();
+        config.GpuIndex = 0;
+        var guard = CreateGuard(config, provider, new RecordingClientMessageService());
+        var request = HardwareTranscodeRequest();
+        request.CommandLineArguments = request.CommandLineArguments!.Replace("cuda=cu:0", "cuda=cu:2", StringComparison.Ordinal);
+
+        Assert.True(await guard.IsAdmittedAsync(request, CancellationToken.None));
+        Assert.Equal(2, provider.LastGpuIndex);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_ConflictingGpuSelectorsFailOpenWithoutQueryingAnArbitraryDevice()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(10);
+        var guard = CreateGuard(EnabledConfig(), provider, new RecordingClientMessageService());
+        var request = HardwareTranscodeRequest();
+        request.CommandLineArguments = request.CommandLineArguments!
+            .Replace("-hwaccel cuda", "-hwaccel cuda -hwaccel_device 1", StringComparison.Ordinal);
+
+        Assert.True(await guard.IsAdmittedAsync(request, CancellationToken.None));
+        Assert.Equal(0, provider.QueryCount);
     }
 
     [Fact]
@@ -230,7 +290,7 @@ public class GpuResourceGuardTests
     {
         var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
         var messages = new RecordingClientMessageService();
-        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+        var guard = CreateGuard(EnabledConfig(), provider, messages);
 
         // No session registered for this device: the popup cannot be delivered, the refusal stands.
         Assert.False(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
@@ -244,7 +304,7 @@ public class GpuResourceGuardTests
         var messages = new RecordingClientMessageService();
         messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
 
-        var config = EnabledConfig(1500);
+        var config = EnabledConfig();
         config.GpuGuardDeniedHeader = string.Empty;
         config.GpuGuardDeniedMessage = "   ";
 
@@ -267,7 +327,7 @@ public class GpuResourceGuardTests
         // jellyfin-web falls back with setTimeout(..., 100) per hop, so a real burst from one
         // press of play is a few hundred milliseconds end to end.
         var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
-        var guard = CreateGuard(EnabledConfig(1500), provider, messages, () => now);
+        var guard = CreateGuard(EnabledConfig(), provider, messages, () => now);
 
         foreach (var (playSessionId, afterMs) in new[] { ("play-2", 0), ("play-3", 250), ("play-4", 400) })
         {
@@ -289,7 +349,7 @@ public class GpuResourceGuardTests
         messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
 
         var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
-        var guard = CreateGuard(EnabledConfig(1500), provider, messages, () => now);
+        var guard = CreateGuard(EnabledConfig(), provider, messages, () => now);
 
         for (var hop = 0; hop < 4; hop++)
         {
@@ -312,7 +372,7 @@ public class GpuResourceGuardTests
         messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
 
         var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
-        var guard = CreateGuard(EnabledConfig(1500), provider, messages, () => now);
+        var guard = CreateGuard(EnabledConfig(), provider, messages, () => now);
 
         for (var attempt = 0; attempt < 9; attempt++)
         {
@@ -333,7 +393,7 @@ public class GpuResourceGuardTests
         messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
 
         var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
-        var guard = CreateGuard(EnabledConfig(1500), provider, messages, () => now);
+        var guard = CreateGuard(EnabledConfig(), provider, messages, () => now);
 
         // Press play: one popup, and the client's two renegotiations stay quiet.
         foreach (var afterMs in new[] { 0, 250, 400 })
@@ -355,7 +415,7 @@ public class GpuResourceGuardTests
         var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
         var messages = new RecordingClientMessageService();
         messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
-        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+        var guard = CreateGuard(EnabledConfig(), provider, messages);
 
         var firstItem = HardwareTranscodeRequest("device-2", "play-2");
         var secondItem = HardwareTranscodeRequest("device-2", "play-3");
@@ -380,7 +440,7 @@ public class GpuResourceGuardTests
             provider,
             messages,
             NullLogger<GpuResourceGuard>.Instance,
-            () => EnabledConfig(1500));
+            () => EnabledConfig());
 
         Assert.False(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
     }
@@ -394,7 +454,7 @@ public class GpuResourceGuardTests
         var messages = new RecordingClientMessageService();
         messages.AddSession(TestSessions.Create("session-1", "device-1", AliceId));
         messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
-        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+        var guard = CreateGuard(EnabledConfig(), provider, messages);
 
         var first = await guard.IsAdmittedAsync(HardwareTranscodeRequest("device-1", "play-1"), CancellationToken.None);
         var second = await guard.IsAdmittedAsync(HardwareTranscodeRequest("device-2", "play-2"), CancellationToken.None);
@@ -405,21 +465,254 @@ public class GpuResourceGuardTests
     }
 
     [Fact]
-    public async Task IsAdmittedAsync_ConcurrentAdmissionsEachQueryTheGpu()
+    public async Task TryReserveAsync_ConcurrentAdmissionsCannotSpendTheSameFreeMemory()
     {
-        // The gate holds every admission inside its query until all four are in flight, so this
-        // is real overlap rather than four calls completing as Task.WhenAll enumerates them.
-        var provider = new GatedGpuMemoryProvider(4, 2500, 2500, 700, 700);
+        // Both queries see the same pre-allocation reading. The first admission's job budget
+        // is reserved before the second decision, so only one can launch.
+        var provider = new SequencedGpuMemoryProvider(2000, 2000);
         var messages = new RecordingClientMessageService();
-        var guard = CreateGuard(EnabledConfig(1500), provider, messages);
+        var guard = CreateGuard(EnabledConfig(), provider, messages);
+        var firstRequest = HardwareTranscodeRequest("device-1", "play-1");
+        firstRequest.OutputPath = "/transcodes/one.m3u8";
+        var secondRequest = HardwareTranscodeRequest("device-2", "play-2");
+        secondRequest.OutputPath = "/transcodes/two.m3u8";
 
-        var results = await Task.WhenAll(Enumerable.Range(0, 4)
-            .Select(index => guard.IsAdmittedAsync(
-                HardwareTranscodeRequest("device-" + index, "play-" + index),
-                CancellationToken.None)));
+        var first = await guard.TryReserveAsync(firstRequest, CancellationToken.None);
+        var second = await guard.TryReserveAsync(secondRequest, CancellationToken.None);
 
-        Assert.Equal(4, provider.QueryCount);
-        Assert.Equal(2, results.Count(admitted => admitted));
+        Assert.True(first.IsAdmitted);
+        Assert.NotNull(first.Reservation);
+        Assert.False(second.IsAdmitted);
+        Assert.Equal(2, provider.QueryCount);
+        first.Reservation.Dispose();
+    }
+
+    [Fact]
+    public async Task TryReserveAsync_SerializesAnActuallyOverlappingReadAndReservation()
+    {
+        var provider = new BlockingFirstGpuMemoryProvider(2000);
+        var guard = CreateGuard(EnabledConfig(), provider, new RecordingClientMessageService());
+        var firstRequest = HardwareTranscodeRequest("device-1", "play-1");
+        firstRequest.OutputPath = "/transcodes/one.m3u8";
+        var secondRequest = HardwareTranscodeRequest("device-2", "play-2");
+        secondRequest.OutputPath = "/transcodes/two.m3u8";
+
+        var firstTask = guard.TryReserveAsync(firstRequest, CancellationToken.None);
+        await provider.FirstQueryStarted;
+        var secondTask = guard.TryReserveAsync(secondRequest, CancellationToken.None);
+
+        // Async methods run synchronously to their first incomplete await. The second call has
+        // reached the occupied admission gate, so it cannot have queried yet.
+        Assert.Equal(1, provider.QueryCount);
+
+        provider.ReleaseFirstQuery();
+        var first = await firstTask;
+        var second = await secondTask;
+
+        Assert.True(first.IsAdmitted);
+        Assert.False(second.IsAdmitted);
+        Assert.Equal(2, provider.QueryCount);
+        first.Reservation!.Dispose();
+    }
+
+    [Fact]
+    public async Task TryReserveAsync_QueryFailureLaunchIsStillReservedForTheNextAdmission()
+    {
+        // Fail open for this request, but do not let a successful query immediately afterwards
+        // spend memory that the just-launched FFmpeg process has not exposed to nvidia-smi yet.
+        var provider = new SequencedGpuMemoryProvider(
+            GpuMemoryQueryResult.Failed("temporary failure"),
+            GpuMemoryQueryResult.FromFreeMiB(600));
+        var guard = CreateGuard(EnabledConfig(), provider, new RecordingClientMessageService());
+        var firstRequest = SmallHardwareTranscodeRequest("device-1", "play-1");
+        firstRequest.OutputPath = "/transcodes/one.m3u8";
+        var secondRequest = SmallHardwareTranscodeRequest("device-2", "play-2");
+        secondRequest.OutputPath = "/transcodes/two.m3u8";
+
+        var first = await guard.TryReserveAsync(firstRequest, CancellationToken.None);
+        var second = await guard.TryReserveAsync(secondRequest, CancellationToken.None);
+
+        Assert.True(first.IsAdmitted);
+        Assert.NotNull(first.Reservation);
+        Assert.False(second.IsAdmitted);
+        first.Reservation.Dispose();
+    }
+
+    [Fact]
+    public async Task TryReserveAsync_LaunchedBudgetExpiresAfterTheRaceWindow()
+    {
+        // A free-memory drop cannot prove which process allocated it: Gemma may be growing beside
+        // Jellyfin. Keep the reservation for the full race window, then trust fresh readings.
+        var provider = new SequencedGpuMemoryProvider(600, 600, 600);
+        var messages = new RecordingClientMessageService();
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var guard = CreateGuard(EnabledConfig(), provider, messages, () => now);
+        var firstRequest = SmallHardwareTranscodeRequest("device-1", "play-1");
+        var secondRequest = SmallHardwareTranscodeRequest("device-2", "play-2");
+        var thirdRequest = SmallHardwareTranscodeRequest("device-3", "play-3");
+
+        var first = await guard.TryReserveAsync(firstRequest, CancellationToken.None);
+        Assert.NotNull(first.Reservation);
+        await first.Reservation.MarkLaunched();
+
+        now = now.AddSeconds(2);
+        var second = await guard.TryReserveAsync(secondRequest, CancellationToken.None);
+        now = now.AddSeconds(2);
+        var third = await guard.TryReserveAsync(thirdRequest, CancellationToken.None);
+
+        Assert.False(second.IsAdmitted);
+        Assert.True(third.IsAdmitted);
+        Assert.NotNull(third.Reservation);
+        third.Reservation.Dispose();
+    }
+
+    [Fact]
+    public async Task TryReserveAsync_ProcessSpecificAllocationReleasesOnlyItsOwnReservationEarly()
+    {
+        // The first free reading is before launch. The second already includes the observed
+        // 323-MiB FFmpeg allocation, so its temporary budget must no longer be subtracted too.
+        var provider = new ObservingGpuMemoryProvider(processUsedMiB: 323, 1112, 600);
+        var guard = CreateGuard(EnabledConfig(), provider, new RecordingClientMessageService());
+        var firstRequest = SmallHardwareTranscodeRequest("device-1", "play-1");
+        firstRequest.OutputPath = "/transcodes/one.m3u8";
+        var secondRequest = SmallHardwareTranscodeRequest("device-2", "play-2");
+        secondRequest.OutputPath = "/transcodes/two.m3u8";
+
+        var first = await guard.TryReserveAsync(firstRequest, CancellationToken.None);
+        await first.Reservation!.MarkLaunched(Environment.ProcessId, firstRequest);
+
+        var second = await guard.TryReserveAsync(secondRequest, CancellationToken.None);
+
+        Assert.True(second.IsAdmitted);
+        second.Reservation!.Dispose();
+    }
+
+    [Fact]
+    public async Task TryReserveAsync_VisibleOutputJobAllowsItsDuplicateWithoutBudgetingANewProcess()
+    {
+        var provider = new ObservingGpuMemoryProvider(processUsedMiB: 323, 600, 0);
+        var guard = CreateGuard(EnabledConfig(), provider, new RecordingClientMessageService());
+        var request = SmallHardwareTranscodeRequest("device-1", "play-1");
+        request.OutputPath = "/transcodes/one.m3u8";
+
+        var first = await guard.TryReserveAsync(request, CancellationToken.None);
+        await first.Reservation!.MarkLaunched(Environment.ProcessId, request);
+        var duplicate = await guard.TryReserveAsync(request, CancellationToken.None);
+
+        Assert.True(duplicate.IsAdmitted);
+        Assert.NotNull(duplicate.Reservation);
+        duplicate.Reservation.Dispose();
+    }
+
+    [Fact]
+    public async Task TryReserveAsync_StaleProcessObservationCannotReleaseAReusedPathReservation()
+    {
+        var provider = new DelayedObservingGpuMemoryProvider(600, 600, 600);
+        var now = new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var guard = CreateGuard(
+            EnabledConfig(),
+            provider,
+            new RecordingClientMessageService(),
+            () => now);
+        var oldRequest = SmallHardwareTranscodeRequest("device-1", "play-1");
+        oldRequest.OutputPath = "/transcodes/reused.m3u8";
+
+        var oldAttempt = await guard.TryReserveAsync(oldRequest, CancellationToken.None);
+        var oldObservation = oldAttempt.Reservation!.MarkLaunched(Environment.ProcessId, oldRequest);
+        await provider.ProcessQueryStarted;
+
+        // Expire and recreate the same path while the old PID query is still pending.
+        now = now.AddSeconds(4);
+        var replacement = await guard.TryReserveAsync(oldRequest, CancellationToken.None);
+        Assert.True(replacement.IsAdmitted);
+
+        provider.ReleaseProcessQuery();
+        await oldObservation;
+
+        var otherRequest = SmallHardwareTranscodeRequest("device-2", "play-2");
+        otherRequest.OutputPath = "/transcodes/other.m3u8";
+        var other = await guard.TryReserveAsync(otherRequest, CancellationToken.None);
+
+        Assert.False(other.IsAdmitted);
+        replacement.Reservation!.Dispose();
+    }
+
+    [Fact]
+    public async Task TryReserveAsync_DuplicateStartForOneOutputPathUsesOneBudget()
+    {
+        // Jellyfin can call StartFfMpeg more than once for one playlist. The server-derived output
+        // path identifies that one FFmpeg allocation even if client metadata changes.
+        var provider = new SequencedGpuMemoryProvider(600, 0);
+        var messages = new RecordingClientMessageService();
+        var guard = CreateGuard(EnabledConfig(), provider, messages);
+        var initSegment = SmallHardwareTranscodeRequest("device-1", "play-1");
+        initSegment.OutputPath = "/transcodes/session/main.m3u8";
+        var mediaSegment = SmallHardwareTranscodeRequest("device-1", "client-reused-a-different-id");
+        mediaSegment.OutputPath = "/transcodes/session/main.m3u8";
+
+        var first = await guard.TryReserveAsync(initSegment, CancellationToken.None);
+        var second = await guard.TryReserveAsync(mediaSegment, CancellationToken.None);
+
+        Assert.True(first.IsAdmitted);
+        Assert.True(second.IsAdmitted);
+        first.Reservation!.Dispose();
+        second.Reservation!.Dispose();
+    }
+
+    [Fact]
+    public async Task TryReserveAsync_SamePlaySessionCannotMergeDistinctOutputJobs()
+    {
+        var provider = new SequencedGpuMemoryProvider(600, 600);
+        var guard = CreateGuard(EnabledConfig(), provider, new RecordingClientMessageService());
+        var firstRequest = SmallHardwareTranscodeRequest("device-1", "client-chosen-id");
+        firstRequest.OutputPath = "/transcodes/one.m3u8";
+        var secondRequest = SmallHardwareTranscodeRequest("device-1", "client-chosen-id");
+        secondRequest.OutputPath = "/transcodes/two.m3u8";
+
+        var first = await guard.TryReserveAsync(firstRequest, CancellationToken.None);
+        var second = await guard.TryReserveAsync(secondRequest, CancellationToken.None);
+
+        Assert.True(first.IsAdmitted);
+        Assert.False(second.IsAdmitted);
+        first.Reservation!.Dispose();
+    }
+
+    [Fact]
+    public async Task TryReserveAsync_ThrowingLoggerCannotLoseAnAllowedReservation()
+    {
+        var provider = new SequencedGpuMemoryProvider(600, 600);
+        var guard = new GpuResourceGuard(
+            provider,
+            new RecordingClientMessageService(),
+            new ThrowingLogger<GpuResourceGuard>(),
+            () => EnabledConfig());
+        var firstRequest = SmallHardwareTranscodeRequest("device-1", "play-1");
+        firstRequest.OutputPath = "/transcodes/one.m3u8";
+        var secondRequest = SmallHardwareTranscodeRequest("device-2", "play-2");
+        secondRequest.OutputPath = "/transcodes/two.m3u8";
+
+        var first = await guard.TryReserveAsync(firstRequest, CancellationToken.None);
+        var second = await guard.TryReserveAsync(secondRequest, CancellationToken.None);
+
+        Assert.True(first.IsAdmitted);
+        Assert.NotNull(first.Reservation);
+        Assert.False(second.IsAdmitted);
+        first.Reservation.Dispose();
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_ThrowingLoggerCannotReverseADenial()
+    {
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+        var guard = new GpuResourceGuard(
+            FakeGpuMemoryProvider.WithFreeMiB(10),
+            messages,
+            new ThrowingLogger<GpuResourceGuard>(),
+            () => EnabledConfig());
+
+        Assert.False(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
+        Assert.Single(messages.SentMessages);
     }
 
     [Fact]

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuVramEstimatorTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuVramEstimatorTests.cs
@@ -1,0 +1,247 @@
+using Jellyfin.Plugin.TranscodeNag.Gpu;
+
+namespace Jellyfin.Plugin.TranscodeNag.Tests;
+
+public class GpuVramEstimatorTests
+{
+    private const string NvencArguments =
+        "-hwaccel cuda -hwaccel_output_format cuda -i source.mkv -codec:v:0 h264_nvenc output.m3u8";
+
+    private const string TonemapArguments =
+        "-hwaccel cuda -hwaccel_output_format cuda -i source.mkv " +
+        "-vf \"tonemap_cuda=format=yuv420p,scale_cuda=1920:1080\" -codec:v:0 h264_nvenc output.m3u8";
+
+    private static GpuTranscodeRequest VideoRequest() => new()
+    {
+        IsVideoRequest = true,
+        OutputVideoCodec = "h264",
+        CommandLineArguments = NvencArguments,
+        SourceWidth = 1920,
+        SourceHeight = 1080,
+        SourceBitDepth = 8,
+        SourceCodec = "h264",
+        SourceRefFrames = 4,
+        SourceFramerate = 24,
+        SourcePixelFormat = "yuv420p",
+        OutputWidth = 1920,
+        OutputHeight = 1080,
+        OutputBitDepth = 8,
+        OutputFramerate = 24,
+        OutputRefFrames = 4
+    };
+
+    [Fact]
+    public void Estimate_Small1080pJobUsesHalfGiBBudget()
+    {
+        var estimate = GpuVramEstimator.Estimate(VideoRequest());
+
+        Assert.Equal(512, estimate.BudgetMiB);
+        Assert.False(estimate.UsedFallbackMetadata);
+    }
+
+    [Fact]
+    public void Estimate_4kHdrTonemapUsesOneAndAHalfGiBBudget()
+    {
+        var request = VideoRequest();
+        request.CommandLineArguments = TonemapArguments;
+        request.SourceWidth = 3840;
+        request.SourceHeight = 2160;
+        request.SourceBitDepth = 10;
+        request.SourceCodec = "hevc";
+        request.SourceVideoRangeType = "HDR10";
+        request.OutputWidth = 3840;
+        request.OutputHeight = 2160;
+
+        var estimate = GpuVramEstimator.Estimate(request);
+
+        Assert.Equal(1536, estimate.BudgetMiB);
+        Assert.True(estimate.UsesTonemap);
+    }
+
+    [Fact]
+    public void Estimate_4k10BitWithoutTonemapUsesOneGiBBudget()
+    {
+        var request = VideoRequest();
+        request.SourceWidth = 3840;
+        request.SourceHeight = 2160;
+        request.SourceBitDepth = 10;
+        request.SourceCodec = "hevc";
+        request.SourceVideoRangeType = "HDR10";
+        request.OutputWidth = 3840;
+        request.OutputHeight = 2160;
+
+        var estimate = GpuVramEstimator.Estimate(request);
+
+        Assert.Equal(1024, estimate.BudgetMiB);
+        Assert.False(estimate.UsesTonemap);
+    }
+
+    [Fact]
+    public void Estimate_4kTo1080pScaleCostsMoreThanNative1080p()
+    {
+        var native1080p = VideoRequest();
+        var downscale4k = VideoRequest();
+        downscale4k.CommandLineArguments =
+            "-hwaccel cuda -hwaccel_output_format cuda -i source.mkv " +
+            "-vf scale_cuda=1920:1080 -codec:v:0 h264_nvenc output.m3u8";
+        downscale4k.SourceWidth = 3840;
+        downscale4k.SourceHeight = 2160;
+
+        var nativeEstimate = GpuVramEstimator.Estimate(native1080p);
+        var downscaleEstimate = GpuVramEstimator.Estimate(downscale4k);
+
+        Assert.Equal(512, nativeEstimate.BudgetMiB);
+        Assert.Equal(768, downscaleEstimate.BudgetMiB);
+    }
+
+    [Fact]
+    public void Estimate_AudioOnlyUsesNoGpuBudget()
+    {
+        var request = VideoRequest();
+        request.IsVideoRequest = false;
+        request.OutputVideoCodec = null;
+
+        Assert.Equal(0, GpuVramEstimator.Estimate(request).BudgetMiB);
+    }
+
+    [Fact]
+    public void Estimate_RemuxUsesNoGpuBudget()
+    {
+        var request = VideoRequest();
+        request.OutputVideoCodec = "copy";
+
+        Assert.Equal(0, GpuVramEstimator.Estimate(request).BudgetMiB);
+    }
+
+    [Fact]
+    public void Estimate_MissingMetadataFallsBackConservatively()
+    {
+        var request = new GpuTranscodeRequest
+        {
+            IsVideoRequest = true,
+            OutputVideoCodec = "h264",
+            CommandLineArguments = NvencArguments
+        };
+
+        var estimate = GpuVramEstimator.Estimate(request);
+
+        Assert.True(estimate.BudgetMiB >= 1024);
+        Assert.True(estimate.UsedFallbackMetadata);
+    }
+
+    [Fact]
+    public void Estimate_8k10BitScalesBeyondTheOld4GiBCap()
+    {
+        var request = VideoRequest();
+        request.SourceWidth = 7680;
+        request.SourceHeight = 4320;
+        request.SourceBitDepth = 10;
+        request.OutputWidth = 7680;
+        request.OutputHeight = 4320;
+        request.OutputBitDepth = 10;
+
+        Assert.Equal(4096, GpuVramEstimator.Estimate(request).BudgetMiB);
+
+        request.CommandLineArguments = TonemapArguments;
+        Assert.Equal(6144, GpuVramEstimator.Estimate(request).BudgetMiB);
+    }
+
+    [Fact]
+    public void Estimate_8kSourceStillScalesWhenOutputMetadataIsMissing()
+    {
+        var request = VideoRequest();
+        request.SourceWidth = 7680;
+        request.SourceHeight = 4320;
+        request.SourceBitDepth = 10;
+        request.OutputWidth = null;
+        request.OutputHeight = null;
+
+        var estimate = GpuVramEstimator.Estimate(request);
+
+        Assert.Equal(4096, estimate.BudgetMiB);
+        Assert.True(estimate.UsedFallbackMetadata);
+    }
+
+    [Fact]
+    public void Estimate_HighSourceFramerateIsCountedWhenNoTargetCapExists()
+    {
+        var request = VideoRequest();
+        request.SourceFramerate = 120;
+        request.OutputFramerate = null;
+
+        Assert.Equal(768, GpuVramEstimator.Estimate(request).BudgetMiB);
+    }
+
+    [Fact]
+    public void Estimate_InfersHighOutputReferencePressureFromFfmpegArguments()
+    {
+        var request = VideoRequest();
+        request.OutputRefFrames = null;
+        request.CommandLineArguments =
+            "-hwaccel cuda -i source.mkv -codec:v:0 h264_nvenc -refs:v:0 12 output.m3u8";
+
+        Assert.Equal(768, GpuVramEstimator.Estimate(request).BudgetMiB);
+    }
+
+    [Fact]
+    public void Estimate_InfersHighOutputFramerateFromFfmpegArguments()
+    {
+        var request = VideoRequest();
+        request.OutputFramerate = 24;
+        request.CommandLineArguments =
+            "-hwaccel cuda -i source.mkv -codec:v:0 h264_nvenc -r:v:0 120/1 output.m3u8";
+
+        Assert.Equal(768, GpuVramEstimator.Estimate(request).BudgetMiB);
+    }
+
+    [Fact]
+    public void Estimate_InfersTenBitOutputFromTheFfmpegPixelFormat()
+    {
+        var request = VideoRequest();
+        request.SourceWidth = 3840;
+        request.SourceHeight = 2160;
+        request.SourceBitDepth = 8;
+        request.OutputWidth = 3840;
+        request.OutputHeight = 2160;
+        request.OutputBitDepth = null;
+        request.CommandLineArguments =
+            "-hwaccel cuda -i source.mkv -pix_fmt p010le -codec:v:0 hevc_nvenc output.m3u8";
+
+        Assert.Equal(1024, GpuVramEstimator.Estimate(request).BudgetMiB);
+    }
+
+    [Fact]
+    public void Estimate_AccountsForAdditionalCudaFilterSurfaces()
+    {
+        var request = VideoRequest();
+        request.CommandLineArguments =
+            "-hwaccel cuda -i source.mkv -vf \"hwupload_cuda,overlay_cuda\" " +
+            "-codec:v:0 h264_nvenc output.m3u8";
+
+        Assert.Equal(768, GpuVramEstimator.Estimate(request).BudgetMiB);
+    }
+
+    [Fact]
+    public void Estimate_InfersMissingSourceDepthFromPixelFormat()
+    {
+        var request = VideoRequest();
+        request.SourceBitDepth = null;
+        request.SourcePixelFormat = "yuv420p10le";
+
+        var estimate = GpuVramEstimator.Estimate(request);
+
+        Assert.Equal(512, estimate.BudgetMiB);
+        Assert.False(estimate.UsedFallbackMetadata);
+        Assert.Equal(10, estimate.SourceBitDepth);
+    }
+
+    [Fact]
+    public void Estimate_ExtremeDimensionsSaturateWithoutOverflowing()
+    {
+        var request = VideoRequest();
+        request.SourceWidth = int.MaxValue;
+        request.SourceHeight = int.MaxValue;
+
+        Assert.Equal(int.MaxValue, GpuVramEstimator.Estimate(request).BudgetMiB);
+    }
+}

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GuardedTranscodeManagerTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GuardedTranscodeManagerTests.cs
@@ -5,6 +5,7 @@ using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Net;
 using MediaBrowser.Controller.Streaming;
 using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -15,7 +16,8 @@ public class GuardedTranscodeManagerTests
 {
     private const string CudaNvencArguments =
         "-init_hw_device cuda=cu:0 -filter_hw_device cu -hwaccel cuda -hwaccel_output_format cuda " +
-        "-i \"/media/movie.mkv\" -codec:v:0 av1_nvenc -codec:a:0 libfdk_aac";
+        "-i \"/media/movie.mkv\" -vf \"tonemap_cuda=format=yuv420p,scale_cuda=1920:1080\" " +
+        "-codec:v:0 h264_nvenc -codec:a:0 libfdk_aac";
 
     private static readonly Guid AliceId = Guid.Parse("11111111-1111-1111-1111-111111111111");
     private static readonly Guid MovieTwoId = Guid.Parse("22222222-2222-2222-2222-222222222222");
@@ -29,6 +31,8 @@ public class GuardedTranscodeManagerTests
 
         public int DisposeCallCount { get; private set; }
 
+        public int StartFailuresRemaining { get; set; }
+
         public bool Disposed => DisposeCallCount > 0;
 
         public Task<TranscodingJob> StartFfMpeg(
@@ -41,6 +45,12 @@ public class GuardedTranscodeManagerTests
             string? workingDirectory = null)
         {
             StartFfMpegCallCount++;
+            if (StartFailuresRemaining > 0)
+            {
+                StartFailuresRemaining--;
+                throw new InvalidOperationException("inner start failed after process creation");
+            }
+
             return Task.FromResult(new TranscodingJob(NullLogger<TranscodingJob>.Instance));
         }
 
@@ -95,22 +105,33 @@ public class GuardedTranscodeManagerTests
             {
                 Id = MovieTwoId,
                 DeviceId = "device-2",
-                PlaySessionId = "play-2"
+                PlaySessionId = "play-2",
+                MaxWidth = 1920,
+                MaxHeight = 1080
             },
             OutputVideoCodec = outputVideoCodec,
-            MediaSource = new MediaSourceInfo { Name = "Movie Two" }
+            MediaSource = new MediaSourceInfo { Name = "Movie Two" },
+            VideoStream = new MediaStream
+            {
+                Width = 3840,
+                Height = 2160,
+                BitDepth = 10,
+                Codec = "hevc",
+                RefFrames = 4,
+                ColorTransfer = "smpte2084",
+                ColorPrimaries = "bt2020"
+            }
         };
 
         return state;
     }
 
     private static (GuardedTranscodeManager Decorator, SpyTranscodeManager Inner, RecordingClientMessageService Messages)
-        CreateDecorator(int freeMiB, int thresholdMiB, bool guardEnabled = true)
+        CreateDecorator(int freeMiB, bool guardEnabled = true)
     {
         var config = new PluginConfiguration
         {
             EnableGpuResourceGuard = guardEnabled,
-            MinimumFreeGpuMemoryMiB = thresholdMiB,
             GpuIndex = 0
         };
 
@@ -132,7 +153,7 @@ public class GuardedTranscodeManagerTests
     [Fact]
     public async Task StartFfMpeg_LowVramRefusesWithoutEverLaunchingFfmpeg()
     {
-        var (decorator, inner, messages) = CreateDecorator(freeMiB: 700, thresholdMiB: 1500);
+        var (decorator, inner, messages) = CreateDecorator(freeMiB: 700);
         using var cts = new CancellationTokenSource();
 
         // Jellyfin's own SecurityException, not the BCL type of the same name: its exception
@@ -148,7 +169,7 @@ public class GuardedTranscodeManagerTests
             cts));
 
         Assert.Equal("MediaBrowser.Controller.Net.SecurityException", ex.GetType().FullName);
-        Assert.Contains("free GPU memory", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("VRAM budget", ex.Message, StringComparison.OrdinalIgnoreCase);
         Assert.Equal(0, inner.StartFfMpegCallCount);
         Assert.Single(messages.SentMessages);
     }
@@ -156,7 +177,7 @@ public class GuardedTranscodeManagerTests
     [Fact]
     public async Task StartFfMpeg_SufficientVramLaunchesNormally()
     {
-        var (decorator, inner, messages) = CreateDecorator(freeMiB: 2500, thresholdMiB: 1500);
+        var (decorator, inner, messages) = CreateDecorator(freeMiB: 2500);
         using var cts = new CancellationTokenSource();
 
         var job = await decorator.StartFfMpeg(
@@ -175,7 +196,7 @@ public class GuardedTranscodeManagerTests
     [Fact]
     public async Task StartFfMpeg_RemuxLaunchesEvenWhenVramIsExhausted()
     {
-        var (decorator, inner, messages) = CreateDecorator(freeMiB: 10, thresholdMiB: 1500);
+        var (decorator, inner, messages) = CreateDecorator(freeMiB: 10);
         using var cts = new CancellationTokenSource();
 
         await decorator.StartFfMpeg(
@@ -193,7 +214,7 @@ public class GuardedTranscodeManagerTests
     [Fact]
     public async Task StartFfMpeg_GuardDisabledLeavesBehaviourUnchanged()
     {
-        var (decorator, inner, _) = CreateDecorator(freeMiB: 10, thresholdMiB: 1500, guardEnabled: false);
+        var (decorator, inner, _) = CreateDecorator(freeMiB: 10, guardEnabled: false);
         using var cts = new CancellationTokenSource();
 
         await decorator.StartFfMpeg(
@@ -215,7 +236,7 @@ public class GuardedTranscodeManagerTests
             new ThrowingGpuMemoryProvider(),
             new RecordingClientMessageService(),
             NullLogger<GpuResourceGuard>.Instance,
-            () => new PluginConfiguration { EnableGpuResourceGuard = true, MinimumFreeGpuMemoryMiB = 1500 });
+            () => new PluginConfiguration { EnableGpuResourceGuard = true });
 
         var inner = new SpyTranscodeManager();
         var decorator = new GuardedTranscodeManager(inner, guard, NullLogger<GuardedTranscodeManager>.Instance);
@@ -233,9 +254,93 @@ public class GuardedTranscodeManagerTests
     }
 
     [Fact]
+    public async Task StartFfMpeg_InnerFailureRetainsTheRaceWindowReservation()
+    {
+        var (decorator, inner, _) = CreateDecorator(freeMiB: 2000);
+        inner.StartFailuresRemaining = 1;
+        using var firstCts = new CancellationTokenSource();
+        using var secondCts = new CancellationTokenSource();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => decorator.StartFfMpeg(
+            CreateHardwareVideoState(),
+            "/config/transcodes/first.m3u8",
+            CudaNvencArguments,
+            AliceId,
+            TranscodingJobType.Hls,
+            firstCts));
+
+        await Assert.ThrowsAsync<SecurityException>(() => decorator.StartFfMpeg(
+            CreateHardwareVideoState(),
+            "/config/transcodes/second.m3u8",
+            CudaNvencArguments,
+            AliceId,
+            TranscodingJobType.Hls,
+            secondCts));
+
+        Assert.Equal(1, inner.StartFfMpegCallCount);
+    }
+
+    [Fact]
+    public async Task StartFfMpeg_RefusalReasonFailureStillReturnsJellyfins403()
+    {
+        var accessCount = 0;
+        var config = new PluginConfiguration { EnableGpuResourceGuard = true };
+        var guard = new GpuResourceGuard(
+            FakeGpuMemoryProvider.WithFreeMiB(10),
+            new RecordingClientMessageService(),
+            NullLogger<GpuResourceGuard>.Instance,
+            () => ++accessCount == 1 ? config : throw new InvalidOperationException("config reload failed"));
+        var inner = new SpyTranscodeManager();
+        var decorator = new GuardedTranscodeManager(
+            inner,
+            guard,
+            new ThrowingLogger<GuardedTranscodeManager>());
+        using var cts = new CancellationTokenSource();
+
+        var exception = await Assert.ThrowsAsync<SecurityException>(() => decorator.StartFfMpeg(
+            CreateHardwareVideoState(),
+            "/config/transcodes/abc.m3u8",
+            CudaNvencArguments,
+            AliceId,
+            TranscodingJobType.Hls,
+            cts));
+
+        Assert.Equal("MediaBrowser.Controller.Net.SecurityException", exception.GetType().FullName);
+        Assert.Equal(0, inner.StartFfMpegCallCount);
+    }
+
+    [Fact]
+    public async Task StartFfMpeg_MissingRequestMetadataDoesNotBreakPlayback()
+    {
+        var (decorator, inner, _) = CreateDecorator(freeMiB: 2500);
+        var state = new StreamState(null!, TranscodingJobType.Hls, null!)
+        {
+            OutputVideoCodec = "h264",
+            VideoStream = new MediaStream
+            {
+                Width = 1920,
+                Height = 1080,
+                BitDepth = 8,
+                Codec = "h264"
+            }
+        };
+        using var cts = new CancellationTokenSource();
+
+        await decorator.StartFfMpeg(
+            state,
+            "/config/transcodes/abc.m3u8",
+            CudaNvencArguments,
+            AliceId,
+            TranscodingJobType.Hls,
+            cts);
+
+        Assert.Equal(1, inner.StartFfMpegCallCount);
+    }
+
+    [Fact]
     public void Dispose_IsIdempotent()
     {
-        var (decorator, inner, _) = CreateDecorator(freeMiB: 2500, thresholdMiB: 1500);
+        var (decorator, inner, _) = CreateDecorator(freeMiB: 2500);
 
         decorator.Dispose();
         decorator.Dispose();
@@ -246,7 +351,7 @@ public class GuardedTranscodeManagerTests
     [Fact]
     public void Dispose_DisposesTheInnerManager()
     {
-        var (decorator, inner, _) = CreateDecorator(freeMiB: 2500, thresholdMiB: 1500);
+        var (decorator, inner, _) = CreateDecorator(freeMiB: 2500);
 
         decorator.Dispose();
 

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/Jellyfin.Plugin.TranscodeNag.Tests.csproj
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/Jellyfin.Plugin.TranscodeNag.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/NvidiaSmiGpuMemoryProviderTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/NvidiaSmiGpuMemoryProviderTests.cs
@@ -180,4 +180,27 @@ public class NvidiaSmiGpuMemoryProviderTests
 
         Assert.All(results, result => Assert.False(result.Success));
     }
+
+    [UnixFact]
+    public async Task GetUsedMemoryAsync_AttributesTheRequestedFfmpegProcess()
+    {
+        var script = ScriptedNvidiaSmi("2378147, 1339");
+        try
+        {
+            using var provider = Create(script);
+
+            var result = await ((IGpuProcessMemoryProvider)provider).GetUsedMemoryAsync(
+                2378147,
+                5000,
+                CancellationToken.None);
+
+            Assert.True(result.Success);
+            Assert.Equal(1339, result.UsedMiB);
+        }
+        finally
+        {
+            File.Delete(script);
+            File.Delete(script + ".calls");
+        }
+    }
 }

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/NvidiaSmiOutputParserTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/NvidiaSmiOutputParserTests.cs
@@ -50,4 +50,25 @@ public class NvidiaSmiOutputParserTests
         Assert.True(NvidiaSmiOutputParser.TryGetFreeMiB("0, 2318, 24576", 0, out var free));
         Assert.Equal(2318, free);
     }
+
+    [Fact]
+    public void TryGetProcessUsedMiB_ReadsAndSumsTheRequestedProcess()
+    {
+        const string Output = "2378147, 1339\n3230507, 160\n2378147, 12\n";
+
+        Assert.True(NvidiaSmiOutputParser.TryGetProcessUsedMiB(Output, 2378147, out var usedMiB));
+        Assert.Equal(1351, usedMiB);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("2378147, [N/A]")]
+    [InlineData("2378147, -1")]
+    [InlineData("other, 1339")]
+    public void TryGetProcessUsedMiB_ReturnsFalseForUnusableOutput(string? output)
+    {
+        Assert.False(NvidiaSmiOutputParser.TryGetProcessUsedMiB(output, 2378147, out var usedMiB));
+        Assert.Equal(0, usedMiB);
+    }
 }

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/NvidiaTranscodeDetectorTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/NvidiaTranscodeDetectorTests.cs
@@ -71,6 +71,49 @@ public class NvidiaTranscodeDetectorTests
         Assert.False(NvidiaTranscodeDetector.UsesNvidiaGpu(arguments));
     }
 
+    [Fact]
+    public void UsesNvidiaGpu_IsNotTrippedBySubtitlePathsInsideFilterGraphs()
+    {
+        const string arguments =
+            "-i in.mkv -vf \"subtitles=filename='/media/show_cuda.srt',scale=1280:720\" -c:v libx264 out.ts";
+
+        Assert.False(NvidiaTranscodeDetector.UsesNvidiaGpu(arguments));
+    }
+
+    [Theory]
+    [InlineData("-i in.mkv -filter:v:0 \"scale_cuda=1280:720\" -c:v libx264 out.ts")]
+    [InlineData("-i in.mkv -filter_complex \"[0:v]hwupload=derive_device=cuda[out]\" -c:v libx264 out.ts")]
+    [InlineData("-i in.mkv -vf \"hwmap=derive_device=cuda\" -c:v libx264 out.ts")]
+    public void UsesNvidiaGpu_DetectsQualifiedAndDerivedCudaFilters(string arguments)
+    {
+        Assert.True(NvidiaTranscodeDetector.UsesNvidiaGpu(arguments));
+    }
+
+    [Theory]
+    [InlineData("-init_hw_device cuda:2 -hwaccel cuda -i in.mkv -c:v h264_nvenc out.ts", 2)]
+    [InlineData("-init_hw_device cuda=cu:1 -filter_hw_device cu -i in.mkv -c:v h264_nvenc out.ts", 1)]
+    [InlineData("-hwaccel cuda -hwaccel_device 3 -i in.mkv -c:v libx264 out.ts", 3)]
+    [InlineData("-i in.mkv -c:v hevc_nvenc -gpu 4 out.ts", 4)]
+    public void Analyze_ExtractsTheSelectedGpuIndex(string arguments, int expectedGpuIndex)
+    {
+        var features = NvidiaTranscodeDetector.Analyze(arguments);
+
+        Assert.True(features.UsesGpu);
+        Assert.Equal(expectedGpuIndex, features.GpuIndex);
+        Assert.False(features.HasConflictingGpuIndices);
+    }
+
+    [Fact]
+    public void Analyze_FlagsConflictingGpuSelectors()
+    {
+        var features = NvidiaTranscodeDetector.Analyze(
+            "-init_hw_device cuda=cu:0 -hwaccel cuda -hwaccel_device 1 -i in.mkv -c:v h264_nvenc out.ts");
+
+        Assert.True(features.UsesGpu);
+        Assert.Null(features.GpuIndex);
+        Assert.True(features.HasConflictingGpuIndices);
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/PluginConfigurationCompatibilityTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/PluginConfigurationCompatibilityTests.cs
@@ -1,0 +1,35 @@
+using System.Xml.Serialization;
+using Jellyfin.Plugin.TranscodeNag.Configuration;
+
+namespace Jellyfin.Plugin.TranscodeNag.Tests;
+
+public class PluginConfigurationCompatibilityTests
+{
+    [Fact]
+    public void LegacyGpuThresholdElementDoesNotBreakConfigurationLoading()
+    {
+        const string LegacyXml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <PluginConfiguration>
+              <EnableGpuResourceGuard>true</EnableGpuResourceGuard>
+              <GpuIndex>1</GpuIndex>
+              <MinimumFreeGpuMemoryMiB>1500</MinimumFreeGpuMemoryMiB>
+              <GpuCheckTimeoutMilliseconds>1750</GpuCheckTimeoutMilliseconds>
+              <GpuGuardDeniedHeader>Busy</GpuGuardDeniedHeader>
+            </PluginConfiguration>
+            """;
+        var serializer = new XmlSerializer(typeof(PluginConfiguration));
+
+        using var reader = new StringReader(LegacyXml);
+        var config = Assert.IsType<PluginConfiguration>(serializer.Deserialize(reader));
+
+        Assert.True(config.EnableGpuResourceGuard);
+        Assert.Equal(1, config.GpuIndex);
+        Assert.Equal(1750, config.GpuCheckTimeoutMilliseconds);
+        Assert.Equal("Busy", config.GpuGuardDeniedHeader);
+
+        using var writer = new StringWriter();
+        serializer.Serialize(writer, config);
+        Assert.DoesNotContain("MinimumFreeGpuMemoryMiB", writer.ToString(), StringComparison.Ordinal);
+    }
+}

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/TestDoubles.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/TestDoubles.cs
@@ -89,8 +89,13 @@ internal sealed class SequencedGpuMemoryProvider : IGpuMemoryProvider
     private readonly GpuMemoryQueryResult _exhausted;
 
     public SequencedGpuMemoryProvider(params int[] freeMiBReadings)
+        : this(freeMiBReadings.Select(GpuMemoryQueryResult.FromFreeMiB).ToArray())
     {
-        _readings = new Queue<GpuMemoryQueryResult>(freeMiBReadings.Select(GpuMemoryQueryResult.FromFreeMiB));
+    }
+
+    public SequencedGpuMemoryProvider(params GpuMemoryQueryResult[] readings)
+    {
+        _readings = new Queue<GpuMemoryQueryResult>(readings);
         _exhausted = GpuMemoryQueryResult.Failed("no scripted reading left");
     }
 
@@ -107,6 +112,134 @@ internal sealed class SequencedGpuMemoryProvider : IGpuMemoryProvider
             return Task.FromResult(_readings.Count > 0 ? _readings.Dequeue() : _exhausted);
         }
     }
+}
+
+/// <summary>
+/// Holds the first GPU query open so a second admission can be started while it is in flight.
+/// </summary>
+internal sealed class BlockingFirstGpuMemoryProvider : IGpuMemoryProvider
+{
+    private readonly GpuMemoryQueryResult _result;
+    private readonly TaskCompletionSource _firstQueryStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _releaseFirstQuery = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private int _queryCount;
+
+    public BlockingFirstGpuMemoryProvider(int freeMiB)
+    {
+        _result = GpuMemoryQueryResult.FromFreeMiB(freeMiB);
+    }
+
+    public int QueryCount => Volatile.Read(ref _queryCount);
+
+    public Task FirstQueryStarted => _firstQueryStarted.Task;
+
+    public void ReleaseFirstQuery() => _releaseFirstQuery.TrySetResult();
+
+    public async Task<GpuMemoryQueryResult> GetFreeMemoryAsync(
+        int gpuIndex,
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken)
+    {
+        var queryNumber = Interlocked.Increment(ref _queryCount);
+        if (queryNumber == 1)
+        {
+            _firstQueryStarted.TrySetResult();
+            await _releaseFirstQuery.Task.WaitAsync(cancellationToken);
+        }
+
+        return _result;
+    }
+}
+
+internal sealed class ObservingGpuMemoryProvider : IGpuMemoryProvider, IGpuProcessMemoryProvider
+{
+    private readonly Queue<GpuMemoryQueryResult> _freeReadings;
+    private readonly GpuProcessMemoryQueryResult _processReading;
+
+    public ObservingGpuMemoryProvider(int processUsedMiB, params int[] freeMiBReadings)
+    {
+        _freeReadings = new Queue<GpuMemoryQueryResult>(
+            freeMiBReadings.Select(GpuMemoryQueryResult.FromFreeMiB));
+        _processReading = GpuProcessMemoryQueryResult.FromUsedMiB(processUsedMiB);
+    }
+
+    public Task<GpuMemoryQueryResult> GetFreeMemoryAsync(
+        int gpuIndex,
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken)
+    {
+        lock (_freeReadings)
+        {
+            return Task.FromResult(_freeReadings.Dequeue());
+        }
+    }
+
+    public Task<GpuProcessMemoryQueryResult> GetUsedMemoryAsync(
+        int processId,
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(_processReading);
+    }
+}
+
+internal sealed class DelayedObservingGpuMemoryProvider : IGpuMemoryProvider, IGpuProcessMemoryProvider
+{
+    private readonly Queue<GpuMemoryQueryResult> _freeReadings;
+    private readonly TaskCompletionSource _processQueryStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    private readonly TaskCompletionSource _releaseProcessQuery = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public DelayedObservingGpuMemoryProvider(params int[] freeMiBReadings)
+    {
+        _freeReadings = new Queue<GpuMemoryQueryResult>(
+            freeMiBReadings.Select(GpuMemoryQueryResult.FromFreeMiB));
+    }
+
+    public Task ProcessQueryStarted => _processQueryStarted.Task;
+
+    public void ReleaseProcessQuery() => _releaseProcessQuery.TrySetResult();
+
+    public Task<GpuMemoryQueryResult> GetFreeMemoryAsync(
+        int gpuIndex,
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken)
+    {
+        lock (_freeReadings)
+        {
+            return Task.FromResult(_freeReadings.Dequeue());
+        }
+    }
+
+    public async Task<GpuProcessMemoryQueryResult> GetUsedMemoryAsync(
+        int processId,
+        int timeoutMilliseconds,
+        CancellationToken cancellationToken)
+    {
+        _processQueryStarted.TrySetResult();
+        await _releaseProcessQuery.Task.WaitAsync(cancellationToken);
+        return GpuProcessMemoryQueryResult.FromUsedMiB(323);
+    }
+}
+
+/// <summary>
+/// A logger that violates the usual ILogger contract by throwing, used to prove diagnostic
+/// infrastructure cannot change a GPU admission decision.
+/// </summary>
+internal sealed class ThrowingLogger<T> : ILogger<T>
+{
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull
+        => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter)
+        => throw new InvalidOperationException("logger failed");
 }
 
 /// <summary>
@@ -133,52 +266,6 @@ internal sealed class ThrowingClientMessageService : IClientMessageService
         ILogger logger,
         CancellationToken cancellationToken)
         => throw new System.Net.WebSockets.WebSocketException("the remote party closed the connection");
-}
-
-/// <summary>
-/// Holds every caller inside the query until all of them have arrived, so admissions genuinely
-/// overlap instead of completing one at a time as the test enumerates them.
-/// </summary>
-internal sealed class GatedGpuMemoryProvider : IGpuMemoryProvider
-{
-    private readonly int _expectedCallers;
-    private readonly Queue<GpuMemoryQueryResult> _readings;
-    private readonly TaskCompletionSource _allArrived = new(TaskCreationOptions.RunContinuationsAsynchronously);
-    private int _arrived;
-
-    public GatedGpuMemoryProvider(int expectedCallers, params int[] freeMiBReadings)
-    {
-        _expectedCallers = expectedCallers;
-        _readings = new Queue<GpuMemoryQueryResult>(freeMiBReadings.Select(GpuMemoryQueryResult.FromFreeMiB));
-    }
-
-    public int QueryCount { get; private set; }
-
-    public async Task<GpuMemoryQueryResult> GetFreeMemoryAsync(
-        int gpuIndex,
-        int timeoutMilliseconds,
-        CancellationToken cancellationToken)
-    {
-        GpuMemoryQueryResult reading;
-
-        lock (_readings)
-        {
-            QueryCount++;
-            _arrived++;
-            reading = _readings.Count > 0
-                ? _readings.Dequeue()
-                : GpuMemoryQueryResult.Failed("no scripted reading left");
-
-            if (_arrived == _expectedCallers)
-            {
-                _allArrived.TrySetResult();
-            }
-        }
-
-        // Times out rather than hanging if the guard ever serialises admissions.
-        await _allArrived.Task.WaitAsync(TimeSpan.FromSeconds(10), cancellationToken).ConfigureAwait(false);
-        return reading;
-    }
 }
 
 internal static class TestSessions

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/TranscodeEventStoreTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/TranscodeEventStoreTests.cs
@@ -1,5 +1,5 @@
-using Jellyfin.Plugin.TranscodeNag.Data;
 using Jellyfin.Plugin.TranscodeNag.Configuration;
+using Jellyfin.Plugin.TranscodeNag.Data;
 using Jellyfin.Plugin.TranscodeNag.Models;
 using Microsoft.Extensions.Logging.Abstractions;
 


### PR DESCRIPTION
## Summary

This replaces the static Minimum Free GPU Memory ceiling with workload-aware admission against the VRAM that is actually free when Jellyfin is about to launch FFmpeg.

- Queries nvidia-smi for a fresh per-GPU free-memory reading on every admission decision.
- Builds a conservative per-job requirement from resolution, bit depth, frame rate, reference frames, output codec, tone mapping, and CUDA filters.
- Removes the MinimumFreeGpuMemoryMiB setting and its dashboard control.
- Serializes the read/decision/reservation sequence so simultaneous play requests cannot both spend the same headroom.
- Tracks short-lived in-flight reservations until the new FFmpeg allocation appears.
- Samples exact per-process FFmpeg VRAM after launch and logs the observed whole-MiB peak.
- Identifies duplicate Jellyfin starts by output path without double-charging their reservation.
- Detects FFmpeg GPU selection and fails open when selectors conflict or nvidia-smi is unavailable.
- Preserves the HTTP 403 refusal behavior from PR #28 and isolates logging/message failures from admission decisions.

## Precision boundary

Current free VRAM and launched FFmpeg process usage are read directly from nvidia-smi in whole MiB. A future process allocation does not exist before launch, so the pre-launch requirement is deliberately conservative rather than presented as an exact measurement.

## Calibration samples

| Workload | FFmpeg VRAM | Total GPU delta |
| --- | ---: | ---: |
| Gladiator 4K Blu-ray remux transcode | 1339 MiB | 1345 MiB |
| Game of Thrones S01E01 4K HEVC HDR remux | 824 MiB | 829 MiB |
| 1080p episode forced to 720p | 323 MiB | 329 MiB |

## Compatibility and CI

- Legacy configuration XML containing the removed setting still deserializes.
- CI now tests the supported .NET 8 target and includes the test project in formatting checks.
- Documentation and the implementation handoff describe the new policy and its precision boundary.

## Validation

- 164 tests pass on .NET 8.
- Release build passes with warnings treated as errors.
- Formatting and diff checks pass locally.
- Dashboard JavaScript parses successfully.
- Plugin loads and starts on Jellyfin 10.11.11 in Docker without dependency-injection or decoration failures.