### PR TITLE
refactor: resolve CodeQL missed-Where alerts in ResolveNagMessage

### DIFF
--- a/PlaybackMonitor.cs
+++ b/PlaybackMonitor.cs
@@ -321,20 +321,21 @@ public class PlaybackMonitor : IHostedService
 
         if (transcodeInfo != null && overrides != null && overrides.Length > 0 && config.AlertTranscodeReasons != null)
         {
-            foreach (var reasonName in config.AlertTranscodeReasons.Where(reasonName => !string.IsNullOrWhiteSpace(reasonName)))
+            var activeReasons = transcodeInfo.TranscodeReasons;
+            var matchedReasons = config.AlertTranscodeReasons
+                .Where(reasonName => !string.IsNullOrWhiteSpace(reasonName))
+                .Where(reasonName => Enum.TryParse<TranscodeReason>(reasonName, true, out var parsedReason)
+                    && (activeReasons & parsedReason) != 0);
+
+            foreach (var reasonName in matchedReasons)
             {
-                if (Enum.TryParse<TranscodeReason>(reasonName, true, out var parsedReason)
-                    && (transcodeInfo.TranscodeReasons & parsedReason) != 0)
+                var overrideEntry = overrides.FirstOrDefault(entry => entry != null
+                    && string.Equals(entry.ReasonName, reasonName, StringComparison.OrdinalIgnoreCase)
+                    && !string.IsNullOrWhiteSpace(entry.Message));
+
+                if (overrideEntry != null)
                 {
-                    foreach (var overrideEntry in overrides)
-                    {
-                        if (overrideEntry != null
-                            && string.Equals(overrideEntry.ReasonName, reasonName, StringComparison.OrdinalIgnoreCase)
-                            && !string.IsNullOrWhiteSpace(overrideEntry.Message))
-                        {
-                            return overrideEntry.Message;
-                        }
-                    }
+                    return overrideEntry.Message;
                 }
             }
         }


### PR DESCRIPTION
Closes the two open code scanning alerts, [#10](https://github.com/voc0der/jellyfin-transcode-nag/security/code-scanning/10) and [#12](https://github.com/voc0der/jellyfin-transcode-nag/security/code-scanning/12). Both are `cs/linq/missed-where` at severity **note** — readability only, no security or correctness impact — and both point at the same nested loop in `ResolveNagMessage`: the outer loop (alert #12) and the inner one (alert #10). Each wrapped its entire body in a filtering `if`, which is the pattern the rule detects.

`082561a` previously addressed part of this by adding `.Where(...)` for the blank-name check, but the bodies stayed `if`-wrapped, so both alerts survived.

## Change

- Outer loop: the reason-matching `if` moves into a second `.Where(...)`.
- Inner loop: collapses to `FirstOrDefault`, since it was only searching for the first override matching the current reason.
- `TranscodeReasons` is hoisted into a local, so the captured `transcodeInfo` doesn't need its null state re-proven inside the lambda (captured locals lose nullable flow state in closures).

Behaviour is unchanged: same iteration order, same first-match short-circuit, same `config.NagMessage` fallthrough. `ReasonMessageOverride` is a class, so the `FirstOrDefault` / `!= null` pairing is correct.

## Verification

- `dotnet build` — succeeded, 0 warnings, 0 errors.
- Test suite — 169/169 pass.

`ResolveNagMessage` is private and `PlaybackMonitor` needs full DI to construct, and the suite only tests public surfaces, so no direct unit test was added for it — the refactor is mechanical and behaviour-preserving.