### PR TITLE
refactor: drop the last loop from ResolveNagMessage

### DIFF
--- a/PlaybackMonitor.cs
+++ b/PlaybackMonitor.cs
@@ -319,28 +319,24 @@ public class PlaybackMonitor : IHostedService
         var transcodeInfo = session.TranscodingInfo;
         var overrides = config.ReasonMessageOverrides;
 
-        if (transcodeInfo != null && overrides != null && overrides.Length > 0 && config.AlertTranscodeReasons != null)
+        if (transcodeInfo == null || overrides == null || overrides.Length == 0 || config.AlertTranscodeReasons == null)
         {
-            var activeReasons = transcodeInfo.TranscodeReasons;
-            var matchedReasons = config.AlertTranscodeReasons
-                .Where(reasonName => !string.IsNullOrWhiteSpace(reasonName))
-                .Where(reasonName => Enum.TryParse<TranscodeReason>(reasonName, true, out var parsedReason)
-                    && (activeReasons & parsedReason) != 0);
-
-            foreach (var reasonName in matchedReasons)
-            {
-                var overrideEntry = overrides.FirstOrDefault(entry => entry != null
-                    && string.Equals(entry.ReasonName, reasonName, StringComparison.OrdinalIgnoreCase)
-                    && !string.IsNullOrWhiteSpace(entry.Message));
-
-                if (overrideEntry != null)
-                {
-                    return overrideEntry.Message;
-                }
-            }
+            return config.NagMessage;
         }
 
-        return config.NagMessage;
+        var activeReasons = transcodeInfo.TranscodeReasons;
+
+        // First override configured for an active reason wins; reason order sets the priority.
+        var overrideMatch = config.AlertTranscodeReasons
+            .Where(reasonName => !string.IsNullOrWhiteSpace(reasonName))
+            .Where(reasonName => Enum.TryParse<TranscodeReason>(reasonName, true, out var parsedReason)
+                && (activeReasons & parsedReason) != 0)
+            .SelectMany(reasonName => overrides.Where(entry => entry != null
+                && string.Equals(entry.ReasonName, reasonName, StringComparison.OrdinalIgnoreCase)
+                && !string.IsNullOrWhiteSpace(entry.Message)))
+            .FirstOrDefault();
+
+        return overrideMatch?.Message ?? config.NagMessage;
     }
 
     private async Task<bool> SendNagMessageAsync(SessionInfo session, Configuration.PluginConfiguration config)


### PR DESCRIPTION
Closes [alert #19](https://github.com/voc0der/jellyfin-transcode-nag/security/code-scanning/19) (`cs/linq/missed-select`, severity **note**).

This one is self-inflicted: #33 cleared the two `cs/linq/missed-where` alerts but left a `foreach` whose body opened by mapping the iteration variable straight to an override entry — the exact shape `cs/linq/missed-select` looks for. Two notes became one note, which isn't really a fix.

## Change

- `SelectMany` over the matching overrides, then `FirstOrDefault` — no `foreach` remains, so neither `missed-where` nor `missed-select` has anything to flag.
- Guard inverted to an early return, dropping a level of nesting.

Evaluation still short-circuits: `SelectMany` is lazy and `FirstOrDefault` stops at the first element, so it does no more work than the original nested loops did.

## Verification

- `dotnet build` — 0 warnings, 0 errors.
- Test suite — 169/169 pass.
- Differential check against the **original** pre-#33 nested-loop implementation over 400,000 randomised inputs — null reasons, null/empty arrays, null entries, blank names, blank messages, case-insensitive matches, unparseable reason names, and priority ordering — **0 divergences**.

The differential run matters because `ResolveNagMessage` has no direct unit test and this is its second rewrite in two days. It's private, and `PlaybackMonitor` needs full DI to construct, so the suite can't reach it as-is. If this keeps attracting alerts, the durable fix is to move the resolution logic to `TranscodeNagRules` — which is public, already has real coverage, and is where the rest of this decision logic lives. Happy to do that as a follow-up if you want it.