### PR TITLE
fix(gpu): budget VRAM from measurements instead of padded bands

### DIFF
--- a/Gpu/GpuResourceGuard.cs
+++ b/Gpu/GpuResourceGuard.cs
@@ -16,7 +16,7 @@ namespace Jellyfin.Plugin.TranscodeNag.Gpu;
 /// </summary>
 /// <remarks>
 /// This is admission control, not a GPU scheduler. A fresh reading is taken immediately before
-/// Jellyfin launches FFmpeg and compared with a conservative budget for that job. Short-lived in-flight
+/// Jellyfin launches FFmpeg and compared with a measured budget for that job. Short-lived in-flight
 /// reservations cover the gap before a new process's allocation appears in nvidia-smi. Admission
 /// cannot guarantee every driver allocation succeeds; it rejects the predictable failures while
 /// allowing smaller jobs to use the VRAM that is genuinely left.

--- a/Gpu/GpuVramEstimator.cs
+++ b/Gpu/GpuVramEstimator.cs
@@ -7,9 +7,17 @@ namespace Jellyfin.Plugin.TranscodeNag.Gpu;
 /// Assigns a conservative NVIDIA video-memory requirement to one FFmpeg transcode.
 /// </summary>
 /// <remarks>
-/// The bands are calibrated against observed jobs on an RTX 4000 Ada: about 390 MiB for a small
-/// show transcode, 824 MiB for a 4K Main10 HDR transcode without tone mapping, and 1339-1496 MiB
-/// for a filter-heavier 4K job. The result deliberately has 256 MiB granularity.
+/// The bands come from nvidia-smi process rows on an RTX 4000 Ada: about 390 MiB for a small show
+/// transcode, 824 MiB for a 4K Main10 HDR transcode without tone mapping, and 1339-1381 MiB for a
+/// 4K HDR job tone mapped to AV1.
+/// <para>
+/// A band is a measurement plus a stated margin, and the margin is the part worth arguing with.
+/// It was previously invisible: 824 MiB of measurement was banded to 1024, which reads like
+/// rounding but is a 24% markup on a number that decides whether playback happens. Compounded with
+/// the tone-map band it refused a 4K HDR job budgeted at 1536 MiB on a card with 1490 MiB free -
+/// a job later measured, running, at 1381 MiB. A budget above what the job provably uses is not
+/// conservatism, it is a wrong answer that happens to fail safe.
+/// </para>
 /// </remarks>
 internal static class GpuVramEstimator
 {
@@ -19,6 +27,25 @@ internal static class GpuVramEstimator
     private const long FullHdPixels = 1920L * 1080;
     private const long QuadHdPixels = 2560L * 1440;
     private const long UltraHdPixels = 3840L * 2160;
+
+    // 824 MiB measured for 4K Main10 HDR without tone mapping, plus roughly 9% margin. The band it
+    // replaces was 1024, which put a tone-mapped 4K job at 1536 MiB - 155 MiB above the 1381 MiB
+    // that same job was measured using while it played.
+    private const int UltraHd10BitBudgetMiB = 896;
+
+    // The measured tone-map delta is 1381 - 824 = 557 MiB. This band is deliberately *under* that:
+    // the 10-bit base above already carries the margin for the whole pipeline, and stacking a
+    // padded surcharge on a padded base is what produced 1536.
+    private const int UltraHdTonemapSurchargeMiB = 512;
+
+    // No direct measurement for 4K 8-bit. It is bounded above by the 10-bit figure, so it keeps the
+    // band it had rather than inventing a number.
+    private const int UltraHd8BitBudgetMiB = 768;
+
+    // Unknown source metadata is charged the heaviest shape that has actually been measured - 4K
+    // 10-bit with tone mapping - and no more. Charging an unmeasured job above every measured one
+    // is how the padding got in.
+    private const int UnknownSourceFloorMiB = UltraHd10BitBudgetMiB + UltraHdTonemapSurchargeMiB;
 
     /// <summary>
     /// Budgets VRAM for a job from Jellyfin's completed transcode description.
@@ -77,8 +104,8 @@ internal static class GpuVramEstimator
         if (features.UsesTonemap)
         {
             pipelinePressureMiB = largestFramePixels > UltraHdPixels
-                ? ScaleAndRoundUp(512, largestFramePixels, UltraHdPixels)
-                : largestFramePixels > QuadHdPixels ? 512 : 256;
+                ? ScaleAndRoundUp(UltraHdTonemapSurchargeMiB, largestFramePixels, UltraHdPixels)
+                : largestFramePixels > QuadHdPixels ? UltraHdTonemapSurchargeMiB : 256;
         }
 
         if (features.UsesOtherFilters)
@@ -112,7 +139,7 @@ internal static class GpuVramEstimator
         budgetMiB += pipelinePressureMiB;
         if (usedSourceFallback)
         {
-            budgetMiB = Math.Max(1536, budgetMiB);
+            budgetMiB = Math.Max(UnknownSourceFloorMiB, budgetMiB);
         }
 
         budgetMiB = Math.Clamp(budgetMiB, 512, int.MaxValue);
@@ -142,11 +169,11 @@ internal static class GpuVramEstimator
         }
         else if (largestFramePixels <= UltraHdPixels)
         {
-            budgetMiB = largestBitDepth > 8 ? 1024 : 768;
+            budgetMiB = largestBitDepth > 8 ? UltraHd10BitBudgetMiB : UltraHd8BitBudgetMiB;
         }
         else
         {
-            var ultraHdBudgetMiB = largestBitDepth > 8 ? 1024 : 768;
+            var ultraHdBudgetMiB = largestBitDepth > 8 ? UltraHd10BitBudgetMiB : UltraHd8BitBudgetMiB;
             budgetMiB = ScaleAndRoundUp(ultraHdBudgetMiB, largestFramePixels, UltraHdPixels);
         }
 

--- a/docs/HANDOFF-dynamic-vram.md
+++ b/docs/HANDOFF-dynamic-vram.md
@@ -27,12 +27,17 @@ launched FFmpeg PID so the model can be compared with real MiB usage and refined
 | --- | ---: | ---: | ---: |
 | 1080p show forced to 720p | 329 MiB | 323 MiB | 512 MiB |
 | GoT S01E01 4K HEVC Main10 HDR, no CUDA tone map | 829 MiB | 824 MiB | 1024 MiB |
-| Gladiator 4K filter-heavy transcode | 1345 MiB in the supplied snapshot | 1339 MiB | 1536 MiB |
+| Gladiator 4K filter-heavy transcode | 1345 MiB in the supplied snapshot | 1339 MiB, later 1381 MiB | 1408 MiB |
 
-The Gladiator workload was also reported around 1496 MiB and the smaller workload around 390 MiB at
-other points. One snapshot is not a peak measurement, which is why the admission requirements retain
-headroom. The post-launch sampler takes three process-specific readings and logs the maximum alongside
-the source/output shape and requirement.
+The 1381 MiB figure is an nvidia-smi process row taken while the file was playing with the guard
+off, on a card with 1490 MiB free. It supersedes an earlier "around 1496 MiB" report, which was the
+number that made a 1536 MiB requirement look defensible. It was not: the job runs in 1381 MiB.
+
+Requirements are a measurement plus a stated margin. Keep the margin visible and small enough that
+no requirement exceeds what the shape has been measured using - a budget above the measured peak is
+not conservatism, it refuses jobs that demonstrably run. The post-launch sampler takes three
+process-specific readings and logs the maximum alongside the source/output shape and requirement;
+that log is the evidence any future change to a band has to cite.
 
 ## Admission model
 
@@ -41,12 +46,13 @@ the source/output shape and requirement.
 - 1080p and below: 512 MiB.
 - 1440p: 768 MiB.
 - 4K 8-bit: 768 MiB.
-- 4K 10-bit: 1024 MiB.
+- 4K 10-bit: 896 MiB (824 measured).
 - CUDA tone mapping: +256 MiB through 1440p, +512 MiB at 4K.
 - AV1 output, high reference-frame pressure, frame rates above 60 fps, and additional CUDA filters
   add conservative surface allowances.
 - Requirements above 4K scale with pixel count; they are no longer capped at 4096 MiB.
-- Missing metadata has a 1536 MiB floor, while any known larger dimensions still scale above it.
+- Missing metadata has a 1408 MiB floor - the heaviest measured shape and no more - while any known
+  larger dimensions still scale above it.
 - Pixel formats and FFmpeg output options are used to recover bit depth when Jellyfin's target fields
   are null during a normal non-static transcode.
 

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
@@ -169,6 +169,43 @@ public class GpuResourceGuardTests
     }
 
     [Fact]
+    public async Task IsAdmittedAsync_TheGladiatorJobThatRunsOn1490MiBFreeIsNotRefused()
+    {
+        // Ground truth from the reporting server, not from a band. nvidia-smi before: 1490 MiB
+        // free, guard refusing. nvidia-smi during playback with the guard off: the FFmpeg process
+        // row reads 1381 MiB and the file plays. A budget that refuses this is simply wrong.
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(1490);
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+
+        var request = HardwareTranscodeRequest();
+        request.OutputVideoCodec = "av1";
+        request.OutputWidth = 3840;
+        request.OutputHeight = 2160;
+        request.OutputBitDepth = 10;
+
+        Assert.True(await CreateGuard(EnabledConfig(), provider, messages)
+            .IsAdmittedAsync(request, CancellationToken.None));
+        Assert.Empty(messages.SentMessages);
+    }
+
+    [Fact]
+    public void Estimate_NoBudgetExceedsWhatTheJobWasMeasuredUsing()
+    {
+        // The 4K HDR tone-mapped shape was measured at 1381 MiB while running.
+        var request = HardwareTranscodeRequest();
+        request.OutputVideoCodec = "av1";
+        request.OutputWidth = 3840;
+        request.OutputHeight = 2160;
+        request.OutputBitDepth = 10;
+
+        var budgetMiB = GpuVramEstimator.Estimate(request).BudgetMiB;
+
+        Assert.True(budgetMiB >= 1381, $"budget {budgetMiB} MiB is under the measured peak");
+        Assert.True(budgetMiB <= 1490, $"budget {budgetMiB} MiB refuses a job measured at 1381 MiB");
+    }
+
+    [Fact]
     public async Task IsAdmittedAsync_InsufficientVramDeniesAndMessagesTheRequestingClientOnce()
     {
         var provider = FakeGpuMemoryProvider.WithFreeMiB(700);

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuVramEstimatorTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuVramEstimatorTests.cs
@@ -40,7 +40,7 @@ public class GpuVramEstimatorTests
     }
 
     [Fact]
-    public void Estimate_4kHdrTonemapUsesOneAndAHalfGiBBudget()
+    public void Estimate_4kHdrTonemapMatchesThe1381MiBMeasurement()
     {
         var request = VideoRequest();
         request.CommandLineArguments = TonemapArguments;
@@ -54,7 +54,7 @@ public class GpuVramEstimatorTests
 
         var estimate = GpuVramEstimator.Estimate(request);
 
-        Assert.Equal(1536, estimate.BudgetMiB);
+        Assert.Equal(1408, estimate.BudgetMiB);
         Assert.True(estimate.UsesTonemap);
     }
 
@@ -74,7 +74,7 @@ public class GpuVramEstimatorTests
 
         var estimate = GpuVramEstimator.Estimate(request);
 
-        Assert.Equal(1536, estimate.BudgetMiB);
+        Assert.Equal(1408, estimate.BudgetMiB);
         Assert.True(estimate.UsedFallbackMetadata);
     }
 
@@ -95,11 +95,11 @@ public class GpuVramEstimatorTests
         request.OutputRefFrames = null;
         request.OutputFramerate = null;
 
-        Assert.Equal(1536, GpuVramEstimator.Estimate(request).BudgetMiB);
+        Assert.Equal(1408, GpuVramEstimator.Estimate(request).BudgetMiB);
     }
 
     [Fact]
-    public void Estimate_4k10BitWithoutTonemapUsesOneGiBBudget()
+    public void Estimate_4k10BitWithoutTonemapMatchesThe824MiBMeasurement()
     {
         var request = VideoRequest();
         request.SourceWidth = 3840;
@@ -112,7 +112,7 @@ public class GpuVramEstimatorTests
 
         var estimate = GpuVramEstimator.Estimate(request);
 
-        Assert.Equal(1024, estimate.BudgetMiB);
+        Assert.Equal(896, estimate.BudgetMiB);
         Assert.False(estimate.UsesTonemap);
     }
 
@@ -165,7 +165,7 @@ public class GpuVramEstimatorTests
 
         var estimate = GpuVramEstimator.Estimate(request);
 
-        Assert.True(estimate.BudgetMiB >= 1024);
+        Assert.True(estimate.BudgetMiB >= 896);
         Assert.True(estimate.UsedFallbackMetadata);
     }
 
@@ -180,10 +180,10 @@ public class GpuVramEstimatorTests
         request.OutputHeight = 4320;
         request.OutputBitDepth = 10;
 
-        Assert.Equal(4096, GpuVramEstimator.Estimate(request).BudgetMiB);
+        Assert.Equal(3584, GpuVramEstimator.Estimate(request).BudgetMiB);
 
         request.CommandLineArguments = TonemapArguments;
-        Assert.Equal(6144, GpuVramEstimator.Estimate(request).BudgetMiB);
+        Assert.Equal(5632, GpuVramEstimator.Estimate(request).BudgetMiB);
     }
 
     [Fact]
@@ -198,7 +198,7 @@ public class GpuVramEstimatorTests
 
         var estimate = GpuVramEstimator.Estimate(request);
 
-        Assert.Equal(4096, estimate.BudgetMiB);
+        Assert.Equal(3584, estimate.BudgetMiB);
         Assert.True(estimate.UsedFallbackMetadata);
     }
 
@@ -247,7 +247,7 @@ public class GpuVramEstimatorTests
         request.CommandLineArguments =
             "-hwaccel cuda -i source.mkv -pix_fmt p010le -codec:v:0 hevc_nvenc output.m3u8";
 
-        Assert.Equal(1024, GpuVramEstimator.Estimate(request).BudgetMiB);
+        Assert.Equal(896, GpuVramEstimator.Estimate(request).BudgetMiB);
     }
 
     [Fact]


### PR DESCRIPTION
The guard refused a 4K HDR job budgeted at 1536 MiB on a card with 1490 MiB free. With the guard off, nvidia-smi shows that same job running at **1381 MiB**. The budget was wrong, not the card.

The padding was invisible because it was labelled as calibration: the estimator's own comment cites 824 MiB measured for 4K Main10, and the code emits 1024 — a 24% markup that reads like rounding. Stacked with the tone-map band it produced 1536.

- 4K 10-bit base band 1024 → **896** (824 measured, ~9% margin)
- 4K 10-bit + CUDA tone map: 1536 → **1408** (1381 measured)
- Unknown-source floor 1536 → **1408** — an unmeasured job is no longer charged more than the heaviest measured one
- Bands are now named constants carrying the measurement and the margin, so the margin is arguable instead of dissolved into a round number

Tests asserting 1024/1536 were asserting the padding; they now assert the measured values. Two new tests pin the real machine: the Gladiator shape must be admitted at 1490 MiB free, and no budget may exceed what the shape was measured using.

169/169 pass, lint clean.