### PR TITLE
feat(messaging): add opt-in sticky messages for clients that dismiss popups

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -35,6 +35,8 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public string NagMessage { get; set; } = "Your client is transcoding because it doesn't support the video format. Consider using a client that supports direct play (like mpv, VLC, or Jellyfin Media Player) to reduce server load and improve quality!";
 
+    public bool UseStickyPlaybackMessages { get; set; } = false;
+
     public int MessageTimeoutMs { get; set; } = 10000;
 
     public bool EnableLogging { get; set; } = true;
@@ -51,6 +53,8 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public string LoginNagMessage { get; set; } = "You've transcoded {{transcodes}} videos in the last {{timewindow}} due to unsupported formats. Consider switching to mpv, VLC, or Jellyfin Media Player to improve quality and reduce server load!";
 
+    public bool UseStickyLoginNagMessages { get; set; } = false;
+
     public string[] AlertTranscodeReasons { get; set; } = GetDefaultAlertTranscodeReasons();
 
     public ReasonMessageOverride[] ReasonMessageOverrides { get; set; } = Array.Empty<ReasonMessageOverride>();
@@ -64,6 +68,8 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool EnableMotd { get; set; } = false;
 
     public string MotdMessage { get; set; } = "Welcome back! Check the announcements channel for server news and planned maintenance.";
+
+    public bool UseStickyMotdMessages { get; set; } = false;
 
     public string[] MotdExcludedUserIds { get; set; } = Array.Empty<string>();
 
@@ -102,6 +108,8 @@ public class PluginConfiguration : BasePluginConfiguration
     /// Deliberately free of VRAM figures, encoder names, and other server-side detail.
     /// </summary>
     public string GpuGuardDeniedMessage { get; set; } = "GPU resources are currently busy. Please try again later or use Direct Play.";
+
+    public bool UseStickyGpuGuardMessages { get; set; } = false;
 }
 
 public class ReasonMessageOverride

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -15,6 +15,14 @@
                         <div class="fieldDescription">Message to display to users who are transcoding due to unsupported formats.</div>
                     </div>
 
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input type="checkbox" is="emby-checkbox" id="chkUseStickyPlaybackMessages" name="chkUseStickyPlaybackMessages" />
+                            <span>Sticky Messages</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">Sends each playback warning three times, 3 seconds apart, with a 4-second timeout to improve visibility on clients that dismiss Jellyfin messages quickly.</div>
+                    </div>
+
                     <div class="inputContainer">
                         <label class="inputLabel inputLabelUnfocused" for="txtDelaySeconds">Delay Before Check (seconds):</label>
                         <input type="number" id="txtDelaySeconds" name="txtDelaySeconds" min="1" max="30" class="emby-input" />
@@ -24,7 +32,7 @@
                     <div class="inputContainer">
                         <label class="inputLabel inputLabelUnfocused" for="txtMessageTimeout">Message Timeout (ms):</label>
                         <input type="number" id="txtMessageTimeout" name="txtMessageTimeout" min="3000" max="30000" class="emby-input" />
-                        <div class="fieldDescription">How long the nag message stays visible (3000-30000 ms).</div>
+                        <div class="fieldDescription">How long non-sticky messages stay visible (3000-30000 ms). Sticky messages use their fixed 4-second timeout.</div>
                     </div>
 
                     <div class="checkboxContainer checkboxContainer-withDescription">
@@ -108,6 +116,14 @@
                         <div class="fieldDescription">Message shown on login. Use {{transcodes}} for transcode count and {{timewindow}} for time window.</div>
                     </div>
 
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input type="checkbox" is="emby-checkbox" id="chkUseStickyLoginNagMessages" name="chkUseStickyLoginNagMessages" />
+                            <span>Sticky Messages</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">Sends each login warning three times, 3 seconds apart, with a 4-second timeout to improve visibility on clients that dismiss Jellyfin messages quickly.</div>
+                    </div>
+
                     <h2>User Exclusions</h2>
 
                     <div class="fieldDescription" style="margin-bottom: 10px;">
@@ -151,7 +167,15 @@
                         <div class="selectContainer">
                             <label class="inputLabel inputLabelUnfocused" for="txtMotdMessage">MOTD Message:</label>
                             <textarea id="txtMotdMessage" name="txtMotdMessage" rows="4" class="emby-input"></textarea>
-                            <div class="fieldDescription">Message shown at login. Uses the same message timeout as nag messages.</div>
+                            <div class="fieldDescription">Message shown at login. Non-sticky MOTD messages use the shared message timeout.</div>
+                        </div>
+
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label>
+                                <input type="checkbox" is="emby-checkbox" id="chkUseStickyMotdMessages" name="chkUseStickyMotdMessages" />
+                                <span>Sticky Messages</span>
+                            </label>
+                            <div class="fieldDescription checkboxFieldDescription">Sends the MOTD three times, 3 seconds apart, with a 4-second timeout to improve visibility on clients that dismiss Jellyfin messages quickly.</div>
                         </div>
 
                         <div class="fieldDescription" style="margin-bottom: 10px;">
@@ -224,6 +248,14 @@
                             <label class="inputLabel inputLabelUnfocused" for="txtGpuGuardDeniedMessage">Refusal Message:</label>
                             <textarea id="txtGpuGuardDeniedMessage" name="txtGpuGuardDeniedMessage" rows="3" class="emby-input"></textarea>
                             <div class="fieldDescription">Keep this free of server detail. VRAM figures, encoder names, and FFmpeg errors belong in the server log.</div>
+                        </div>
+
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label>
+                                <input type="checkbox" is="emby-checkbox" id="chkUseStickyGpuGuardMessages" name="chkUseStickyGpuGuardMessages" />
+                                <span>Sticky Messages</span>
+                            </label>
+                            <div class="fieldDescription checkboxFieldDescription">Sends each refusal notice three times, 3 seconds apart, with a 4-second timeout to improve visibility on clients that dismiss Jellyfin messages quickly.</div>
                         </div>
                     </div>
 
@@ -931,6 +963,7 @@
                 GpuGuardSection.init();
                 ApiClient.getPluginConfiguration(TranscodeNagConfig.pluginId).then(function (config) {
                     document.getElementById('txtNagMessage').value = config.NagMessage || '';
+                    document.getElementById('chkUseStickyPlaybackMessages').checked = config.UseStickyPlaybackMessages === true;
                     document.getElementById('txtDelaySeconds').value = config.DelaySeconds || 5;
                     document.getElementById('txtMessageTimeout').value = config.MessageTimeoutMs || 10000;
                     document.getElementById('chkEnableLogging').checked = config.EnableLogging || false;
@@ -941,8 +974,10 @@
                     document.getElementById('txtLoginNagThreshold').value = config.LoginNagThreshold || 5;
                     document.getElementById('selectLoginNagTimeWindow').value = config.LoginNagTimeWindow || 'Week';
                     document.getElementById('txtLoginNagMessage').value = config.LoginNagMessage || '';
+                    document.getElementById('chkUseStickyLoginNagMessages').checked = config.UseStickyLoginNagMessages === true;
                     document.getElementById('chkEnableMotd').checked = config.EnableMotd === true;
                     document.getElementById('txtMotdMessage').value = config.MotdMessage || '';
+                    document.getElementById('chkUseStickyMotdMessages').checked = config.UseStickyMotdMessages === true;
                     document.getElementById('txtMotdIncludedClientPatterns').value = ClientPatternEditor.formatPatterns(config.MotdIncludedClientPatterns);
                     document.getElementById('txtMotdExcludedClientPatterns').value = ClientPatternEditor.formatPatterns(config.MotdExcludedClientPatterns);
                     document.getElementById('chkEnableGpuResourceGuard').checked = config.EnableGpuResourceGuard === true;
@@ -951,6 +986,7 @@
                     document.getElementById('txtNvidiaSmiPath').value = config.NvidiaSmiPath || '';
                     document.getElementById('txtGpuGuardDeniedHeader').value = config.GpuGuardDeniedHeader || '';
                     document.getElementById('txtGpuGuardDeniedMessage').value = config.GpuGuardDeniedMessage || '';
+                    document.getElementById('chkUseStickyGpuGuardMessages').checked = config.UseStickyGpuGuardMessages === true;
                     MotdSection.updateVisibility();
                     GpuGuardSection.updateVisibility();
                     ReasonSelector.render(config.AlertTranscodeReasons, config.ReasonMessageOverrides);
@@ -966,6 +1002,7 @@
 
                 ApiClient.getPluginConfiguration(TranscodeNagConfig.pluginId).then(function (config) {
                     config.NagMessage = document.getElementById('txtNagMessage').value;
+                    config.UseStickyPlaybackMessages = document.getElementById('chkUseStickyPlaybackMessages').checked;
                     config.DelaySeconds = parseInt(document.getElementById('txtDelaySeconds').value);
                     config.MessageTimeoutMs = parseInt(document.getElementById('txtMessageTimeout').value);
                     config.EnableLogging = document.getElementById('chkEnableLogging').checked;
@@ -976,8 +1013,10 @@
                     config.LoginNagThreshold = parseInt(document.getElementById('txtLoginNagThreshold').value);
                     config.LoginNagTimeWindow = document.getElementById('selectLoginNagTimeWindow').value;
                     config.LoginNagMessage = document.getElementById('txtLoginNagMessage').value;
+                    config.UseStickyLoginNagMessages = document.getElementById('chkUseStickyLoginNagMessages').checked;
                     config.EnableMotd = document.getElementById('chkEnableMotd').checked;
                     config.MotdMessage = document.getElementById('txtMotdMessage').value;
+                    config.UseStickyMotdMessages = document.getElementById('chkUseStickyMotdMessages').checked;
                     config.MotdIncludedClientPatterns = ClientPatternEditor.splitPatterns(document.getElementById('txtMotdIncludedClientPatterns').value);
                     config.MotdExcludedClientPatterns = ClientPatternEditor.splitPatterns(document.getElementById('txtMotdExcludedClientPatterns').value);
                     config.EnableGpuResourceGuard = document.getElementById('chkEnableGpuResourceGuard').checked;
@@ -986,6 +1025,7 @@
                     config.NvidiaSmiPath = document.getElementById('txtNvidiaSmiPath').value.trim();
                     config.GpuGuardDeniedHeader = document.getElementById('txtGpuGuardDeniedHeader').value;
                     config.GpuGuardDeniedMessage = document.getElementById('txtGpuGuardDeniedMessage').value;
+                    config.UseStickyGpuGuardMessages = document.getElementById('chkUseStickyGpuGuardMessages').checked;
                     config.AlertTranscodeReasons = ReasonSelector.getSelectedReasonNames();
                     config.ReasonMessageOverrides = ReasonSelector.getReasonMessageOverrides();
 

--- a/Gpu/GpuResourceGuard.cs
+++ b/Gpu/GpuResourceGuard.cs
@@ -369,6 +369,7 @@ public sealed class GpuResourceGuard
                 Text = Fallback(config.GpuGuardDeniedMessage, DefaultDeniedMessage),
                 TimeoutMs = config.MessageTimeoutMs
             },
+            config.UseStickyGpuGuardMessages,
             "gpu guard denial",
             "Hardware transcode refused",
             config.EnableLogging,

--- a/Messaging/ClientMessageService.cs
+++ b/Messaging/ClientMessageService.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using MediaBrowser.Common.Extensions;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Session;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.TranscodeNag.Messaging;
@@ -13,18 +14,83 @@ namespace Jellyfin.Plugin.TranscodeNag.Messaging;
 /// <summary>
 /// The shared session-resolution and DisplayMessage plumbing used by every notification the plugin sends.
 /// </summary>
-public sealed class ClientMessageService : IClientMessageService
+public sealed class ClientMessageService : IClientMessageService, IDisposable, IAsyncDisposable
 {
-    private readonly ISessionManager _sessionManager;
+    private readonly Func<IEnumerable<SessionInfo>> _sessionsAccessor;
+    private readonly Func<string, MessageCommand, CancellationToken, Task> _commandSender;
+    private readonly Func<TimeSpan, CancellationToken, Task> _delay;
+    private readonly Dictionary<SessionInfo, SessionDeliveryState> _deliveryStates = new(ReferenceEqualityComparer.Instance);
+    private readonly HashSet<DeliveryRegistration> _activeDeliveries = new();
+    private readonly object _deliveryLock = new();
+    private readonly CancellationTokenRegistration _applicationStoppingRegistration;
+    private bool _stopping;
 
-    public ClientMessageService(ISessionManager sessionManager)
+    public ClientMessageService(
+        ISessionManager sessionManager,
+        IHostApplicationLifetime applicationLifetime)
     {
-        _sessionManager = sessionManager;
+        ArgumentNullException.ThrowIfNull(sessionManager);
+        ArgumentNullException.ThrowIfNull(applicationLifetime);
+
+        _sessionsAccessor = () => sessionManager.Sessions;
+        _commandSender = (sessionId, command, cancellationToken) => SendMessageCommandAsync(
+            sessionManager,
+            sessionId,
+            command,
+            cancellationToken);
+        _delay = Task.Delay;
+        _applicationStoppingRegistration = applicationLifetime.ApplicationStopping.Register(CancelAllPendingMessages);
     }
+
+    internal ClientMessageService(
+        Func<IEnumerable<SessionInfo>> sessionsAccessor,
+        Func<string, MessageCommand, CancellationToken, Task> commandSender,
+        Func<TimeSpan, CancellationToken, Task> delay,
+        CancellationToken applicationStopping = default)
+    {
+        _sessionsAccessor = sessionsAccessor ?? throw new ArgumentNullException(nameof(sessionsAccessor));
+        _commandSender = commandSender ?? throw new ArgumentNullException(nameof(commandSender));
+        _delay = delay ?? throw new ArgumentNullException(nameof(delay));
+        _applicationStoppingRegistration = applicationStopping.Register(CancelAllPendingMessages);
+    }
+
+    private static Task SendMessageCommandAsync(
+        ISessionManager sessionManager,
+        string sessionId,
+        MessageCommand command,
+        CancellationToken cancellationToken)
+        => sessionManager.SendMessageCommand(null, sessionId, command, cancellationToken);
 
     /// <inheritdoc />
     public SessionInfo? ResolveSession(string? deviceId, Guid userId, Guid itemId)
-        => SelectSession(_sessionManager.Sessions, deviceId, userId, itemId);
+        => SelectSession(_sessionsAccessor(), deviceId, userId, itemId);
+
+    /// <inheritdoc />
+    public void CancelPendingMessages(SessionInfo session, string? context = null)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        DeliveryRegistration? pending = null;
+        lock (_deliveryLock)
+        {
+            if (_deliveryStates.TryGetValue(session, out var state)
+                && (context == null
+                    || string.Equals(state.CurrentDelivery?.Context, context, StringComparison.Ordinal)))
+            {
+                pending = state.CurrentDelivery;
+                if (context == null)
+                {
+                    _deliveryStates.Remove(session);
+                }
+                else
+                {
+                    state.CurrentDelivery = null;
+                }
+            }
+        }
+
+        pending?.Cancel();
+    }
 
     /// <summary>
     /// The session-selection rules, separated from <see cref="ISessionManager"/> so they can be tested directly.
@@ -81,6 +147,7 @@ public sealed class ClientMessageService : IClientMessageService
     public async Task<bool> SendMessageAsync(
         SessionInfo session,
         MessageCommand command,
+        bool useStickyMessages,
         string context,
         string detail,
         bool enableLogging,
@@ -88,6 +155,7 @@ public sealed class ClientMessageService : IClientMessageService
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(logger);
 
         if (session.Id == null)
@@ -95,23 +163,51 @@ public sealed class ClientMessageService : IClientMessageService
             return false;
         }
 
-        LogMessageDeliveryDiagnostics(session, context, detail, enableLogging, logger);
-
-        // Jellyfin treats sending to an empty controller collection as a successful no-op.
-        // Do not report or persist that as a delivered message.
-        var (_, activeControllerCount, _) = GetSessionControllerStats(session);
-        if (activeControllerCount == 0)
+        if (!TryBeginDelivery(session, context, out var state, out var delivery))
         {
             return false;
         }
 
+        var commandToSend = useStickyMessages
+            ? new MessageCommand
+            {
+                Header = command.Header,
+                Text = command.Text,
+                TimeoutMs = MessageDeliveryPolicy.StickyMessageTimeoutMs
+            }
+            : command;
+        var gateEntered = false;
+        var refreshOwnsDelivery = false;
+
         try
         {
-            await _sessionManager.SendMessageCommand(
-                null,
+            using var initialSendCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                cancellationToken,
+                delivery.CancellationToken);
+
+            await state.SendGate.WaitAsync(initialSendCancellation.Token).ConfigureAwait(false);
+            gateEntered = true;
+
+            // A newer message can supersede this one while it is waiting behind another send.
+            // In that case, never let the older initial command overtake the newer delivery.
+            if (!IsCurrentDelivery(session, state, delivery))
+            {
+                return false;
+            }
+
+            LogMessageDeliveryDiagnostics(session, context, detail, enableLogging, logger);
+
+            // Jellyfin treats sending to an empty controller collection as a successful no-op.
+            // Do not report or persist that as a delivered message.
+            if (GetSessionControllerStats(session).ActiveControllerCount == 0)
+            {
+                return false;
+            }
+
+            await _commandSender(
                 session.Id,
-                command,
-                cancellationToken).ConfigureAwait(false);
+                commandToSend,
+                initialSendCancellation.Token).ConfigureAwait(false);
 
             if (enableLogging)
             {
@@ -119,6 +215,18 @@ public sealed class ClientMessageService : IClientMessageService
                     "Completed {Context} message send to session {SessionId}",
                     context,
                     session.Id);
+            }
+
+            if (useStickyMessages)
+            {
+                refreshOwnsDelivery = TryStartStickyRefreshes(
+                    session,
+                    state,
+                    delivery,
+                    commandToSend,
+                    context,
+                    enableLogging,
+                    logger);
             }
 
             return true;
@@ -137,14 +245,340 @@ public sealed class ClientMessageService : IClientMessageService
         }
         catch (OperationCanceledException ex)
         {
-            logger.LogError(ex, "Error sending {Context} message to session {SessionId}", context, session.Id);
+            if (delivery.CancellationToken.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+            {
+                if (enableLogging)
+                {
+                    logger.LogDebug(
+                        ex,
+                        "Canceled superseded {Context} message delivery to session {SessionId}",
+                        context,
+                        session.Id);
+                }
+            }
+            else
+            {
+                logger.LogError(ex, "Error sending {Context} message to session {SessionId}", context, session.Id);
+            }
         }
         catch (ArgumentException ex)
         {
             logger.LogError(ex, "Error sending {Context} message to session {SessionId}", context, session.Id);
         }
 
+        finally
+        {
+            if (gateEntered)
+            {
+                state.SendGate.Release();
+            }
+
+            if (!refreshOwnsDelivery)
+            {
+                CompleteDelivery(session, state, delivery);
+            }
+        }
+
         return false;
+    }
+
+    private bool TryStartStickyRefreshes(
+        SessionInfo session,
+        SessionDeliveryState state,
+        DeliveryRegistration delivery,
+        MessageCommand command,
+        string context,
+        bool enableLogging,
+        ILogger logger)
+    {
+        if (!IsCurrentDelivery(session, state, delivery))
+        {
+            return false;
+        }
+
+        // The first delivery determines SendMessageAsync's result. Refreshes remain asynchronous
+        // so a GPU refusal does not hold its HTTP response open for the visibility window.
+        _ = RepeatStickyMessageAsync(session, state, delivery, command, context, enableLogging, logger);
+        return true;
+    }
+
+    private async Task RepeatStickyMessageAsync(
+        SessionInfo session,
+        SessionDeliveryState state,
+        DeliveryRegistration delivery,
+        MessageCommand command,
+        string context,
+        bool enableLogging,
+        ILogger logger)
+    {
+        try
+        {
+            var secondSend = SendStickyRefreshAfterDelayAsync(
+                session,
+                state,
+                delivery,
+                command,
+                context,
+                2,
+                enableLogging,
+                logger);
+            var thirdSend = SendStickyRefreshAfterDelayAsync(
+                session,
+                state,
+                delivery,
+                command,
+                context,
+                3,
+                enableLogging,
+                logger);
+
+            await Task.WhenAll(secondSend, thirdSend).ConfigureAwait(false);
+        }
+        finally
+        {
+            CompleteDelivery(session, state, delivery);
+        }
+    }
+
+    private async Task SendStickyRefreshAfterDelayAsync(
+        SessionInfo session,
+        SessionDeliveryState state,
+        DeliveryRegistration delivery,
+        MessageCommand command,
+        string context,
+        int sendNumber,
+        bool enableLogging,
+        ILogger logger)
+    {
+        var gateEntered = false;
+        try
+        {
+            await _delay(
+                MessageDeliveryPolicy.GetStickyRefreshDelay(sendNumber),
+                delivery.CancellationToken).ConfigureAwait(false);
+
+            await state.SendGate.WaitAsync(delivery.CancellationToken).ConfigureAwait(false);
+            gateEntered = true;
+
+            if (!IsCurrentDelivery(session, state, delivery)
+                || !IsSameLiveSession(session)
+                || session.Id == null
+                || GetSessionControllerStats(session).ActiveControllerCount == 0)
+            {
+                if (enableLogging && !delivery.CancellationToken.IsCancellationRequested)
+                {
+                    logger.LogInformation(
+                        "Stopped refreshing sticky {Context} message because session {SessionId} is no longer the same live session with an active controller",
+                        context,
+                        session.Id ?? "Unknown");
+                }
+
+                return;
+            }
+
+            await _commandSender(session.Id, command, delivery.CancellationToken).ConfigureAwait(false);
+
+            if (enableLogging)
+            {
+                logger.LogInformation(
+                    "Completed sticky {Context} message refresh {SendNumber} of {SendCount} to session {SessionId}",
+                    context,
+                    sendNumber,
+                    MessageDeliveryPolicy.StickyMessageSendCount,
+                    session.Id);
+            }
+        }
+        catch (OperationCanceledException) when (delivery.CancellationToken.IsCancellationRequested)
+        {
+            // A newer message, session end, or host shutdown superseded this refresh.
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            // Each refresh owns its error boundary, so a transient failure at t=3 does not
+            // suppress the final compatibility attempt at t=6.
+            logger.LogError(
+                ex,
+                "Error sending sticky {Context} message refresh {SendNumber} of {SendCount} to session {SessionId}",
+                context,
+                sendNumber,
+                MessageDeliveryPolicy.StickyMessageSendCount,
+                session.Id);
+        }
+        finally
+        {
+            if (gateEntered)
+            {
+                state.SendGate.Release();
+            }
+        }
+    }
+
+    private bool TryBeginDelivery(
+        SessionInfo session,
+        string context,
+        out SessionDeliveryState state,
+        out DeliveryRegistration delivery)
+    {
+        DeliveryRegistration? superseded = null;
+        lock (_deliveryLock)
+        {
+            if (_stopping)
+            {
+                state = null!;
+                delivery = null!;
+                return false;
+            }
+
+            if (!_deliveryStates.TryGetValue(session, out state!))
+            {
+                state = new SessionDeliveryState();
+                _deliveryStates.Add(session, state);
+            }
+
+            superseded = state.CurrentDelivery;
+
+            delivery = new DeliveryRegistration(context);
+            state.CurrentDelivery = delivery;
+            _activeDeliveries.Add(delivery);
+        }
+
+        superseded?.Cancel();
+        return true;
+    }
+
+    private bool IsCurrentDelivery(
+        SessionInfo session,
+        SessionDeliveryState state,
+        DeliveryRegistration delivery)
+    {
+        lock (_deliveryLock)
+        {
+            return !_stopping
+                && _deliveryStates.TryGetValue(session, out var currentState)
+                && ReferenceEquals(currentState, state)
+                && ReferenceEquals(state.CurrentDelivery, delivery);
+        }
+    }
+
+    private bool IsSameLiveSession(SessionInfo session)
+        => _sessionsAccessor().Any(candidate => ReferenceEquals(candidate, session));
+
+    private void CompleteDelivery(
+        SessionInfo session,
+        SessionDeliveryState state,
+        DeliveryRegistration delivery)
+    {
+        lock (_deliveryLock)
+        {
+            _activeDeliveries.Remove(delivery);
+            if (_deliveryStates.TryGetValue(session, out var currentState)
+                && ReferenceEquals(currentState, state)
+                && ReferenceEquals(state.CurrentDelivery, delivery))
+            {
+                state.CurrentDelivery = null;
+            }
+        }
+
+        delivery.Complete();
+    }
+
+    private void CancelAllPendingMessages()
+    {
+        var pending = PrepareToStop();
+        foreach (var delivery in pending)
+        {
+            delivery.Cancel();
+        }
+    }
+
+    private List<DeliveryRegistration> PrepareToStop()
+    {
+        lock (_deliveryLock)
+        {
+            _stopping = true;
+
+            var pending = _activeDeliveries.ToList();
+            _deliveryStates.Clear();
+            return pending;
+        }
+    }
+
+    internal Task WaitForPendingMessagesAsync()
+    {
+        lock (_deliveryLock)
+        {
+            return Task.WhenAll(_activeDeliveries.Select(delivery => delivery.Completion));
+        }
+    }
+
+    public void Dispose()
+    {
+        var pending = PrepareToStop();
+        foreach (var delivery in pending)
+        {
+            delivery.Cancel();
+        }
+
+        _applicationStoppingRegistration.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        var pending = PrepareToStop();
+        foreach (var delivery in pending)
+        {
+            delivery.Cancel();
+        }
+
+        await Task.WhenAll(pending.Select(delivery => delivery.Completion)).ConfigureAwait(false);
+        _applicationStoppingRegistration.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private sealed class SessionDeliveryState
+    {
+        internal SemaphoreSlim SendGate { get; } = new(1, 1);
+
+        internal DeliveryRegistration? CurrentDelivery { get; set; }
+    }
+
+    private sealed class DeliveryRegistration
+    {
+        // Cancellation can be requested concurrently by supersession, session end, and host
+        // shutdown. This source is not linked to a long-lived token and no WaitHandle is created,
+        // so letting it become collectible avoids racing Dispose against Cancel.
+        private readonly CancellationTokenSource _cancellation = new();
+        private readonly TaskCompletionSource _completion = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal DeliveryRegistration(string context)
+        {
+            Context = context;
+        }
+
+        internal string Context { get; }
+
+        internal CancellationToken CancellationToken => _cancellation.Token;
+
+        internal Task Completion => _completion.Task;
+
+        internal void Cancel()
+        {
+            try
+            {
+                _cancellation.Cancel();
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                // Cancellation callbacks are third-party code. A broken callback must not stop
+                // session cleanup, supersession, or host shutdown from canceling other deliveries.
+            }
+        }
+
+        internal void Complete()
+        {
+            _completion.TrySetResult();
+        }
     }
 
     private static bool SessionBelongsToUser(SessionInfo session, Guid userId)

--- a/Messaging/IClientMessageService.cs
+++ b/Messaging/IClientMessageService.cs
@@ -27,10 +27,18 @@ public interface IClientMessageService
     SessionInfo? ResolveSession(string? deviceId, Guid userId, Guid itemId);
 
     /// <summary>
+    /// Cancels pending message delivery for a session, optionally only when its context matches.
+    /// </summary>
+    /// <param name="session">The session whose pending delivery should stop.</param>
+    /// <param name="context">Optional delivery context to match; null cancels any pending message.</param>
+    void CancelPendingMessages(SessionInfo session, string? context = null);
+
+    /// <summary>
     /// Sends a message command to one session, logging the same delivery diagnostics for every caller.
     /// </summary>
     /// <param name="session">Target session.</param>
     /// <param name="command">The message to display.</param>
+    /// <param name="useStickyMessages">Whether to refresh the message for clients that dismiss it early.</param>
     /// <param name="context">Short label for logs, for example "playback nag".</param>
     /// <param name="detail">Extra log detail for this specific send.</param>
     /// <param name="enableLogging">Whether informational delivery logging is switched on.</param>
@@ -40,6 +48,7 @@ public interface IClientMessageService
     Task<bool> SendMessageAsync(
         SessionInfo session,
         MessageCommand command,
+        bool useStickyMessages,
         string context,
         string detail,
         bool enableLogging,

--- a/Messaging/MessageDeliveryPolicy.cs
+++ b/Messaging/MessageDeliveryPolicy.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Jellyfin.Plugin.TranscodeNag.Messaging;
+
+/// <summary>
+/// Defines the fixed compatibility behavior used by opt-in sticky messages.
+/// </summary>
+internal static class MessageDeliveryPolicy
+{
+    internal const int StickyMessageTimeoutMs = 4000;
+    internal const int StickyMessageSendCount = 3;
+    internal const int StickyMessageIntervalMs = 3000;
+
+    internal static TimeSpan GetStickyRefreshDelay(int sendNumber)
+    {
+        if (sendNumber < 2 || sendNumber > StickyMessageSendCount)
+        {
+            throw new ArgumentOutOfRangeException(nameof(sendNumber));
+        }
+
+        return TimeSpan.FromMilliseconds((sendNumber - 1) * StickyMessageIntervalMs);
+    }
+
+    internal static int GetEffectiveVisibilityDurationMs(bool useStickyMessages, int configuredTimeoutMs)
+    {
+        if (!useStickyMessages)
+        {
+            return configuredTimeoutMs;
+        }
+
+        return StickyMessageTimeoutMs
+            + ((StickyMessageSendCount - 1) * StickyMessageIntervalMs);
+    }
+}

--- a/Messaging/MessageDeliveryPolicy.cs
+++ b/Messaging/MessageDeliveryPolicy.cs
@@ -18,7 +18,9 @@ internal static class MessageDeliveryPolicy
             throw new ArgumentOutOfRangeException(nameof(sendNumber));
         }
 
-        return TimeSpan.FromMilliseconds((sendNumber - 1) * StickyMessageIntervalMs);
+        // Widen before multiplying so the offset is computed in double rather than
+        // overflowing int and then being converted (cs/loss-of-precision).
+        return TimeSpan.FromMilliseconds((sendNumber - 1) * (double)StickyMessageIntervalMs);
     }
 
     internal static int GetEffectiveVisibilityDurationMs(bool useStickyMessages, int configuredTimeoutMs)

--- a/PlaybackMonitor.cs
+++ b/PlaybackMonitor.cs
@@ -18,6 +18,8 @@ namespace Jellyfin.Plugin.TranscodeNag;
 
 public class PlaybackMonitor : IHostedService
 {
+    private const string PlaybackNagMessageContext = "playback nag";
+
     private readonly ISessionManager _sessionManager;
     private readonly IClientMessageService _clientMessageService;
     private readonly ILogger<PlaybackMonitor> _logger;
@@ -223,13 +225,13 @@ public class PlaybackMonitor : IHostedService
 
             var playbackKey = $"{session.Id}_{session.NowPlayingItem.Id}";
 
-            if (!IsItemAllowed(session, config, "playback nag"))
+            if (!IsItemAllowed(session, config, PlaybackNagMessageContext))
             {
                 _naggedPlaybacks.Remove(playbackKey);
                 return;
             }
 
-            if (!IsClientAllowed(session, config, "playback nag"))
+            if (!IsClientAllowed(session, config, PlaybackNagMessageContext))
             {
                 _naggedPlaybacks.Remove(playbackKey);
                 return;
@@ -268,6 +270,11 @@ public class PlaybackMonitor : IHostedService
 
     private void OnPlaybackStopped(object? sender, PlaybackStopEventArgs e)
     {
+        if (e.Session != null)
+        {
+            _clientMessageService.CancelPendingMessages(e.Session, PlaybackNagMessageContext);
+        }
+
         if (e.Session?.Id != null && e.Item?.Id != null)
         {
             var playbackKey = $"{e.Session.Id}_{e.Item.Id}";
@@ -370,7 +377,8 @@ public class PlaybackMonitor : IHostedService
                 Text = ResolveNagMessage(session, config),
                 TimeoutMs = config.MessageTimeoutMs
             },
-            "playback nag",
+            config.UseStickyPlaybackMessages,
+            PlaybackNagMessageContext,
             $"Reasons: {transcodeReasons}").ConfigureAwait(false);
     }
 
@@ -378,6 +386,7 @@ public class PlaybackMonitor : IHostedService
         SessionInfo session,
         Configuration.PluginConfiguration config,
         MessageCommand command,
+        bool useStickyMessages,
         string context,
         string detail)
     {
@@ -386,6 +395,7 @@ public class PlaybackMonitor : IHostedService
         return _clientMessageService.SendMessageAsync(
             session,
             command,
+            useStickyMessages,
             context,
             detail,
             config.EnableLogging,
@@ -532,7 +542,10 @@ public class PlaybackMonitor : IHostedService
                 if (motdSent && config.EnableLoginNag)
                 {
                     // Clamped because MessageTimeoutMs is only range-checked by the config UI.
-                    await Task.Delay(Math.Clamp(config.MessageTimeoutMs, 0, MaxMotdFollowUpDelayMs)).ConfigureAwait(false);
+                    var motdVisibilityDurationMs = MessageDeliveryPolicy.GetEffectiveVisibilityDurationMs(
+                        config.UseStickyMotdMessages,
+                        config.MessageTimeoutMs);
+                    await Task.Delay(Math.Clamp(motdVisibilityDurationMs, 0, MaxMotdFollowUpDelayMs)).ConfigureAwait(false);
                 }
 
                 // A session can end (and its deterministic ID can be reused) while waiting for
@@ -564,6 +577,8 @@ public class PlaybackMonitor : IHostedService
         {
             return;
         }
+
+        _clientMessageService.CancelPendingMessages(session);
 
         lock (_sessionNotificationLock)
         {
@@ -639,6 +654,7 @@ public class PlaybackMonitor : IHostedService
                     Text = config.MotdMessage,
                     TimeoutMs = config.MessageTimeoutMs
                 },
+                config.UseStickyMotdMessages,
                 "motd",
                 "Message of the day").ConfigureAwait(false);
         }
@@ -728,6 +744,7 @@ public class PlaybackMonitor : IHostedService
                 Text = message,
                 TimeoutMs = config.MessageTimeoutMs
             },
+            config.UseStickyLoginNagMessages,
             "login/open nag",
             $"{status.BadTranscodeCount} bad transcodes in last {timeWindowText}").ConfigureAwait(false);
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Open **Dashboard** → **Plugins** → **Transcode Nag**.
 
 - Choose which playback transcode reasons should trigger nags. Defaults focus on unsupported container, codec, subtitle, profile, level, resolution, bit depth, framerate, and related compatibility failures.
 - Set the playback message, delay, and timeout.
+- Enable **Sticky Messages** independently for playback nags, login nags, the MOTD, or GPU refusal notices when clients dismiss Jellyfin popups too quickly.
 - Enable **Exclude Live TV** if Live TV channel streams should not trigger playback nags or count toward login nags.
 - Optionally add client include/exclude filters using case-insensitive text matching. If the include list is empty, all clients are eligible; exclude matches always win.
 - If you want login nags, enable them and set the threshold, time window, and message. The login message supports `{{transcodes}}` and `{{timewindow}}`.
@@ -96,6 +97,7 @@ Open **Dashboard** → **Plugins** → **Transcode Nag**.
 - If a user returns to direct play after a bad transcode, login nags are suppressed until they regress again.
 - The MOTD is sent once per session at login and is unrelated to transcode history. Sessions that were already signed in when you enabled it receive nothing until they sign in again.
 - If a user qualifies for both the MOTD and a login nag, the nag waits for the MOTD to time out first, so clients that show one message at a time still display both.
+- A sticky message is sent three times, 3 seconds apart, with a 4-second timeout per send. Non-sticky messages continue to use the configured message timeout.
 - The GPU guard only refuses NVIDIA video transcodes. Direct Play, Direct Stream, remux, audio-only, and CPU transcodes are never refused, and playback is allowed whenever free VRAM cannot be read.
 - After launch, the guard samples `nvidia-smi`'s per-process memory for the FFmpeg PID. Successful samples are logged with the job shape and budget for MiB-level calibration; if container PID namespaces prevent attribution, admission still works and the temporary reservation simply expires on its timer.
 - A refused stream returns HTTP 403 and starts no FFmpeg process. Freeing GPU memory restores playback on the next attempt, with no setting change or restart.

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/ClientMessageServiceTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/ClientMessageServiceTests.cs
@@ -1,5 +1,7 @@
 using Jellyfin.Plugin.TranscodeNag.Messaging;
 using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Session;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Jellyfin.Plugin.TranscodeNag.Tests;
 
@@ -104,5 +106,320 @@ public class ClientMessageServiceTests
     {
         Assert.Null(ClientMessageService.SelectSession(null, "device-1", AliceId, Guid.Empty));
         Assert.Null(ClientMessageService.SelectSession(new List<SessionInfo>(), "device-1", AliceId, Guid.Empty));
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_NormalMessageSendsOnceWithConfiguredTimeout()
+    {
+        var timeoutValues = new List<int>();
+        var delays = new List<TimeSpan>();
+        var session = ActiveSession();
+        await using var service = new ClientMessageService(
+            () => new[] { session },
+            (_, command, _) =>
+            {
+                timeoutValues.Add(Convert.ToInt32(command.TimeoutMs));
+                return Task.CompletedTask;
+            },
+            (delay, _) =>
+            {
+                delays.Add(delay);
+                return Task.CompletedTask;
+            });
+
+        var sent = await service.SendMessageAsync(
+            session,
+            new MessageCommand { Header = "header", Text = "text", TimeoutMs = 9750 },
+            false,
+            "test",
+            "normal delivery",
+            false,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        Assert.True(sent);
+        Assert.Equal(new[] { 9750 }, timeoutValues);
+        Assert.Empty(delays);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_StickyMessageRefreshesTwiceWithoutBlockingInitialDelivery()
+    {
+        var timeoutValues = new List<int>();
+        var scheduledDelays = new List<TimeSpan>();
+        var threeSecondGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var sixSecondGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var bothDelaysScheduled = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var secondSendCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var thirdSendCompleted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var session = ActiveSession();
+        await using var service = new ClientMessageService(
+            () => new[] { session },
+            (_, command, _) =>
+            {
+                timeoutValues.Add(Convert.ToInt32(command.TimeoutMs));
+                if (timeoutValues.Count == 2)
+                {
+                    secondSendCompleted.TrySetResult();
+                }
+                else if (timeoutValues.Count == 3)
+                {
+                    thirdSendCompleted.TrySetResult();
+                }
+
+                return Task.CompletedTask;
+            },
+            (delay, cancellationToken) =>
+            {
+                scheduledDelays.Add(delay);
+                if (scheduledDelays.Count == 2)
+                {
+                    bothDelaysScheduled.TrySetResult();
+                }
+
+                return delay == TimeSpan.FromSeconds(3)
+                    ? threeSecondGate.Task.WaitAsync(cancellationToken)
+                    : sixSecondGate.Task.WaitAsync(cancellationToken);
+            });
+
+        var originalCommand = new MessageCommand { Header = "header", Text = "text", TimeoutMs = 15000 };
+        var initialSend = service.SendMessageAsync(
+            session,
+            originalCommand,
+            true,
+            "test",
+            "sticky delivery",
+            false,
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        await bothDelaysScheduled.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        var sent = await initialSend.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.True(sent);
+        Assert.Equal(new[] { 4000 }, timeoutValues);
+        Assert.Equal(new[] { TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(6) }, scheduledDelays);
+        Assert.Equal(15000, originalCommand.TimeoutMs);
+
+        threeSecondGate.TrySetResult();
+        await secondSendCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.Equal(2, timeoutValues.Count);
+        Assert.False(thirdSendCompleted.Task.IsCompleted);
+
+        sixSecondGate.TrySetResult();
+        await thirdSendCompleted.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await service.WaitForPendingMessagesAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(new[] { 4000, 4000, 4000 }, timeoutValues);
+        Assert.Equal(10000, MessageDeliveryPolicy.GetEffectiveVisibilityDurationMs(true, 15000));
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_NewerMessageCancelsOlderStickyRefreshes()
+    {
+        var sentTexts = new List<string?>();
+        var delayGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var session = ActiveSession();
+        await using var service = new ClientMessageService(
+            () => new[] { session },
+            (_, command, _) =>
+            {
+                sentTexts.Add(command.Text);
+                return Task.CompletedTask;
+            },
+            (_, cancellationToken) => delayGate.Task.WaitAsync(cancellationToken));
+
+        Assert.True(await service.SendMessageAsync(
+            session,
+            new MessageCommand { Header = "old", Text = "old sticky", TimeoutMs = 15000 },
+            true,
+            "test",
+            "old delivery",
+            false,
+            NullLogger.Instance,
+            CancellationToken.None));
+
+        Assert.True(await service.SendMessageAsync(
+            session,
+            new MessageCommand { Header = "new", Text = "new normal", TimeoutMs = 9000 },
+            false,
+            "test",
+            "new delivery",
+            false,
+            NullLogger.Instance,
+            CancellationToken.None));
+
+        delayGate.TrySetResult();
+        await service.WaitForPendingMessagesAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(new[] { "old sticky", "new normal" }, sentTexts);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_DoesNotRefreshAReplacementSessionWithTheSameId()
+    {
+        var sendCount = 0;
+        var delayGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        SessionInfo liveSession = ActiveSession();
+        var originalSession = liveSession;
+        await using var service = new ClientMessageService(
+            () => new[] { liveSession },
+            (_, _, _) =>
+            {
+                sendCount++;
+                return Task.CompletedTask;
+            },
+            (_, cancellationToken) => delayGate.Task.WaitAsync(cancellationToken));
+
+        Assert.True(await service.SendMessageAsync(
+            originalSession,
+            new MessageCommand { Header = "header", Text = "text", TimeoutMs = 15000 },
+            true,
+            "test",
+            "sticky delivery",
+            false,
+            NullLogger.Instance,
+            CancellationToken.None));
+
+        liveSession = TestSessions.Create("session-1", "device-2", BobId, "bob");
+        liveSession.AddController(new ActiveSessionController());
+        delayGate.TrySetResult();
+
+        await service.WaitForPendingMessagesAsync().WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.Equal(1, sendCount);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_FinalRefreshStillRunsAfterTransientSecondSendFailure()
+    {
+        var sendCount = 0;
+        var session = ActiveSession();
+        await using var service = new ClientMessageService(
+            () => new[] { session },
+            (_, _, _) =>
+            {
+                sendCount++;
+                return sendCount == 2
+                    ? Task.FromException(new System.Net.WebSockets.WebSocketException("transient failure"))
+                    : Task.CompletedTask;
+            },
+            (_, _) => Task.CompletedTask);
+
+        Assert.True(await service.SendMessageAsync(
+            session,
+            new MessageCommand { Header = "header", Text = "text", TimeoutMs = 15000 },
+            true,
+            "test",
+            "sticky delivery",
+            false,
+            NullLogger.Instance,
+            CancellationToken.None));
+
+        await service.WaitForPendingMessagesAsync().WaitAsync(TimeSpan.FromSeconds(1));
+        Assert.Equal(3, sendCount);
+    }
+
+    [Fact]
+    public async Task CancelPendingMessages_StopsStickyRefreshesWithMatchingContext()
+    {
+        var sendCount = 0;
+        var delayGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var session = ActiveSession();
+        await using var service = new ClientMessageService(
+            () => new[] { session },
+            (_, _, _) =>
+            {
+                sendCount++;
+                return Task.CompletedTask;
+            },
+            (_, cancellationToken) => delayGate.Task.WaitAsync(cancellationToken));
+
+        Assert.True(await service.SendMessageAsync(
+            session,
+            new MessageCommand { Header = "header", Text = "text", TimeoutMs = 15000 },
+            true,
+            "test",
+            "sticky delivery",
+            false,
+            NullLogger.Instance,
+            CancellationToken.None));
+
+        service.CancelPendingMessages(session, "test");
+        delayGate.TrySetResult();
+        await service.WaitForPendingMessagesAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(1, sendCount);
+    }
+
+    [Fact]
+    public async Task CancelPendingMessages_DoesNotCancelADifferentMessageContext()
+    {
+        var sendCount = 0;
+        var delayGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var session = ActiveSession();
+        await using var service = new ClientMessageService(
+            () => new[] { session },
+            (_, _, _) =>
+            {
+                sendCount++;
+                return Task.CompletedTask;
+            },
+            (_, cancellationToken) => delayGate.Task.WaitAsync(cancellationToken));
+
+        Assert.True(await service.SendMessageAsync(
+            session,
+            new MessageCommand { Header = "header", Text = "text", TimeoutMs = 15000 },
+            true,
+            "motd",
+            "sticky delivery",
+            false,
+            NullLogger.Instance,
+            CancellationToken.None));
+
+        service.CancelPendingMessages(session, "playback nag");
+        delayGate.TrySetResult();
+        await service.WaitForPendingMessagesAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(3, sendCount);
+    }
+
+    [Fact]
+    public async Task ApplicationStopping_CancelsPendingStickyRefreshes()
+    {
+        var sendCount = 0;
+        var delayGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var applicationStopping = new CancellationTokenSource();
+        var session = ActiveSession();
+        await using var service = new ClientMessageService(
+            () => new[] { session },
+            (_, _, _) =>
+            {
+                sendCount++;
+                return Task.CompletedTask;
+            },
+            (_, cancellationToken) => delayGate.Task.WaitAsync(cancellationToken),
+            applicationStopping.Token);
+
+        Assert.True(await service.SendMessageAsync(
+            session,
+            new MessageCommand { Header = "header", Text = "text", TimeoutMs = 15000 },
+            true,
+            "test",
+            "sticky delivery",
+            false,
+            NullLogger.Instance,
+            CancellationToken.None));
+
+        applicationStopping.Cancel();
+        delayGate.TrySetResult();
+        await service.WaitForPendingMessagesAsync().WaitAsync(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(1, sendCount);
+    }
+
+    private static SessionInfo ActiveSession()
+    {
+        var session = TestSessions.Create("session-1", "device-1", AliceId);
+        session.AddController(new ActiveSessionController());
+        return session;
     }
 }

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/GpuResourceGuardTests.cs
@@ -225,6 +225,21 @@ public class GpuResourceGuardTests
     }
 
     [Fact]
+    public async Task DenialMessage_UsesGpuGuardStickySetting()
+    {
+        var provider = FakeGpuMemoryProvider.WithFreeMiB(700);
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+        var config = EnabledConfig();
+        config.UseStickyGpuGuardMessages = true;
+        var guard = CreateGuard(config, provider, messages);
+
+        Assert.False(await guard.IsAdmittedAsync(HardwareTranscodeRequest(), CancellationToken.None));
+
+        Assert.True(Assert.Single(messages.SentMessages).UseStickyMessages);
+    }
+
+    [Fact]
     public async Task DenialMessage_LeaksNoServerSideDetail()
     {
         var provider = FakeGpuMemoryProvider.WithFreeMiB(700);

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/PluginConfigurationCompatibilityTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/PluginConfigurationCompatibilityTests.cs
@@ -6,6 +6,41 @@ namespace Jellyfin.Plugin.TranscodeNag.Tests;
 public class PluginConfigurationCompatibilityTests
 {
     [Fact]
+    public void StickyMessagesAreOptInByDefault()
+    {
+        var config = new PluginConfiguration();
+
+        Assert.False(config.UseStickyPlaybackMessages);
+        Assert.False(config.UseStickyLoginNagMessages);
+        Assert.False(config.UseStickyMotdMessages);
+        Assert.False(config.UseStickyGpuGuardMessages);
+    }
+
+    [Fact]
+    public void StickyMessageSettingsRoundTripThroughXml()
+    {
+        var serializer = new XmlSerializer(typeof(PluginConfiguration));
+        var config = new PluginConfiguration
+        {
+            UseStickyPlaybackMessages = true,
+            UseStickyLoginNagMessages = true,
+            UseStickyMotdMessages = true,
+            UseStickyGpuGuardMessages = true
+        };
+
+        using var writer = new StringWriter();
+        serializer.Serialize(writer, config);
+
+        using var reader = new StringReader(writer.ToString());
+        var roundTripped = Assert.IsType<PluginConfiguration>(serializer.Deserialize(reader));
+
+        Assert.True(roundTripped.UseStickyPlaybackMessages);
+        Assert.True(roundTripped.UseStickyLoginNagMessages);
+        Assert.True(roundTripped.UseStickyMotdMessages);
+        Assert.True(roundTripped.UseStickyGpuGuardMessages);
+    }
+
+    [Fact]
     public void LegacyGpuThresholdElementDoesNotBreakConfigurationLoading()
     {
         const string LegacyXml = """
@@ -27,6 +62,10 @@ public class PluginConfigurationCompatibilityTests
         Assert.Equal(1, config.GpuIndex);
         Assert.Equal(1750, config.GpuCheckTimeoutMilliseconds);
         Assert.Equal("Busy", config.GpuGuardDeniedHeader);
+        Assert.False(config.UseStickyPlaybackMessages);
+        Assert.False(config.UseStickyLoginNagMessages);
+        Assert.False(config.UseStickyMotdMessages);
+        Assert.False(config.UseStickyGpuGuardMessages);
 
         using var writer = new StringWriter();
         serializer.Serialize(writer, config);

--- a/tests/Jellyfin.Plugin.TranscodeNag.Tests/TestDoubles.cs
+++ b/tests/Jellyfin.Plugin.TranscodeNag.Tests/TestDoubles.cs
@@ -48,7 +48,7 @@ internal sealed class RecordingClientMessageService : IClientMessageService
 {
     private readonly Dictionary<string, SessionInfo> _sessionsByDeviceId = new(StringComparer.Ordinal);
 
-    public List<(SessionInfo Session, MessageCommand Command)> SentMessages { get; } = new();
+    public List<(SessionInfo Session, MessageCommand Command, bool UseStickyMessages)> SentMessages { get; } = new();
 
     public void AddSession(SessionInfo session)
     {
@@ -65,16 +65,21 @@ internal sealed class RecordingClientMessageService : IClientMessageService
         return _sessionsByDeviceId.TryGetValue(deviceId, out var session) ? session : null;
     }
 
+    public void CancelPendingMessages(SessionInfo session, string? context = null)
+    {
+    }
+
     public Task<bool> SendMessageAsync(
         SessionInfo session,
         MessageCommand command,
+        bool useStickyMessages,
         string context,
         string detail,
         bool enableLogging,
         ILogger logger,
         CancellationToken cancellationToken)
     {
-        SentMessages.Add((session, command));
+        SentMessages.Add((session, command, useStickyMessages));
         return Task.FromResult(true);
     }
 }
@@ -257,15 +262,34 @@ internal sealed class ThrowingClientMessageService : IClientMessageService
 
     public SessionInfo? ResolveSession(string? deviceId, Guid userId, Guid itemId) => _session;
 
+    public void CancelPendingMessages(SessionInfo session, string? context = null)
+    {
+    }
+
     public Task<bool> SendMessageAsync(
         SessionInfo session,
         MessageCommand command,
+        bool useStickyMessages,
         string context,
         string detail,
         bool enableLogging,
         ILogger logger,
         CancellationToken cancellationToken)
         => throw new System.Net.WebSockets.WebSocketException("the remote party closed the connection");
+}
+
+internal sealed class ActiveSessionController : ISessionController
+{
+    public bool IsSessionActive => true;
+
+    public bool SupportsMediaControl => true;
+
+    public Task SendMessage<T>(
+        SessionMessageType name,
+        Guid messageId,
+        T data,
+        CancellationToken cancellationToken)
+        => Task.CompletedTask;
 }
 
 internal static class TestSessions


### PR DESCRIPTION
## What

Adds a per-notification **Sticky Messages** toggle for playback nags, login nags, the MOTD, and GPU refusals.

A sticky message is sent three times, 3 seconds apart, each with a fixed 4-second timeout — a 10-second visibility window. All four settings default to off, and the non-sticky path is unchanged, so existing installs behave exactly as before.

## Why

Some clients drop a Jellyfin `DisplayMessage` well before its `TimeoutMs` elapses. The nag gets sent, recorded as delivered, and never actually seen. Raising `MessageTimeoutMs` doesn't help when the client is the one cutting the popup short, so repeating the send is the only lever that works.

## How

Delivery is now tracked per session in `ClientMessageService`:

- A newer message **supersedes** a pending one rather than racing it.
- Refreshes stop when the session ends, the controller goes away, playback stops, or the host shuts down (`IHostApplicationLifetime.ApplicationStopping`).
- Each refresh owns its error boundary, so a transient failure at t=3 doesn't suppress the final attempt at t=6.
- Only the first send determines the `SendMessageAsync` result, so a GPU refusal doesn't hold its HTTP response open for the whole visibility window.

MOTD-then-login-nag sequencing derives its delay from the effective visibility duration instead of `MessageTimeoutMs`. Without that, a sticky MOTD would still hand off after the configured timeout and the nag would land on top of the MOTD's own refreshes.

## Testing

180/180 unit tests pass; `dotnet format whitespace` and `dotnet format style --severity warn` are both clean.

Tested against a running **Jellyfin 10.10.7** instance with a real library and a real H.264 re-encode, using a WebSocket client recording delivery timestamps:

| Scenario | Observed |
|---|---|
| MOTD, non-sticky | 1 msg, timeout 10000 (configured) |
| MOTD, sticky | 3 msgs @ 0.000 / 3.006 / 6.005s, timeout 4000 |
| Playback nag, sticky, real transcode | 3 msgs @ 1.001 / 4.008 / 7.007s, timeout 4000 |

Sequencing with `MessageTimeoutMs=3000` and both MOTD + login nag sticky:

```
MOTD  0.000s / 3.000s / 6.001s   (window closes t=10)
NAG  10.001s / 13.002s / 16.002s
```

The nag starts exactly as the MOTD window closes. Non-sticky still hands off at 3.004s, unchanged.

Cancellation verified on all three paths — client disconnect, playback stopped (context-scoped: refreshes at t=4 and t=7 both suppressed after a stop at t=3.5), and host shutdown mid-refresh (clean exit 0 in ~2s, not a kill on timeout).

Plugin loads cleanly with the new `IHostApplicationLifetime` dependency resolved, and the server log shows zero errors or exceptions across the entire run.

## Notes

- `ShouldNagTranscode` correctly skips container remuxes (`IsVideoDirect=true`) even when `TranscodeReasons` lists unsupported codecs — the nag needs a genuine re-encode. Unchanged by this PR, but worth knowing if anyone reports a missing nag.
- A `SessionDeliveryState` entry can outlive its session if `SessionEnded` is ever missed, holding a `SessionInfo` reference until shutdown. Bounded by session count and no worse than the existing `_motdSentSessions` tracking, so left as-is.
