### PR TITLE
fix(config): render the login nag time window select in the dark theme

### DIFF
--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -5,7 +5,7 @@
     <title>Transcode Nag</title>
 </head>
 <body>
-    <div id="TranscodeNagConfigPage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-input,emby-button,emby-checkbox">
+    <div id="TranscodeNagConfigPage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-input,emby-button,emby-checkbox,emby-select">
         <div data-role="content">
             <div class="content-primary">
                 <form id="TranscodeNagConfigForm">
@@ -103,7 +103,7 @@
 
                     <div class="selectContainer">
                         <label class="inputLabel inputLabelUnfocused" for="selectLoginNagTimeWindow">Login Nag Time Window:</label>
-                        <select id="selectLoginNagTimeWindow" name="selectLoginNagTimeWindow" class="emby-select">
+                        <select is="emby-select" id="selectLoginNagTimeWindow" name="selectLoginNagTimeWindow" class="emby-select-withcolor emby-select">
                             <option value="Week">Week</option>
                             <option value="Month">Month</option>
                         </select>


### PR DESCRIPTION
## What

The **Login Nag Time Window** dropdown on the plugin configuration page renders as a native light-grey control against the dark Jellyfin dashboard.

## Why

`class="emby-select"` only sets box model and typography — nothing in that rule touches `background` or `color`:

```css
.emby-select{box-sizing:border-box;display:block;font-family:inherit;font-size:110%;
             font-weight:inherit;margin:0;outline:none!important;width:100%}
```

The class that actually removes the native appearance is `.emby-select-withcolor`. Stock jellyfin-web pages carry both, alongside `is="emby-select"`.

## Verification

Measured computed styles against a real `emby-select` on a stock Jellyfin 10.11.11 page (`#/mypreferencesplayback`), which renders `bg=rgb(41, 41, 41) color=rgba(255,255,255,0.8) appearance=none`:

| markup | background | appearance |
|---|---|---|
| `class="emby-select"` (before) | `rgb(239, 239, 239)` | `auto` |
| `is="emby-select"` + `class="emby-select"` | `rgb(239, 239, 239)` | `auto` |
| **`is=` + `emby-select-withcolor emby-select`** | **`rgb(41, 41, 41)`** | **`none`** |

Note `is=` alone is not sufficient — the `emby-select` custom element is not registered in 10.11, so the classes are what do the work. It is kept anyway to match stock markup.

Also adds `emby-select` to `data-require`, which listed every other component the page uses but not this one.

## Scope

Only this page has a `<select>`; the other plugin config pages were checked and are unaffected.