### PR TITLE
fix(gpu): stop double-counting 4K pipeline VRAM

### DIFF
--- a/Gpu/GpuVramEstimator.cs
+++ b/Gpu/GpuVramEstimator.cs
@@ -42,11 +42,12 @@ internal static class GpuVramEstimator
 
         var inferredSourceBitDepth = InferPixelFormatBitDepth(request.SourcePixelFormat);
         var inferredOutputBitDepth = InferOutputBitDepth(request.CommandLineArguments);
-        var usedFallback = !IsDimension(request.SourceWidth)
+        var usedSourceFallback = !IsDimension(request.SourceWidth)
             || !IsDimension(request.SourceHeight)
-            || !IsDimension(request.OutputWidth)
-            || !IsDimension(request.OutputHeight)
             || (!IsBitDepth(request.SourceBitDepth) && !inferredSourceBitDepth.HasValue);
+        var usedFallback = usedSourceFallback
+            || !IsDimension(request.OutputWidth)
+            || !IsDimension(request.OutputHeight);
 
         var sourceWidth = ValidDimension(request.SourceWidth, DefaultWidth);
         var sourceHeight = ValidDimension(request.SourceHeight, DefaultHeight);
@@ -67,26 +68,31 @@ internal static class GpuVramEstimator
             outputWidth * (long)outputHeight);
         var largestBitDepth = Math.Max(sourceBitDepth, outputBitDepth);
 
-        var budgetMiB = BaseBudgetMiB(largestFramePixels, largestBitDepth, usedFallback);
+        var budgetMiB = BaseBudgetMiB(largestFramePixels, largestBitDepth);
+        long pipelinePressureMiB = 0;
 
         // Tone mapping is the observed distinction between a roughly 1 GiB 4K HDR job and a
         // roughly 1.5 GiB one. Merely being HDR does not incur this band: Jellyfin must actually
         // have placed tonemap_cuda in the command line.
         if (features.UsesTonemap)
         {
-            budgetMiB += largestFramePixels > UltraHdPixels
+            pipelinePressureMiB = largestFramePixels > UltraHdPixels
                 ? ScaleAndRoundUp(512, largestFramePixels, UltraHdPixels)
                 : largestFramePixels > QuadHdPixels ? 512 : 256;
         }
 
         if (features.UsesOtherFilters)
         {
-            budgetMiB += ScaleSurcharge(256, largestFramePixels);
+            pipelinePressureMiB = Math.Max(
+                pipelinePressureMiB,
+                ScaleSurcharge(256, largestFramePixels));
         }
 
         if (string.Equals(request.OutputVideoCodec, "av1", StringComparison.OrdinalIgnoreCase))
         {
-            budgetMiB += ScaleSurcharge(256, largestFramePixels);
+            pipelinePressureMiB = Math.Max(
+                pipelinePressureMiB,
+                ScaleSurcharge(256, largestFramePixels));
         }
 
         if (request.SourceRefFrames > 8
@@ -94,7 +100,19 @@ internal static class GpuVramEstimator
             || request.SourceFramerate > 60
             || outputFramerate > 60)
         {
-            budgetMiB += ScaleSurcharge(256, largestFramePixels);
+            pipelinePressureMiB = Math.Max(
+                pipelinePressureMiB,
+                ScaleSurcharge(256, largestFramePixels));
+        }
+
+        // These signals all describe pressure on the same decoder/filter/encoder surface pool.
+        // Adding them as if they were independent allocations double-counts the pipeline and made
+        // the measured 1339-1496 MiB 4K workload require 2048 MiB. Use the largest applicable
+        // envelope, then apply the unknown-source floor to the completed budget.
+        budgetMiB += pipelinePressureMiB;
+        if (usedSourceFallback)
+        {
+            budgetMiB = Math.Max(1536, budgetMiB);
         }
 
         budgetMiB = Math.Clamp(budgetMiB, 512, int.MaxValue);
@@ -111,7 +129,7 @@ internal static class GpuVramEstimator
             usedFallback);
     }
 
-    private static long BaseBudgetMiB(long largestFramePixels, int largestBitDepth, bool usedFallback)
+    private static long BaseBudgetMiB(long largestFramePixels, int largestBitDepth)
     {
         long budgetMiB;
         if (largestFramePixels <= FullHdPixels)
@@ -132,9 +150,7 @@ internal static class GpuVramEstimator
             budgetMiB = ScaleAndRoundUp(ultraHdBudgetMiB, largestFramePixels, UltraHdPixels);
         }
 
-        // Missing fields must not silently turn an unknown job into the cheapest class, but known
-        // dimensions above 4K must still scale beyond this fallback floor.
-        return usedFallback ? Math.Max(1536, budgetMiB) : budgetMiB;
+        return budgetMiB;
     }
 
     private static long ScaleAndRoundUp(int referenceMiB, long pixels, long referencePixels)

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
@@ -108,6 +108,22 @@ public class GpuResourceGuardTests
     }
 
     [Fact]
+    public async Task IsAdmittedAsync_GladiatorWith1918MiBFreeIsAllowed()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(1918);
+        var messages = new RecordingClientMessageService();
+        var guard = CreateGuard(EnabledConfig(), provider, messages);
+        var request = HardwareTranscodeRequest();
+        request.OutputWidth = null;
+        request.OutputHeight = null;
+        request.OutputBitDepth = null;
+
+        Assert.True(await guard.IsAdmittedAsync(request, CancellationToken.None));
+        Assert.Equal(1, provider.QueryCount);
+        Assert.Empty(messages.SentMessages);
+    }
+
+    [Fact]
     public async Task IsAdmittedAsync_RemuxIsAllowedWithoutQueryingTheGpu()
     {
         var provider = FakeGpuMemoryProvider.WithFreeMiB(10);

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuVramEstimatorTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuVramEstimatorTests.cs
@@ -59,6 +59,46 @@ public class GpuVramEstimatorTests
     }
 
     [Fact]
+    public void Estimate_4kGladiatorShapeWithMissingOutputMetadataUsesCompleteMeasuredEnvelope()
+    {
+        var request = VideoRequest();
+        request.CommandLineArguments = TonemapArguments;
+        request.SourceWidth = 3840;
+        request.SourceHeight = 2160;
+        request.SourceBitDepth = 10;
+        request.SourceCodec = "hevc";
+        request.SourceVideoRangeType = "HDR10";
+        request.OutputWidth = null;
+        request.OutputHeight = null;
+        request.OutputBitDepth = null;
+
+        var estimate = GpuVramEstimator.Estimate(request);
+
+        Assert.Equal(1536, estimate.BudgetMiB);
+        Assert.True(estimate.UsedFallbackMetadata);
+    }
+
+    [Fact]
+    public void Estimate_4kPipelinePressureSignalsDoNotDoubleCountTheSameSurfacePool()
+    {
+        var request = VideoRequest();
+        request.CommandLineArguments =
+            "-hwaccel cuda -i source.mkv " +
+            "-vf \"tonemap_cuda,scale_cuda=1920:1080,overlay_cuda\" " +
+            "-codec:v:0 av1_nvenc -refs:v:0 12 -r:v:0 120 output.m3u8";
+        request.OutputVideoCodec = "av1";
+        request.SourceWidth = 3840;
+        request.SourceHeight = 2160;
+        request.SourceBitDepth = 10;
+        request.OutputWidth = null;
+        request.OutputHeight = null;
+        request.OutputRefFrames = null;
+        request.OutputFramerate = null;
+
+        Assert.Equal(1536, GpuVramEstimator.Estimate(request).BudgetMiB);
+    }
+
+    [Fact]
     public void Estimate_4k10BitWithoutTonemapUsesOneGiBBudget()
     {
         var request = VideoRequest();


### PR DESCRIPTION
## Root cause

When Jellyfin omitted output dimensions, the estimator promoted the 4K job to a 1536 MiB fallback base and then added a separate 512 MiB tone-map surcharge. That double-counted one pipeline as 2048 MiB and falsely blocked Gladiator with 1918 MiB free, despite its measured 1339-1496 MiB allocation.

## Fix

- Treat 1536 MiB as the complete calibrated 4K filter-heavy envelope.
- Model tone mapping, codec, filter, frame-rate, and reference-frame pressure as alternative signals for the same surface pool instead of additive allocations.
- Apply the unknown-source fallback floor to the completed budget.
- Falling back missing output dimensions to known source dimensions no longer inflates the base.

## Release-blocking acceptance case

A Gladiator-shaped 4K HEVC HDR request with Jellyfin output metadata absent and exactly 1918 MiB free is admitted with a 1536 MiB budget.

## Validation

- 167 tests pass.
- C# style verification passes.
- Diff check passes.