### PR TITLE
feat(gpu): let admins tune the automatic VRAM budget

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -83,6 +83,19 @@ public class PluginConfiguration : BasePluginConfiguration
     public int GpuIndex { get; set; } = 0;
 
     /// <summary>
+    /// Gets or sets the percentage of the automatic per-job VRAM budget the guard actually demands.
+    /// </summary>
+    /// <remarks>
+    /// The automatic budget is deliberately conservative: it is the worst plausible peak for a job
+    /// shape, not the usage of any one run, so on a card that is already mostly occupied it can
+    /// refuse a job that would in fact have fitted. This is the dial for that case. 100 keeps the
+    /// model as calibrated, below 100 trades margin for admissions, above 100 buys extra margin.
+    /// Under-budgeting is what CUDA reports as OOM (FFmpeg exit 187), so lower it in small steps
+    /// and read the calibration lines in the log before lowering it again.
+    /// </remarks>
+    public int GpuVramBudgetPercent { get; set; } = 100;
+
+    /// <summary>
     /// Gets or sets how long the nvidia-smi query may run before it is abandoned.
     /// </summary>
     public int GpuCheckTimeoutMilliseconds { get; set; } = 1000;

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -203,6 +203,20 @@
                         </div>
 
                         <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtGpuVramBudgetPercent">VRAM budget (%):</label>
+                            <input type="number" id="txtGpuVramBudgetPercent" name="txtGpuVramBudgetPercent" min="10" max="500" step="5" class="emby-input" />
+                            <div class="fieldDescription">
+                                How much of each job's automatic VRAM budget the guard demands. 100 uses the budget as
+                                calibrated, which is the worst plausible peak for that job shape rather than any single
+                                run &mdash; on a card that is already mostly occupied it can refuse a job that would in
+                                fact have fitted. Lower this to admit those jobs, raise it for more margin. Search the
+                                server log for <code>GPU VRAM calibration</code> to see what your jobs really used, and
+                                lower it in small steps: budgeting under the real peak is what CUDA reports as an
+                                out-of-memory failure.
+                            </div>
+                        </div>
+
+                        <div class="inputContainer">
                             <label class="inputLabel inputLabelUnfocused" for="txtGpuCheckTimeoutMs">GPU check timeout (ms):</label>
                             <input type="number" id="txtGpuCheckTimeoutMs" name="txtGpuCheckTimeoutMs" min="100" max="10000" class="emby-input" />
                             <div class="fieldDescription">How long to wait for nvidia-smi before giving up and allowing playback.</div>
@@ -947,6 +961,7 @@
                     document.getElementById('txtMotdExcludedClientPatterns').value = ClientPatternEditor.formatPatterns(config.MotdExcludedClientPatterns);
                     document.getElementById('chkEnableGpuResourceGuard').checked = config.EnableGpuResourceGuard === true;
                     document.getElementById('txtGpuIndex').value = GpuGuardSection.numberOrDefault(config.GpuIndex, 0);
+                    document.getElementById('txtGpuVramBudgetPercent').value = GpuGuardSection.numberOrDefault(config.GpuVramBudgetPercent, 100);
                     document.getElementById('txtGpuCheckTimeoutMs').value = GpuGuardSection.numberOrDefault(config.GpuCheckTimeoutMilliseconds, 1000);
                     document.getElementById('txtNvidiaSmiPath').value = config.NvidiaSmiPath || '';
                     document.getElementById('txtGpuGuardDeniedHeader').value = config.GpuGuardDeniedHeader || '';
@@ -982,6 +997,7 @@
                     config.MotdExcludedClientPatterns = ClientPatternEditor.splitPatterns(document.getElementById('txtMotdExcludedClientPatterns').value);
                     config.EnableGpuResourceGuard = document.getElementById('chkEnableGpuResourceGuard').checked;
                     config.GpuIndex = GpuGuardSection.readNumber('txtGpuIndex', 0);
+                    config.GpuVramBudgetPercent = GpuGuardSection.readNumber('txtGpuVramBudgetPercent', 100);
                     config.GpuCheckTimeoutMilliseconds = GpuGuardSection.readNumber('txtGpuCheckTimeoutMs', 1000);
                     config.NvidiaSmiPath = document.getElementById('txtNvidiaSmiPath').value.trim();
                     config.GpuGuardDeniedHeader = document.getElementById('txtGpuGuardDeniedHeader').value;

--- a/Gpu/GpuAdmissionPolicy.cs
+++ b/Gpu/GpuAdmissionPolicy.cs
@@ -108,6 +108,61 @@ internal static class GpuAdmissionPolicy
     }
 
     /// <summary>
+    /// Minimum and maximum values accepted for <see cref="PluginConfiguration.GpuVramBudgetPercent"/>.
+    /// A stored configuration is not necessarily one this build's settings page wrote, so the
+    /// bounds are enforced here rather than trusted from the UI.
+    /// </summary>
+    internal const int MinimumBudgetPercent = 10;
+
+    /// <summary>The largest accepted VRAM budget percentage.</summary>
+    internal const int MaximumBudgetPercent = 500;
+
+    /// <summary>
+    /// Applies the admin's budget percentage to one job's automatic requirement.
+    /// </summary>
+    /// <remarks>
+    /// The model produces the worst plausible peak for a job shape. An admin who has watched the
+    /// calibration log on their own hardware knows better than the model does, so this scales the
+    /// requirement rather than forcing them to choose between the model's number and no guard at
+    /// all. A job that needs any VRAM keeps needing at least 1 MiB, so scaling can never turn a
+    /// real transcode into a free one.
+    /// </remarks>
+    /// <param name="budgetMiB">The model's conservative requirement.</param>
+    /// <param name="config">Plugin configuration.</param>
+    /// <returns>The requirement the guard will actually demand.</returns>
+    internal static int ScaleBudgetMiB(int budgetMiB, PluginConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (budgetMiB <= 0)
+        {
+            return 0;
+        }
+
+        var percent = EffectiveBudgetPercent(config);
+        if (percent == 100)
+        {
+            return budgetMiB;
+        }
+
+        var scaled = (long)budgetMiB * percent / 100;
+
+        return (int)Math.Clamp(scaled, 1, int.MaxValue);
+    }
+
+    /// <summary>
+    /// Gets the budget percentage actually in force, with an out-of-range stored value clamped.
+    /// </summary>
+    /// <param name="config">Plugin configuration.</param>
+    /// <returns>The percentage applied to every model budget.</returns>
+    internal static int EffectiveBudgetPercent(PluginConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        return Math.Clamp(config.GpuVramBudgetPercent, MinimumBudgetPercent, MaximumBudgetPercent);
+    }
+
+    /// <summary>
     /// Returns true when the guard must read GPU state before deciding.
     /// </summary>
     /// <param name="config">Plugin configuration.</param>

--- a/Gpu/GpuResourceGuard.cs
+++ b/Gpu/GpuResourceGuard.cs
@@ -144,9 +144,15 @@ public sealed class GpuResourceGuard
         var gpuIndex = features.GpuIndex ?? config.GpuIndex;
         int? reservationGpuIndex = features.HasConflictingGpuIndices ? null : gpuIndex;
         var estimate = requiresGpu ? GpuVramEstimator.Estimate(request) : GpuVramEstimate.Zero;
+
+        // The model's number is the worst plausible peak for this shape. What the guard demands is
+        // that number after the admin's budget percentage, and everything downstream - the
+        // comparison, the reservation, and the refusal text - uses the demanded figure so a tuned
+        // deployment cannot reserve one amount and be judged against another.
+        var jobBudgetMiB = GpuAdmissionPolicy.ScaleBudgetMiB(estimate.BudgetMiB, config);
         var reservationKey = BuildReservationKey(reservationGpuIndex, request);
         var inFlightBudgetMiB = 0;
-        var decisionJobBudgetMiB = estimate.BudgetMiB;
+        var decisionJobBudgetMiB = jobBudgetMiB;
         var currentJobAlreadyTracked = false;
         GpuMemoryQueryResult? memory = null;
         GpuAdmissionOutcome outcome;
@@ -158,7 +164,7 @@ public sealed class GpuResourceGuard
                 config,
                 requiresGpu,
                 memory,
-                estimate.BudgetMiB);
+                jobBudgetMiB);
         }
         else
         {
@@ -219,7 +225,7 @@ public sealed class GpuResourceGuard
                     && outcome is GpuAdmissionOutcome.AllowedSufficientMemory
                         or GpuAdmissionOutcome.AllowedQueryFailed)
                 {
-                    reservation = AddReservation(reservationGpuIndex, reservationKey, estimate.BudgetMiB);
+                    reservation = AddReservation(reservationGpuIndex, reservationKey, jobBudgetMiB);
                 }
             }
             finally
@@ -238,13 +244,15 @@ public sealed class GpuResourceGuard
             if (outcome == GpuAdmissionOutcome.AllowedSufficientMemory)
             {
                 BestEffort(() => _logger.LogDebug(
-                    "GPU resource guard allowed transcode of {ItemName}: free VRAM {FreeMiB} MiB fits decision budget {DecisionBudgetMiB} MiB plus in-flight budget {InFlightBudgetMiB} MiB on GPU {GpuIndex}; profile budget {ProfileBudgetMiB} MiB, existing output job {ExistingOutputJob}",
+                    "GPU resource guard allowed transcode of {ItemName}: free VRAM {FreeMiB} MiB fits decision budget {DecisionBudgetMiB} MiB plus in-flight budget {InFlightBudgetMiB} MiB on GPU {GpuIndex}; profile budget {ProfileBudgetMiB} MiB at {BudgetPercent}% is {DemandedBudgetMiB} MiB, existing output job {ExistingOutputJob}",
                     request.ItemName ?? "Unknown",
                     memory!.Value.FreeMiB,
                     decisionJobBudgetMiB,
                     inFlightBudgetMiB,
                     gpuIndex,
                     estimate.BudgetMiB,
+                    GpuAdmissionPolicy.EffectiveBudgetPercent(config),
+                    jobBudgetMiB,
                     currentJobAlreadyTracked));
             }
             else
@@ -269,6 +277,7 @@ public sealed class GpuResourceGuard
                 config,
                 memory!.Value,
                 estimate,
+                jobBudgetMiB,
                 inFlightBudgetMiB,
                 gpuIndex,
                 cancellationToken).ConfigureAwait(false);
@@ -306,7 +315,7 @@ public sealed class GpuResourceGuard
             CultureInfo.InvariantCulture,
             "Transcode Nag refused this hardware transcode: its conservative {1} MiB VRAM budget does not fit in the memory currently free on GPU {0}.",
             selectedGpuIndex ?? config.GpuIndex,
-            estimate.BudgetMiB);
+            GpuAdmissionPolicy.ScaleBudgetMiB(estimate.BudgetMiB, config));
     }
 
     private async Task DenyAsync(
@@ -314,6 +323,7 @@ public sealed class GpuResourceGuard
         PluginConfiguration config,
         GpuMemoryQueryResult memory,
         GpuVramEstimate estimate,
+        int jobBudgetMiB,
         int inFlightBudgetMiB,
         int gpuIndex,
         CancellationToken cancellationToken)
@@ -331,15 +341,17 @@ public sealed class GpuResourceGuard
         }
 
         BestEffort(() => _logger.LogWarning(
-            "GPU transcode blocked for session {SessionId}, user {UserName}, device {DeviceName}, item {ItemName}: free VRAM {FreeMiB} MiB cannot fit conservative job budget {JobBudgetMiB} MiB plus in-flight budget {InFlightBudgetMiB} MiB on GPU {GpuIndex}; shape {SourceWidth}x{SourceHeight} {SourceBitDepth}-bit {SourceCodec} to {OutputWidth}x{OutputHeight} {OutputBitDepth}-bit {OutputCodec}, CUDA tonemap {UsesTonemap}, metadata fallback {UsedFallbackMetadata}",
+            "GPU transcode blocked for session {SessionId}, user {UserName}, device {DeviceName}, item {ItemName}: free VRAM {FreeMiB} MiB cannot fit conservative job budget {JobBudgetMiB} MiB plus in-flight budget {InFlightBudgetMiB} MiB on GPU {GpuIndex}; the model budget is {ProfileBudgetMiB} MiB at {BudgetPercent}% (lower GpuVramBudgetPercent to admit jobs this size); shape {SourceWidth}x{SourceHeight} {SourceBitDepth}-bit {SourceCodec} to {OutputWidth}x{OutputHeight} {OutputBitDepth}-bit {OutputCodec}, CUDA tonemap {UsesTonemap}, metadata fallback {UsedFallbackMetadata}",
             session?.Id ?? "Unknown",
             session?.UserName ?? "Unknown",
             session?.DeviceName ?? "Unknown",
             request.ItemName ?? "Unknown",
             memory.FreeMiB,
-            estimate.BudgetMiB,
+            jobBudgetMiB,
             inFlightBudgetMiB,
             gpuIndex,
+            estimate.BudgetMiB,
+            GpuAdmissionPolicy.EffectiveBudgetPercent(config),
             estimate.SourceWidth,
             estimate.SourceHeight,
             estimate.SourceBitDepth,

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Open **Dashboard** → **Plugins** → **Transcode Nag**.
 - Use the built-in live session monitor to see which active sessions currently match your rules.
 - Enable **Message of the Day** (off by default) to send an announcement to everyone at login. Its options stay collapsed until the toggle is on, and it has its own message, its own **Manage Excluded Users (MOTD)** list, and its own client include/exclude filters, all independent of the nag settings.
 - Enable **GPU resource guard** (off by default) to set the fallback GPU index, nvidia-smi timeout and path, and the message a refused client sees. The guard reads current free memory immediately before launch and automatically budgets each job from its source, CUDA filters, and output instead of using a fixed free-VRAM threshold. An explicit GPU selected by FFmpeg overrides the fallback index. `nvidia-smi` must be runnable by the Jellyfin server process.
+- **VRAM budget (%)** tunes how much of that automatic budget the guard demands. The budget is the worst plausible peak for a job shape, not the usage of any one run, so on a card that is already mostly occupied it can refuse a job that would in fact have fitted. Lower this to admit those jobs, raise it for more margin. Every refusal logs both the model budget and the percentage applied, and each launched job logs a `GPU VRAM calibration` line with what FFmpeg really used - tune against those rather than guessing, and lower it in small steps: budgeting under the real peak is what CUDA reports as an out-of-memory failure.
 
 ## Behavior Notes
 

--- a/docs/HANDOFF-dynamic-vram.md
+++ b/docs/HANDOFF-dynamic-vram.md
@@ -52,6 +52,19 @@ the source/output shape and requirement.
 
 The policy comparison is inclusive: `freeMiB >= jobRequirementMiB + inFlightMiB`.
 
+## Admin override
+
+`GpuVramBudgetPercent` (default 100, clamped to 10-500) scales the model's requirement before it is
+compared and before it is reserved. It exists because the model deliberately returns the worst
+plausible peak for a shape: on a card already mostly occupied by something else, a 4K HDR tone-mapped
+job budgeted at 1536 MiB is refused against a 1490 MiB reading even though the same shape has been
+measured at 1339 MiB. Without a dial the only recourse was switching the guard off entirely.
+
+Scaling applies to the decision, the in-flight reservation, and the refusal reason, so a tuned
+deployment cannot reserve one figure and be judged against another. The `GPU VRAM calibration` line
+keeps reporting the unscaled model budget next to the observed maximum: that is the calibration
+record, and it must stay comparable across deployments with different percentages.
+
 ## Concurrent starts
 
 The free-memory query, decision, and reservation are serialized. This prevents two starts from both
@@ -94,7 +107,7 @@ Gpu/GpuVramEstimator.cs              Pure conservative requirement model
 Gpu/NvidiaTranscodeDetector.cs       Token/graph parsing and selected-GPU detection
 Gpu/NvidiaSmiGpuMemoryProvider.cs    Free and per-process nvidia-smi queries
 Gpu/NvidiaSmiOutputParser.cs         Whole-MiB CSV parsing
-Configuration/configPage.html        Guard settings (no fixed free-memory knob)
+Configuration/configPage.html        Guard settings (budget percentage, no fixed free-memory knob)
 tests/Jellyfin.Plugin.TranscodeNag.Tests/
 ```
 

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuAdmissionPolicyTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuAdmissionPolicyTests.cs
@@ -16,6 +16,77 @@ public class GpuAdmissionPolicyTests
     };
 
     [Fact]
+    public void ScaleBudgetMiB_DefaultPercentageLeavesTheModelBudgetAlone()
+    {
+        Assert.Equal(100, new PluginConfiguration().GpuVramBudgetPercent);
+        Assert.Equal(1536, GpuAdmissionPolicy.ScaleBudgetMiB(1536, EnabledConfig()));
+    }
+
+    [Fact]
+    public void ScaleBudgetMiB_LoweringThePercentageAdmitsAJobTheModelBudgetWouldRefuse()
+    {
+        // The reported case: a 4K HDR tone-mapped job budgeted at 1536 MiB against 1490 MiB free.
+        var config = EnabledConfig();
+        config.GpuVramBudgetPercent = 90;
+
+        var budgetMiB = GpuAdmissionPolicy.ScaleBudgetMiB(1536, config);
+
+        Assert.Equal(1382, budgetMiB);
+        Assert.Equal(
+            GpuAdmissionOutcome.AllowedSufficientMemory,
+            GpuAdmissionPolicy.Evaluate(
+                config,
+                requiresGpuVideoTranscode: true,
+                memory: GpuMemoryQueryResult.FromFreeMiB(1490),
+                jobBudgetMiB: budgetMiB));
+    }
+
+    [Fact]
+    public void ScaleBudgetMiB_RaisingThePercentageBuysMargin()
+    {
+        var config = EnabledConfig();
+        config.GpuVramBudgetPercent = 125;
+
+        Assert.Equal(1920, GpuAdmissionPolicy.ScaleBudgetMiB(1536, config));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-50)]
+    [InlineData(int.MinValue)]
+    public void ScaleBudgetMiB_PercentagesBelowTheFloorAreClamped(int percent)
+    {
+        // A stored configuration need not have come from this build's settings page.
+        var config = EnabledConfig();
+        config.GpuVramBudgetPercent = percent;
+
+        Assert.Equal(
+            1536 * GpuAdmissionPolicy.MinimumBudgetPercent / 100,
+            GpuAdmissionPolicy.ScaleBudgetMiB(1536, config));
+    }
+
+    [Fact]
+    public void ScaleBudgetMiB_PercentagesAboveTheCeilingAreClamped()
+    {
+        var config = EnabledConfig();
+        config.GpuVramBudgetPercent = int.MaxValue;
+
+        Assert.Equal(
+            1536 * GpuAdmissionPolicy.MaximumBudgetPercent / 100,
+            GpuAdmissionPolicy.ScaleBudgetMiB(1536, config));
+    }
+
+    [Fact]
+    public void ScaleBudgetMiB_AJobThatNeedsVramNeverScalesDownToFree()
+    {
+        var config = EnabledConfig();
+        config.GpuVramBudgetPercent = GpuAdmissionPolicy.MinimumBudgetPercent;
+
+        Assert.Equal(1, GpuAdmissionPolicy.ScaleBudgetMiB(1, config));
+        Assert.Equal(0, GpuAdmissionPolicy.ScaleBudgetMiB(0, config));
+    }
+
+    [Fact]
     public void Evaluate_GuardDisabled_AllowsWithoutNeedingAGpuReading()
     {
         var config = new PluginConfiguration { EnableGpuResourceGuard = false };

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
@@ -169,6 +169,82 @@ public class GpuResourceGuardTests
     }
 
     [Fact]
+    public async Task IsAdmittedAsync_TheReportedGladiatorRefusalIsAdmittedOnceTheBudgetPercentageIsLowered()
+    {
+        // 4K HDR10 tone-mapped job, model budget 1536 MiB, on a card sharing VRAM with an LLM:
+        // nvidia-smi reported 1490 MiB free, so the default budget refuses it by 46 MiB.
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+
+        var config = EnabledConfig();
+        Assert.False(await CreateGuard(config, FakeGpuMemoryProvider.WithFreeMiB(1490), messages)
+            .IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
+
+        config.GpuVramBudgetPercent = 90;
+
+        Assert.True(await CreateGuard(config, FakeGpuMemoryProvider.WithFreeMiB(1490), messages)
+            .IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_RaisingTheBudgetPercentageRefusesAJobTheModelBudgetWouldAdmit()
+    {
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+
+        var config = EnabledConfig();
+        config.GpuVramBudgetPercent = 150;
+
+        // 1536 MiB model budget, 2304 MiB demanded.
+        Assert.False(await CreateGuard(config, FakeGpuMemoryProvider.WithFreeMiB(2000), messages)
+            .IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
+    }
+
+    [Fact]
+    public void BuildRefusalReason_QuotesTheBudgetTheGuardActuallyDemanded()
+    {
+        var config = EnabledConfig();
+        config.GpuVramBudgetPercent = 90;
+        var guard = CreateGuard(config, FakeGpuMemoryProvider.WithFreeMiB(1490), new RecordingClientMessageService());
+
+        var reason = guard.BuildRefusalReason(HardwareTranscodeRequest());
+
+        Assert.Contains("1382 MiB", reason, StringComparison.Ordinal);
+        Assert.DoesNotContain("1536 MiB", reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task IsAdmittedAsync_ScaledBudgetsAlsoScaleTheInFlightReservation()
+    {
+        // Two 1536 MiB jobs at 50% demand 768 MiB each. The first must reserve the scaled figure,
+        // not the model figure, or the second is judged against a reservation nobody will allocate.
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+
+        var config = EnabledConfig();
+        config.GpuVramBudgetPercent = 50;
+        var guard = CreateGuard(config, FakeGpuMemoryProvider.WithFreeMiB(1536), messages);
+
+        var first = await guard.TryReserveAsync(
+            OutputPathRequest("/cache/transcodes/first.m3u8", "device-1"),
+            CancellationToken.None);
+        Assert.True(first.IsAdmitted);
+
+        var second = await guard.TryReserveAsync(
+            OutputPathRequest("/cache/transcodes/second.m3u8", "device-2"),
+            CancellationToken.None);
+
+        Assert.True(second.IsAdmitted);
+    }
+
+    private static GpuTranscodeRequest OutputPathRequest(string outputPath, string deviceId)
+    {
+        var request = HardwareTranscodeRequest(deviceId, deviceId);
+        request.OutputPath = outputPath;
+        return request;
+    }
+
+    [Fact]
     public async Task IsAdmittedAsync_InsufficientVramDeniesAndMessagesTheRequestingClientOnce()
     {
         var provider = FakeGpuMemoryProvider.WithFreeMiB(700);


### PR DESCRIPTION
## Problem

PR #29 removed `MinimumFreeGpuMemoryMiB` and replaced it with the automatic per-job budget, but did
not replace the knob. That left a conservative model, a hard 403, and no admin override — when the
model is pessimistic by a few dozen MiB, the only recourse is switching the guard off entirely.

Reported case, a card shared with an LLM server:

```
free VRAM 1490 MiB cannot fit conservative job budget 1536 MiB plus in-flight budget 0 MiB on GPU 0;
shape 3840x2160 10-bit hevc to 3840x2160 10-bit av1, CUDA tonemap True, metadata fallback False
```

The reading and the budget are both right. 1490 MiB is what `memory.free` reports once ~428 MiB of
driver-reserved memory is excluded, and 1536 MiB is the 4K/10-bit band (1024) plus the 4K tone-map
band (512) — the AV1 surcharge folded under it via `Math.Max`, as intended since #30. The calibration
table in `docs/HANDOFF-dynamic-vram.md` records this same shape at 1339 MiB in one snapshot and
~1496 MiB in another, so the refusal is marginal rather than wrong. There is simply no way to say so.

## Change

Adds `GpuVramBudgetPercent` (default 100, clamped 10–500), surfaced on the config page as
**VRAM budget (%)**. It scales the model's requirement before it is compared *and* before it is
reserved, so a tuned deployment cannot reserve one figure and be judged against another. The refusal
text quotes the demanded figure; the refusal log prints both the model budget and the percentage in
force, and names the setting.

The `GPU VRAM calibration` line deliberately keeps reporting the **unscaled** model budget next to
the observed maximum — that is the calibration record and has to stay comparable across deployments
running different percentages.

Default 100 means upgrading changes no behaviour.

## Notes

- Clamping lives in `GpuAdmissionPolicy`, not the settings page: a stored configuration is not
  necessarily one this build's UI wrote.
- A job that needs VRAM never scales to a 0 MiB requirement.
- Under-budgeting is what CUDA reports as OOM (FFmpeg exit 187), so both the UI description and the
  README point admins at the calibration log and tell them to lower it in small steps.

## Testing

- `dotnet build` clean, `dotnet format whitespace` and `dotnet format style --severity warn` clean.
- 179/179 tests pass, 11 new: percentage scaling and clamping, the reported 1490/1536 case admitting
  at 90%, a raised percentage refusing a job the model budget would admit, the refusal reason quoting
  the demanded budget, and in-flight reservations scaling with the decision.
