### PR TITLE
feat: republish as Transcode Guard under a separate plugin identity

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,10 +19,10 @@ jobs:
         dotnet-version: 8.0.x
 
     - name: Restore dependencies
-      run: dotnet restore tests/Jellyfin.Plugin.TranscodeNag.Tests/Jellyfin.Plugin.TranscodeNag.Tests.csproj
+      run: dotnet restore tests/Jellyfin.Plugin.TranscodeGuard.Tests/Jellyfin.Plugin.TranscodeGuard.Tests.csproj
 
     - name: Run unit tests
-      run: dotnet test tests/Jellyfin.Plugin.TranscodeNag.Tests/Jellyfin.Plugin.TranscodeNag.Tests.csproj --configuration Release --no-restore
+      run: dotnet test tests/Jellyfin.Plugin.TranscodeGuard.Tests/Jellyfin.Plugin.TranscodeGuard.Tests.csproj --configuration Release --no-restore
 
     - name: Check whitespace formatting
       run: dotnet format whitespace --verify-no-changes --verbosity minimal
@@ -31,7 +31,7 @@ jobs:
       run: dotnet format style --verify-no-changes --severity warn --verbosity minimal
 
     - name: Check test whitespace formatting
-      run: dotnet format tests/Jellyfin.Plugin.TranscodeNag.Tests/Jellyfin.Plugin.TranscodeNag.Tests.csproj whitespace --verify-no-changes --verbosity minimal
+      run: dotnet format tests/Jellyfin.Plugin.TranscodeGuard.Tests/Jellyfin.Plugin.TranscodeGuard.Tests.csproj whitespace --verify-no-changes --verbosity minimal
 
     - name: Check test C# style formatting
-      run: dotnet format tests/Jellyfin.Plugin.TranscodeNag.Tests/Jellyfin.Plugin.TranscodeNag.Tests.csproj style --verify-no-changes --severity warn --verbosity minimal
+      run: dotnet format tests/Jellyfin.Plugin.TranscodeGuard.Tests/Jellyfin.Plugin.TranscodeGuard.Tests.csproj style --verify-no-changes --severity warn --verbosity minimal

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -50,7 +50,7 @@ jobs:
         PR_NUMBER="${{ github.event.inputs.pr_number }}"
         BUILD_TAG="pr/${PR_NUMBER}"
         SAFE_TAG="pr-${PR_NUMBER}"
-        FOLDER_NAME="Transcode_Nag_${SAFE_TAG}_develop"
+        FOLDER_NAME="Transcode_Guard_${SAFE_TAG}_develop"
         ZIP_NAME="${FOLDER_NAME}.zip"
 
         echo "PR_NUMBER=${PR_NUMBER}" >> "$GITHUB_ENV"
@@ -68,7 +68,7 @@ jobs:
       shell: bash
       run: |
         mkdir -p "release/${FOLDER_NAME}"
-        cp bin/Release/net8.0/Jellyfin.Plugin.TranscodeNag.dll "release/${FOLDER_NAME}/"
+        cp bin/Release/net8.0/Jellyfin.Plugin.TranscodeGuard.dll "release/${FOLDER_NAME}/"
         echo "${BUILD_TAG}" > "release/${FOLDER_NAME}/BUILD_TAG.txt"
         cd release
         zip -r "../${ZIP_NAME}" "${FOLDER_NAME}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,13 @@ on:
 permissions:
   contents: write
 
+env:
+  # The Transcode Guard plugin identity. manifest.json also carries the retired
+  # Transcode Nag entry under its own GUID, so every write must say which one it
+  # means. Changing this value creates a new plugin as far as Jellyfin is
+  # concerned; it is not a cosmetic string.
+  PLUGIN_GUID: 2ce6b237-2610-4dfd-a34b-3f4c2ac64a88
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
@@ -32,8 +39,8 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v7
       with:
-        name: Jellyfin.Plugin.TranscodeNag
-        path: bin/Release/net8.0/Jellyfin.Plugin.TranscodeNag.dll
+        name: Jellyfin.Plugin.TranscodeGuard
+        path: bin/Release/net8.0/Jellyfin.Plugin.TranscodeGuard.dll
 
     - name: Generate version and changelog
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -100,12 +107,12 @@ jobs:
         VERSION=${{ steps.version.outputs.version }}
         # Strip 'v' prefix for folder name (Jellyfin expects folder without 'v')
         VERSION_NO_V="${VERSION#v}"
-        FOLDER_NAME="Transcode_Nag_${VERSION_NO_V}"
-        ZIP_NAME="Transcode_Nag_${VERSION}.zip"
+        FOLDER_NAME="Transcode_Guard_${VERSION_NO_V}"
+        ZIP_NAME="Transcode_Guard_${VERSION}.zip"
 
         # Create versioned folder structure
         mkdir -p "release/${FOLDER_NAME}"
-        cp bin/Release/net8.0/Jellyfin.Plugin.TranscodeNag.dll "release/${FOLDER_NAME}/"
+        cp bin/Release/net8.0/Jellyfin.Plugin.TranscodeGuard.dll "release/${FOLDER_NAME}/"
 
         # Create ZIP
         cd release
@@ -121,26 +128,42 @@ jobs:
         VERSION=${{ steps.version.outputs.version }}
         # Strip 'v' prefix for manifest.json version field (Jellyfin requires semantic version without 'v')
         MANIFEST_VERSION="${VERSION#v}"
-        ZIP_NAME="Transcode_Nag_${VERSION}.zip"
+        ZIP_NAME="Transcode_Guard_${VERSION}.zip"
         CHECKSUM=$(md5sum "${ZIP_NAME}" | awk '{print $1}')
         TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
         REPO="${{ github.repository }}"
         IMAGE_URL="https://raw.githubusercontent.com/${REPO}/main/icon.png"
 
+        # Select the entry by GUID rather than by position. manifest.json also
+        # carries the retired Transcode Nag entry, which must never be rewritten:
+        # it is frozen at its final version so existing installs are never
+        # offered an update.
         jq --arg version "$MANIFEST_VERSION" \
            --rawfile changelog CHANGELOG.md \
            --arg checksum "$CHECKSUM" \
            --arg timestamp "$TIMESTAMP" \
            --arg url "https://github.com/${REPO}/releases/download/${VERSION}/${ZIP_NAME}" \
            --arg imageUrl "$IMAGE_URL" \
-           '.[0].imageUrl = $imageUrl | .[0].versions = [{
-             "version": $version,
-             "changelog": $changelog,
-             "targetAbi": "10.9.0.0",
-             "sourceUrl": $url,
-             "checksum": $checksum,
-             "timestamp": $timestamp
-           }] + .[0].versions' manifest.json > manifest.tmp && mv manifest.tmp manifest.json
+           --arg guid "$PLUGIN_GUID" \
+           'map(if .guid == $guid then
+              .imageUrl = $imageUrl
+              | .versions = [{
+                  "version": $version,
+                  "changelog": $changelog,
+                  "targetAbi": "10.9.0.0",
+                  "sourceUrl": $url,
+                  "checksum": $checksum,
+                  "timestamp": $timestamp
+                }] + .versions
+            else . end)' manifest.json > manifest.tmp
+
+        if ! jq -e --arg guid "$PLUGIN_GUID" \
+             'map(select(.guid == $guid)) | length == 1' manifest.tmp > /dev/null; then
+          echo "manifest.json does not contain exactly one entry for $PLUGIN_GUID" >&2
+          exit 1
+        fi
+
+        mv manifest.tmp manifest.json
 
     - name: Commit updated manifest
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -161,7 +184,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         VERSION=${{ steps.version.outputs.version }}
-        ZIP_NAME="Transcode_Nag_${VERSION}.zip"
+        ZIP_NAME="Transcode_Guard_${VERSION}.zip"
 
         gh release create "$VERSION" \
           --title "Release $VERSION" \

--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -2,7 +2,7 @@ using System;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Session;
 
-namespace Jellyfin.Plugin.TranscodeNag.Configuration;
+namespace Jellyfin.Plugin.TranscodeGuard.Configuration;
 
 public class PluginConfiguration : BasePluginConfiguration
 {

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -5,10 +5,10 @@
     <title>Transcode Guard</title>
 </head>
 <body>
-    <div id="TranscodeNagConfigPage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-input,emby-button,emby-checkbox,emby-select">
+    <div id="TranscodeGuardConfigPage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-input,emby-button,emby-checkbox,emby-select">
         <div data-role="content">
             <div class="content-primary">
-                <form id="TranscodeNagConfigForm">
+                <form id="TranscodeGuardConfigForm">
                     <div class="selectContainer">
                         <label class="inputLabel inputLabelUnfocused" for="txtNagMessage">Nag Message:</label>
                         <textarea id="txtNagMessage" name="txtNagMessage" rows="4" class="emby-input"></textarea>
@@ -333,7 +333,7 @@
         </div>
 
         <script type="text/javascript">
-            var TranscodeNagConfig = {
+            var TranscodeGuardConfig = {
                 pluginId: "fdcf27a6-bd64-42e3-9f57-41880552bf83"
             };
 
@@ -926,7 +926,7 @@
 
                     var configPromise = preloadedConfig
                         ? Promise.resolve(preloadedConfig)
-                        : ApiClient.getPluginConfiguration(TranscodeNagConfig.pluginId);
+                        : ApiClient.getPluginConfiguration(TranscodeGuardConfig.pluginId);
 
                     return configPromise.then(function(config) {
                         LiveSessionMonitor.setConfig(config);
@@ -953,7 +953,7 @@
                 }
             };
 
-            document.getElementById('TranscodeNagConfigPage').addEventListener('pageshow', function () {
+            document.getElementById('TranscodeGuardConfigPage').addEventListener('pageshow', function () {
                 Dashboard.showLoadingMsg();
                 ReasonSelector.init();
                 LiveSessionMonitor.init();
@@ -961,7 +961,7 @@
                 MotdUserExclusionManager.init();
                 MotdSection.init();
                 GpuGuardSection.init();
-                ApiClient.getPluginConfiguration(TranscodeNagConfig.pluginId).then(function (config) {
+                ApiClient.getPluginConfiguration(TranscodeGuardConfig.pluginId).then(function (config) {
                     document.getElementById('txtNagMessage').value = config.NagMessage || '';
                     document.getElementById('chkUseStickyPlaybackMessages').checked = config.UseStickyPlaybackMessages === true;
                     document.getElementById('txtDelaySeconds').value = config.DelaySeconds || 5;
@@ -996,11 +996,11 @@
                 });
             });
 
-            document.getElementById('TranscodeNagConfigForm').addEventListener('submit', function (e) {
+            document.getElementById('TranscodeGuardConfigForm').addEventListener('submit', function (e) {
                 e.preventDefault();
                 Dashboard.showLoadingMsg();
 
-                ApiClient.getPluginConfiguration(TranscodeNagConfig.pluginId).then(function (config) {
+                ApiClient.getPluginConfiguration(TranscodeGuardConfig.pluginId).then(function (config) {
                     config.NagMessage = document.getElementById('txtNagMessage').value;
                     config.UseStickyPlaybackMessages = document.getElementById('chkUseStickyPlaybackMessages').checked;
                     config.DelaySeconds = parseInt(document.getElementById('txtDelaySeconds').value);
@@ -1029,7 +1029,7 @@
                     config.AlertTranscodeReasons = ReasonSelector.getSelectedReasonNames();
                     config.ReasonMessageOverrides = ReasonSelector.getReasonMessageOverrides();
 
-                    ApiClient.updatePluginConfiguration(TranscodeNagConfig.pluginId, config).then(function (result) {
+                    ApiClient.updatePluginConfiguration(TranscodeGuardConfig.pluginId, config).then(function (result) {
                         Dashboard.processPluginConfigurationUpdateResult(result);
                     });
                 });
@@ -1065,7 +1065,7 @@
                         Dashboard.showLoadingMsg();
 
                         // Fetch current exclusion list from config
-                        ApiClient.getPluginConfiguration(TranscodeNagConfig.pluginId).then(function(config) {
+                        ApiClient.getPluginConfiguration(TranscodeGuardConfig.pluginId).then(function(config) {
                             manager.excludedUserIds = config[options.configProperty] || [];
 
                             // Fetch all users from Jellyfin
@@ -1146,10 +1146,10 @@
                         });
 
                         // Update configuration
-                        ApiClient.getPluginConfiguration(TranscodeNagConfig.pluginId).then(function(config) {
+                        ApiClient.getPluginConfiguration(TranscodeGuardConfig.pluginId).then(function(config) {
                             config[options.configProperty] = newExcludedUserIds;
 
-                            return ApiClient.updatePluginConfiguration(TranscodeNagConfig.pluginId, config);
+                            return ApiClient.updatePluginConfiguration(TranscodeGuardConfig.pluginId, config);
                         }).then(function() {
                             manager.excludedUserIds = newExcludedUserIds;
                             manager.closeModal();
@@ -1198,7 +1198,7 @@
                 excludedMessageSuffix: ' user(s) excluded from the MOTD.'
             });
 
-            document.getElementById('TranscodeNagConfigPage').addEventListener('pagehide', function() {
+            document.getElementById('TranscodeGuardConfigPage').addEventListener('pagehide', function() {
                 LiveSessionMonitor.stopRefreshTimer();
             });
         </script>

--- a/Data/TranscodeEventStore.cs
+++ b/Data/TranscodeEventStore.cs
@@ -4,11 +4,11 @@ using System.IO;
 using System.Linq;
 using System.Text.Json;
 using System.Threading;
-using Jellyfin.Plugin.TranscodeNag.Models;
+using Jellyfin.Plugin.TranscodeGuard.Models;
 using MediaBrowser.Common.Configuration;
 using Microsoft.Extensions.Logging;
 
-namespace Jellyfin.Plugin.TranscodeNag.Data;
+namespace Jellyfin.Plugin.TranscodeGuard.Data;
 
 public class TranscodeEventStore
 {
@@ -25,7 +25,7 @@ public class TranscodeEventStore
 
     private string GetDataFilePath()
     {
-        var dataDir = Path.GetFullPath(Path.Join(_appPaths.DataPath, "plugins", "data", "TranscodeNag"));
+        var dataDir = Path.GetFullPath(Path.Join(_appPaths.DataPath, "plugins", "data", "TranscodeGuard"));
         Directory.CreateDirectory(dataDir);
 
         // Keep file segment normalized so future refactors cannot inject rooted paths here.

--- a/Gpu/GpuAdmissionAttempt.cs
+++ b/Gpu/GpuAdmissionAttempt.cs
@@ -2,7 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+namespace Jellyfin.Plugin.TranscodeGuard.Gpu;
 
 /// <summary>
 /// One admission result and, when needed, its temporary in-flight VRAM reservation.

--- a/Gpu/GpuAdmissionPolicy.cs
+++ b/Gpu/GpuAdmissionPolicy.cs
@@ -1,7 +1,7 @@
 using System;
-using Jellyfin.Plugin.TranscodeNag.Configuration;
+using Jellyfin.Plugin.TranscodeGuard.Configuration;
 
-namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+namespace Jellyfin.Plugin.TranscodeGuard.Gpu;
 
 /// <summary>
 /// Why a transcode was allowed, or that it was refused.

--- a/Gpu/GpuMemoryQueryResult.cs
+++ b/Gpu/GpuMemoryQueryResult.cs
@@ -1,4 +1,4 @@
-namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+namespace Jellyfin.Plugin.TranscodeGuard.Gpu;
 
 /// <summary>
 /// Outcome of a single free-VRAM lookup.

--- a/Gpu/GpuProcessMemoryQueryResult.cs
+++ b/Gpu/GpuProcessMemoryQueryResult.cs
@@ -1,4 +1,4 @@
-namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+namespace Jellyfin.Plugin.TranscodeGuard.Gpu;
 
 /// <summary>
 /// Outcome of attributing NVIDIA memory to one operating-system process.

--- a/Gpu/GpuResourceGuard.cs
+++ b/Gpu/GpuResourceGuard.cs
@@ -4,12 +4,12 @@ using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using Jellyfin.Plugin.TranscodeNag.Configuration;
-using Jellyfin.Plugin.TranscodeNag.Messaging;
+using Jellyfin.Plugin.TranscodeGuard.Configuration;
+using Jellyfin.Plugin.TranscodeGuard.Messaging;
 using MediaBrowser.Model.Session;
 using Microsoft.Extensions.Logging;
 
-namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+namespace Jellyfin.Plugin.TranscodeGuard.Gpu;
 
 /// <summary>
 /// Admission control for GPU-backed video transcodes.

--- a/Gpu/GpuTranscodeRequest.cs
+++ b/Gpu/GpuTranscodeRequest.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+namespace Jellyfin.Plugin.TranscodeGuard.Gpu;
 
 /// <summary>
 /// Everything the guard needs about a transcode Jellyfin is about to launch, lifted out of

--- a/Gpu/GpuVramEstimate.cs
+++ b/Gpu/GpuVramEstimate.cs
@@ -1,4 +1,4 @@
-namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+namespace Jellyfin.Plugin.TranscodeGuard.Gpu;
 
 /// <summary>
 /// A conservative, quarter-GiB budget for the video memory one FFmpeg job will allocate.

--- a/Gpu/GpuVramEstimator.cs
+++ b/Gpu/GpuVramEstimator.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 
-namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+namespace Jellyfin.Plugin.TranscodeGuard.Gpu;
 
 /// <summary>
 /// Assigns a conservative NVIDIA video-memory requirement to one FFmpeg transcode.

--- a/Gpu/GuardedTranscodeManager.cs
+++ b/Gpu/GuardedTranscodeManager.cs
@@ -6,7 +6,7 @@ using MediaBrowser.Controller.Net;
 using MediaBrowser.Controller.Streaming;
 using Microsoft.Extensions.Logging;
 
-namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+namespace Jellyfin.Plugin.TranscodeGuard.Gpu;
 
 /// <summary>
 /// Wraps Jellyfin's <see cref="ITranscodeManager"/> so the GPU guard runs immediately before

--- a/Gpu/IGpuMemoryProvider.cs
+++ b/Gpu/IGpuMemoryProvider.cs
@@ -1,7 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+namespace Jellyfin.Plugin.TranscodeGuard.Gpu;
 
 /// <summary>
 /// Reads free video memory for a single GPU.

--- a/Gpu/IGpuProcessMemoryProvider.cs
+++ b/Gpu/IGpuProcessMemoryProvider.cs
@@ -1,7 +1,7 @@
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+namespace Jellyfin.Plugin.TranscodeGuard.Gpu;
 
 /// <summary>
 /// Optionally attributes NVIDIA memory to a launched process for calibration and reservation

--- a/Gpu/NvidiaSmiGpuMemoryProvider.cs
+++ b/Gpu/NvidiaSmiGpuMemoryProvider.cs
@@ -6,7 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
-namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+namespace Jellyfin.Plugin.TranscodeGuard.Gpu;
 
 /// <summary>
 /// Reads free and per-process VRAM by running narrow, machine-readable nvidia-smi queries.

--- a/Gpu/NvidiaSmiOutputParser.cs
+++ b/Gpu/NvidiaSmiOutputParser.cs
@@ -2,7 +2,7 @@ using System;
 using System.Globalization;
 using System.Linq;
 
-namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+namespace Jellyfin.Plugin.TranscodeGuard.Gpu;
 
 /// <summary>
 /// Parses the machine-readable nvidia-smi output the guard asks for:

--- a/Gpu/NvidiaTranscodeDetector.cs
+++ b/Gpu/NvidiaTranscodeDetector.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Jellyfin.Plugin.TranscodeNag.Gpu;
+namespace Jellyfin.Plugin.TranscodeGuard.Gpu;
 
 /// <summary>
 /// Decides whether an FFmpeg invocation Jellyfin is about to launch will touch the NVIDIA GPU.

--- a/Jellyfin.Plugin.TranscodeGuard.csproj
+++ b/Jellyfin.Plugin.TranscodeGuard.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RootNamespace>Jellyfin.Plugin.TranscodeNag</RootNamespace>
+    <RootNamespace>Jellyfin.Plugin.TranscodeGuard</RootNamespace>
     <AssemblyVersion>1.0.1.27</AssemblyVersion>
     <FileVersion>1.0.1.27</FileVersion>
     <Version>1.0.1.27</Version>

--- a/Messaging/ClientMessageService.cs
+++ b/Messaging/ClientMessageService.cs
@@ -9,7 +9,7 @@ using MediaBrowser.Model.Session;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace Jellyfin.Plugin.TranscodeNag.Messaging;
+namespace Jellyfin.Plugin.TranscodeGuard.Messaging;
 
 /// <summary>
 /// The shared session-resolution and DisplayMessage plumbing used by every notification the plugin sends.

--- a/Messaging/IClientMessageService.cs
+++ b/Messaging/IClientMessageService.cs
@@ -5,7 +5,7 @@ using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Session;
 using Microsoft.Extensions.Logging;
 
-namespace Jellyfin.Plugin.TranscodeNag.Messaging;
+namespace Jellyfin.Plugin.TranscodeGuard.Messaging;
 
 /// <summary>
 /// Resolves Jellyfin sessions and delivers DisplayMessage popups to a single one of them.

--- a/Messaging/MessageDeliveryPolicy.cs
+++ b/Messaging/MessageDeliveryPolicy.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Jellyfin.Plugin.TranscodeNag.Messaging;
+namespace Jellyfin.Plugin.TranscodeGuard.Messaging;
 
 /// <summary>
 /// Defines the fixed compatibility behavior used by opt-in sticky messages.

--- a/Models/NagEventKind.cs
+++ b/Models/NagEventKind.cs
@@ -1,4 +1,4 @@
-namespace Jellyfin.Plugin.TranscodeNag.Models;
+namespace Jellyfin.Plugin.TranscodeGuard.Models;
 
 /// <summary>
 /// Stored alongside events.json to support rate limiting and "improvement" credits.

--- a/Models/TranscodeEvent.cs
+++ b/Models/TranscodeEvent.cs
@@ -1,7 +1,7 @@
 using System;
 using MediaBrowser.Model.Session;
 
-namespace Jellyfin.Plugin.TranscodeNag.Models;
+namespace Jellyfin.Plugin.TranscodeGuard.Models;
 
 public class TranscodeEvent
 {

--- a/Models/UserNagStatus.cs
+++ b/Models/UserNagStatus.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Jellyfin.Plugin.TranscodeNag.Models;
+namespace Jellyfin.Plugin.TranscodeGuard.Models;
 
 public class UserNagStatus
 {

--- a/PlaybackMonitor.cs
+++ b/PlaybackMonitor.cs
@@ -4,9 +4,9 @@ using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
-using Jellyfin.Plugin.TranscodeNag.Data;
-using Jellyfin.Plugin.TranscodeNag.Messaging;
-using Jellyfin.Plugin.TranscodeNag.Models;
+using Jellyfin.Plugin.TranscodeGuard.Data;
+using Jellyfin.Plugin.TranscodeGuard.Messaging;
+using Jellyfin.Plugin.TranscodeGuard.Models;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;
@@ -14,7 +14,7 @@ using MediaBrowser.Model.Session;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace Jellyfin.Plugin.TranscodeNag;
+namespace Jellyfin.Plugin.TranscodeGuard;
 
 public class PlaybackMonitor : IHostedService
 {
@@ -250,7 +250,7 @@ public class PlaybackMonitor : IHostedService
             }
 
             // Check if transcoding is due to unsupported format/codec
-            if (TranscodeNagRules.ShouldNagTranscode(transcodeInfo, config))
+            if (TranscodeGuardRules.ShouldNagTranscode(transcodeInfo, config))
             {
                 // Record the event
                 RecordTranscodeEvent(session, transcodeInfo);
@@ -284,7 +284,7 @@ public class PlaybackMonitor : IHostedService
 
     private bool IsItemAllowed(SessionInfo session, Configuration.PluginConfiguration config, string context)
     {
-        if (TranscodeNagRules.IsItemAllowed(session.NowPlayingItem, config))
+        if (TranscodeGuardRules.IsItemAllowed(session.NowPlayingItem, config))
         {
             return true;
         }
@@ -304,7 +304,7 @@ public class PlaybackMonitor : IHostedService
 
     private bool IsClientAllowed(SessionInfo session, Configuration.PluginConfiguration config, string context)
     {
-        if (TranscodeNagRules.IsClientAllowed(session.Client, config))
+        if (TranscodeGuardRules.IsClientAllowed(session.Client, config))
         {
             return true;
         }
@@ -354,7 +354,7 @@ public class PlaybackMonitor : IHostedService
         }
 
         // Check if user is excluded from nag messages
-        if (TranscodeNagRules.IsUserExcluded(session.UserId, config.ExcludedUserIds))
+        if (TranscodeGuardRules.IsUserExcluded(session.UserId, config.ExcludedUserIds))
         {
             if (config.EnableLogging)
             {
@@ -419,7 +419,7 @@ public class PlaybackMonitor : IHostedService
             Timestamp = DateTime.UtcNow,
             Reasons = transcodeInfo.TranscodeReasons,
             Client = session.Client ?? "Unknown",
-            IsLiveTv = TranscodeNagRules.IsLiveTvItem(session.NowPlayingItem),
+            IsLiveTv = TranscodeGuardRules.IsLiveTvItem(session.NowPlayingItem),
             Kind = NagEventKind.BadTranscode
         };
 
@@ -443,7 +443,7 @@ public class PlaybackMonitor : IHostedService
                 var status = await _eventStore.GetUserNagStatusAsync(
                     session.UserId.ToString(),
                     30,
-                    e => TranscodeNagRules.IsStoredEventAllowed(e, config)).ConfigureAwait(false);
+                    e => TranscodeGuardRules.IsStoredEventAllowed(e, config)).ConfigureAwait(false);
 
                 if (!status.LastBadTranscodeUtc.HasValue)
                 {
@@ -465,7 +465,7 @@ public class PlaybackMonitor : IHostedService
                     Timestamp = DateTime.UtcNow,
                     Reasons = 0,
                     Client = session.Client ?? "Unknown",
-                    IsLiveTv = TranscodeNagRules.IsLiveTvItem(session.NowPlayingItem),
+                    IsLiveTv = TranscodeGuardRules.IsLiveTvItem(session.NowPlayingItem),
                     Kind = NagEventKind.ImprovementCredit
                 };
 
@@ -607,7 +607,7 @@ public class PlaybackMonitor : IHostedService
             return false;
         }
 
-        if (TranscodeNagRules.IsUserExcluded(session.UserId, config.MotdExcludedUserIds))
+        if (TranscodeGuardRules.IsUserExcluded(session.UserId, config.MotdExcludedUserIds))
         {
             if (config.EnableLogging)
             {
@@ -620,7 +620,7 @@ public class PlaybackMonitor : IHostedService
             return false;
         }
 
-        if (!TranscodeNagRules.IsMotdClientAllowed(session.Client, config))
+        if (!TranscodeGuardRules.IsMotdClientAllowed(session.Client, config))
         {
             if (config.EnableLogging)
             {
@@ -687,7 +687,7 @@ public class PlaybackMonitor : IHostedService
         }
 
         // Check if user is excluded from nag messages
-        if (TranscodeNagRules.IsUserExcluded(session.UserId, config.ExcludedUserIds))
+        if (TranscodeGuardRules.IsUserExcluded(session.UserId, config.ExcludedUserIds))
         {
             if (config.EnableLogging)
             {
@@ -705,12 +705,12 @@ public class PlaybackMonitor : IHostedService
 
         var userId = session.UserId.ToString();
 
-        var (days, timeWindowText) = TranscodeNagRules.ResolveLoginNagWindow(config.LoginNagTimeWindow);
+        var (days, timeWindowText) = TranscodeGuardRules.ResolveLoginNagWindow(config.LoginNagTimeWindow);
 
         var status = await _eventStore.GetUserNagStatusAsync(
             userId,
             days,
-            e => TranscodeNagRules.IsStoredEventAllowed(e, config)).ConfigureAwait(false);
+            e => TranscodeGuardRules.IsStoredEventAllowed(e, config)).ConfigureAwait(false);
 
         // Rate limit: only once per configured period.
         if (status.NaggedRecently)
@@ -730,7 +730,7 @@ public class PlaybackMonitor : IHostedService
             return;
         }
 
-        var message = TranscodeNagRules.FormatLoginNagMessage(
+        var message = TranscodeGuardRules.FormatLoginNagMessage(
             config.LoginNagMessage,
             status.BadTranscodeCount,
             timeWindowText);

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Collections.Generic;
-using Jellyfin.Plugin.TranscodeNag.Configuration;
+using Jellyfin.Plugin.TranscodeGuard.Configuration;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
 
-namespace Jellyfin.Plugin.TranscodeNag;
+namespace Jellyfin.Plugin.TranscodeGuard;
 
 public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 {
@@ -18,7 +18,7 @@ public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
 
     public override string Name => "Transcode Guard";
 
-    public override Guid Id => Guid.Parse("fdcf27a6-bd64-42e3-9f57-41880552bf83");
+    public override Guid Id => Guid.Parse("2ce6b237-2610-4dfd-a34b-3f4c2ac64a88");
 
     public override string Description => "Nags users when they transcode due to unsupported formats (but allows bitrate transcoding)";
 

--- a/PluginServiceRegistrator.cs
+++ b/PluginServiceRegistrator.cs
@@ -1,15 +1,15 @@
 using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using Jellyfin.Plugin.TranscodeNag.Gpu;
-using Jellyfin.Plugin.TranscodeNag.Messaging;
+using Jellyfin.Plugin.TranscodeGuard.Gpu;
+using Jellyfin.Plugin.TranscodeGuard.Messaging;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Plugins;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace Jellyfin.Plugin.TranscodeNag;
+namespace Jellyfin.Plugin.TranscodeGuard;
 
 public class PluginServiceRegistrator : IPluginServiceRegistrator
 {

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 using System.Runtime.CompilerServices;
 
-[assembly: InternalsVisibleTo("Jellyfin.Plugin.TranscodeNag.Tests")]
+[assembly: InternalsVisibleTo("Jellyfin.Plugin.TranscodeGuard.Tests")]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
   <a href="LICENSE">
     <img src="https://img.shields.io/github/license/voc0der/jellyfin-plugin-transcode-guard?color=97CA00" alt="License" />
   </a>
-  <a href="https://github.com/voc0der/jellyfin-plugin-transcode-guard/blob/main/Jellyfin.Plugin.TranscodeNag.csproj">
+  <a href="https://github.com/voc0der/jellyfin-plugin-transcode-guard/blob/main/Jellyfin.Plugin.TranscodeGuard.csproj">
     <img src="https://img.shields.io/badge/dependencies-2%20outdated-orange" alt="Dependencies status" />
   </a>
 </p>
@@ -83,7 +83,7 @@ A Jellyfin plugin that intelligently nags users when they're transcoding due to 
 dotnet build --configuration Release
 ```
 
-Copy `bin/Release/net8.0/Jellyfin.Plugin.TranscodeNag.dll` into a versioned plugin folder, then restart Jellyfin.
+Copy `bin/Release/net8.0/Jellyfin.Plugin.TranscodeGuard.dll` into a versioned plugin folder, then restart Jellyfin.
 
 ## Configuration
 

--- a/TranscodeGuardRules.cs
+++ b/TranscodeGuardRules.cs
@@ -1,14 +1,14 @@
 using System;
 using System.Linq;
 using Jellyfin.Data.Enums;
-using Jellyfin.Plugin.TranscodeNag.Configuration;
-using Jellyfin.Plugin.TranscodeNag.Models;
+using Jellyfin.Plugin.TranscodeGuard.Configuration;
+using Jellyfin.Plugin.TranscodeGuard.Models;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Session;
 
-namespace Jellyfin.Plugin.TranscodeNag;
+namespace Jellyfin.Plugin.TranscodeGuard;
 
-internal static class TranscodeNagRules
+internal static class TranscodeGuardRules
 {
     internal static TranscodeReason BuildConfiguredNagReasonMask(string[]? configuredReasonNames)
     {

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,21 @@
 [
   {
     "category": "General",
+    "guid": "2ce6b237-2610-4dfd-a34b-3f4c2ac64a88",
+    "name": "Transcode Guard",
+    "description": "Intelligently alerts users when they transcode due to unsupported formats/codecs, while allowing bitrate-based transcoding without harassment. Successor to Transcode Nag, with a separate plugin identity: it installs alongside the old plugin rather than updating it, and does not carry its configuration over.",
+    "owner": "voc0der",
+    "overview": "Smart transcoding monitor that only alerts for format/codec incompatibility",
+    "imageUrl": "https://raw.githubusercontent.com/voc0der/jellyfin-plugin-transcode-guard/main/icon.png",
+    "versions": []
+  },
+  {
+    "category": "General",
     "guid": "fdcf27a6-bd64-42e3-9f57-41880552bf83",
     "name": "Transcode Nag",
-    "description": "Intelligently nags users when they transcode due to unsupported formats/codecs, while allowing bitrate-based transcoding without harassment.",
+    "description": "No longer maintained. This entry is frozen at 1.0.1.40 so existing installations keep working and are never offered an update. Its successor, Transcode Guard, is a separate plugin with its own identity: installing it will not touch this one, and it does not carry configuration over. Configure it once, then uninstall this plugin.",
     "owner": "voc0der",
-    "overview": "Smart transcoding monitor that only nags for format/codec incompatibility",
+    "overview": "Retired -- superseded by Transcode Guard, which installs alongside it",
     "imageUrl": "https://raw.githubusercontent.com/voc0der/jellyfin-plugin-transcode-guard/main/icon.png",
     "versions": [
       {

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/ClientMessageServiceTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/ClientMessageServiceTests.cs
@@ -1,9 +1,9 @@
-using Jellyfin.Plugin.TranscodeNag.Messaging;
+using Jellyfin.Plugin.TranscodeGuard.Messaging;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Session;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace Jellyfin.Plugin.TranscodeNag.Tests;
+namespace Jellyfin.Plugin.TranscodeGuard.Tests;
 
 public class ClientMessageServiceTests
 {

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/GpuAdmissionPolicyTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/GpuAdmissionPolicyTests.cs
@@ -1,7 +1,7 @@
-using Jellyfin.Plugin.TranscodeNag.Configuration;
-using Jellyfin.Plugin.TranscodeNag.Gpu;
+using Jellyfin.Plugin.TranscodeGuard.Configuration;
+using Jellyfin.Plugin.TranscodeGuard.Gpu;
 
-namespace Jellyfin.Plugin.TranscodeNag.Tests;
+namespace Jellyfin.Plugin.TranscodeGuard.Tests;
 
 public class GpuAdmissionPolicyTests
 {

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/GpuResourceGuardTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/GpuResourceGuardTests.cs
@@ -1,8 +1,8 @@
-using Jellyfin.Plugin.TranscodeNag.Configuration;
-using Jellyfin.Plugin.TranscodeNag.Gpu;
+using Jellyfin.Plugin.TranscodeGuard.Configuration;
+using Jellyfin.Plugin.TranscodeGuard.Gpu;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace Jellyfin.Plugin.TranscodeNag.Tests;
+namespace Jellyfin.Plugin.TranscodeGuard.Tests;
 
 public class GpuResourceGuardTests
 {

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/GpuVramEstimatorTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/GpuVramEstimatorTests.cs
@@ -1,6 +1,6 @@
-using Jellyfin.Plugin.TranscodeNag.Gpu;
+using Jellyfin.Plugin.TranscodeGuard.Gpu;
 
-namespace Jellyfin.Plugin.TranscodeNag.Tests;
+namespace Jellyfin.Plugin.TranscodeGuard.Tests;
 
 public class GpuVramEstimatorTests
 {

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/GuardedTranscodeManagerTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/GuardedTranscodeManagerTests.cs
@@ -1,6 +1,6 @@
-using Jellyfin.Plugin.TranscodeNag.Configuration;
-using Jellyfin.Plugin.TranscodeNag.Gpu;
-using Jellyfin.Plugin.TranscodeNag.Messaging;
+using Jellyfin.Plugin.TranscodeGuard.Configuration;
+using Jellyfin.Plugin.TranscodeGuard.Gpu;
+using Jellyfin.Plugin.TranscodeGuard.Messaging;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Net;
 using MediaBrowser.Controller.Streaming;
@@ -10,7 +10,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace Jellyfin.Plugin.TranscodeNag.Tests;
+namespace Jellyfin.Plugin.TranscodeGuard.Tests;
 
 public class GuardedTranscodeManagerTests
 {

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/Jellyfin.Plugin.TranscodeGuard.Tests.csproj
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/Jellyfin.Plugin.TranscodeGuard.Tests.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Jellyfin.Plugin.TranscodeNag.csproj" />
+    <ProjectReference Include="..\..\Jellyfin.Plugin.TranscodeGuard.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/NvidiaSmiGpuMemoryProviderTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/NvidiaSmiGpuMemoryProviderTests.cs
@@ -1,7 +1,7 @@
-using Jellyfin.Plugin.TranscodeNag.Gpu;
+using Jellyfin.Plugin.TranscodeGuard.Gpu;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace Jellyfin.Plugin.TranscodeNag.Tests;
+namespace Jellyfin.Plugin.TranscodeGuard.Tests;
 
 /// <summary>
 /// Exercises the real process path against stand-in executables, so the fail-open behaviour is

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/NvidiaSmiOutputParserTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/NvidiaSmiOutputParserTests.cs
@@ -1,6 +1,6 @@
-using Jellyfin.Plugin.TranscodeNag.Gpu;
+using Jellyfin.Plugin.TranscodeGuard.Gpu;
 
-namespace Jellyfin.Plugin.TranscodeNag.Tests;
+namespace Jellyfin.Plugin.TranscodeGuard.Tests;
 
 public class NvidiaSmiOutputParserTests
 {

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/NvidiaTranscodeDetectorTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/NvidiaTranscodeDetectorTests.cs
@@ -1,6 +1,6 @@
-using Jellyfin.Plugin.TranscodeNag.Gpu;
+using Jellyfin.Plugin.TranscodeGuard.Gpu;
 
-namespace Jellyfin.Plugin.TranscodeNag.Tests;
+namespace Jellyfin.Plugin.TranscodeGuard.Tests;
 
 public class NvidiaTranscodeDetectorTests
 {

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/PluginConfigurationCompatibilityTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/PluginConfigurationCompatibilityTests.cs
@@ -1,7 +1,7 @@
 using System.Xml.Serialization;
-using Jellyfin.Plugin.TranscodeNag.Configuration;
+using Jellyfin.Plugin.TranscodeGuard.Configuration;
 
-namespace Jellyfin.Plugin.TranscodeNag.Tests;
+namespace Jellyfin.Plugin.TranscodeGuard.Tests;
 
 public class PluginConfigurationCompatibilityTests
 {

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/TestApplicationPaths.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/TestApplicationPaths.cs
@@ -1,6 +1,6 @@
 using MediaBrowser.Common.Configuration;
 
-namespace Jellyfin.Plugin.TranscodeNag.Tests;
+namespace Jellyfin.Plugin.TranscodeGuard.Tests;
 
 internal sealed class TestApplicationPaths : IApplicationPaths
 {

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/TestDoubles.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/TestDoubles.cs
@@ -1,12 +1,12 @@
 using System.Linq;
-using Jellyfin.Plugin.TranscodeNag.Gpu;
-using Jellyfin.Plugin.TranscodeNag.Messaging;
+using Jellyfin.Plugin.TranscodeGuard.Gpu;
+using Jellyfin.Plugin.TranscodeGuard.Messaging;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Session;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace Jellyfin.Plugin.TranscodeNag.Tests;
+namespace Jellyfin.Plugin.TranscodeGuard.Tests;
 
 /// <summary>
 /// A canned free-VRAM reading, plus a count of how often it was asked for.

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/TranscodeEventStoreTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/TranscodeEventStoreTests.cs
@@ -1,9 +1,9 @@
-using Jellyfin.Plugin.TranscodeNag.Configuration;
-using Jellyfin.Plugin.TranscodeNag.Data;
-using Jellyfin.Plugin.TranscodeNag.Models;
+using Jellyfin.Plugin.TranscodeGuard.Configuration;
+using Jellyfin.Plugin.TranscodeGuard.Data;
+using Jellyfin.Plugin.TranscodeGuard.Models;
 using Microsoft.Extensions.Logging.Abstractions;
 
-namespace Jellyfin.Plugin.TranscodeNag.Tests;
+namespace Jellyfin.Plugin.TranscodeGuard.Tests;
 
 public class TranscodeEventStoreTests
 {
@@ -93,11 +93,11 @@ public class TranscodeEventStoreTests
         var status = await harness.Store.GetUserNagStatusAsync(
             userId,
             7,
-            e => TranscodeNagRules.IsClientAllowed(e.Client, config));
+            e => TranscodeGuardRules.IsClientAllowed(e.Client, config));
         var events = await harness.Store.GetUserEventsAsync(
             userId,
             7,
-            e => TranscodeNagRules.IsClientAllowed(e.Client, config));
+            e => TranscodeGuardRules.IsClientAllowed(e.Client, config));
 
         Assert.Equal(1, status.BadTranscodeCount);
         Assert.False(status.HasImprovementCredit);
@@ -124,11 +124,11 @@ public class TranscodeEventStoreTests
         var status = await harness.Store.GetUserNagStatusAsync(
             userId,
             7,
-            e => TranscodeNagRules.IsStoredEventAllowed(e, config));
+            e => TranscodeGuardRules.IsStoredEventAllowed(e, config));
         var events = await harness.Store.GetUserEventsAsync(
             userId,
             7,
-            e => TranscodeNagRules.IsStoredEventAllowed(e, config));
+            e => TranscodeGuardRules.IsStoredEventAllowed(e, config));
 
         Assert.Equal(1, status.BadTranscodeCount);
         Assert.False(status.HasImprovementCredit);

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/TranscodeGuardRulesTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/TranscodeGuardRulesTests.cs
@@ -1,17 +1,17 @@
 using Jellyfin.Data.Enums;
-using Jellyfin.Plugin.TranscodeNag.Configuration;
-using Jellyfin.Plugin.TranscodeNag.Models;
+using Jellyfin.Plugin.TranscodeGuard.Configuration;
+using Jellyfin.Plugin.TranscodeGuard.Models;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Session;
 
-namespace Jellyfin.Plugin.TranscodeNag.Tests;
+namespace Jellyfin.Plugin.TranscodeGuard.Tests;
 
-public class TranscodeNagRulesTests
+public class TranscodeGuardRulesTests
 {
     [Fact]
     public void BuildConfiguredNagReasonMask_UsesDefaultsWhenConfigurationIsNull()
     {
-        var mask = TranscodeNagRules.BuildConfiguredNagReasonMask(null);
+        var mask = TranscodeGuardRules.BuildConfiguredNagReasonMask(null);
 
         Assert.NotEqual((TranscodeReason)0, mask);
         Assert.True(mask.HasFlag(TranscodeReason.ContainerNotSupported));
@@ -22,7 +22,7 @@ public class TranscodeNagRulesTests
     [Fact]
     public void BuildConfiguredNagReasonMask_IgnoresEmptyAndUnknownReasons()
     {
-        var mask = TranscodeNagRules.BuildConfiguredNagReasonMask(
+        var mask = TranscodeGuardRules.BuildConfiguredNagReasonMask(
             new[]
             {
                 "VideoCodecNotSupported",
@@ -61,9 +61,9 @@ public class TranscodeNagRulesTests
             TranscodeReasons = (TranscodeReason)0
         };
 
-        Assert.True(TranscodeNagRules.ShouldNagTranscode(matching, config));
-        Assert.False(TranscodeNagRules.ShouldNagTranscode(nonMatching, config));
-        Assert.False(TranscodeNagRules.ShouldNagTranscode(noReasons, config));
+        Assert.True(TranscodeGuardRules.ShouldNagTranscode(matching, config));
+        Assert.False(TranscodeGuardRules.ShouldNagTranscode(nonMatching, config));
+        Assert.False(TranscodeGuardRules.ShouldNagTranscode(noReasons, config));
     }
 
     [Fact]
@@ -74,8 +74,8 @@ public class TranscodeNagRulesTests
             ExcludedClientPatterns = new[] { "android tv" }
         };
 
-        Assert.True(TranscodeNagRules.IsClientAllowed("Jellyfin Web", config));
-        Assert.False(TranscodeNagRules.IsClientAllowed("Jellyfin Android TV", config));
+        Assert.True(TranscodeGuardRules.IsClientAllowed("Jellyfin Web", config));
+        Assert.False(TranscodeGuardRules.IsClientAllowed("Jellyfin Android TV", config));
     }
 
     [Fact]
@@ -87,11 +87,11 @@ public class TranscodeNagRulesTests
             ExcludedClientPatterns = new[] { "chrome" }
         };
 
-        Assert.True(TranscodeNagRules.IsClientAllowed("Jellyfin Web", config));
-        Assert.True(TranscodeNagRules.IsClientAllowed("Firefox Browser", config));
-        Assert.False(TranscodeNagRules.IsClientAllowed("Jellyfin Android TV", config));
-        Assert.False(TranscodeNagRules.IsClientAllowed("Chrome Web", config));
-        Assert.False(TranscodeNagRules.IsClientAllowed(null, config));
+        Assert.True(TranscodeGuardRules.IsClientAllowed("Jellyfin Web", config));
+        Assert.True(TranscodeGuardRules.IsClientAllowed("Firefox Browser", config));
+        Assert.False(TranscodeGuardRules.IsClientAllowed("Jellyfin Android TV", config));
+        Assert.False(TranscodeGuardRules.IsClientAllowed("Chrome Web", config));
+        Assert.False(TranscodeGuardRules.IsClientAllowed(null, config));
     }
 
     [Fact]
@@ -105,9 +105,9 @@ public class TranscodeNagRulesTests
             MotdExcludedClientPatterns = new[] { "roku" }
         };
 
-        Assert.True(TranscodeNagRules.IsMotdClientAllowed("Jellyfin Android TV", config));
-        Assert.False(TranscodeNagRules.IsMotdClientAllowed("Jellyfin Web", config));
-        Assert.False(TranscodeNagRules.IsMotdClientAllowed("Jellyfin Roku", config));
+        Assert.True(TranscodeGuardRules.IsMotdClientAllowed("Jellyfin Android TV", config));
+        Assert.False(TranscodeGuardRules.IsMotdClientAllowed("Jellyfin Web", config));
+        Assert.False(TranscodeGuardRules.IsMotdClientAllowed("Jellyfin Roku", config));
     }
 
     [Fact]
@@ -118,9 +118,9 @@ public class TranscodeNagRulesTests
             ExcludedClientPatterns = new[] { "android tv" }
         };
 
-        Assert.True(TranscodeNagRules.IsMotdClientAllowed("Jellyfin Android TV", config));
-        Assert.True(TranscodeNagRules.IsMotdClientAllowed("Jellyfin Web", config));
-        Assert.True(TranscodeNagRules.IsMotdClientAllowed(null, config));
+        Assert.True(TranscodeGuardRules.IsMotdClientAllowed("Jellyfin Android TV", config));
+        Assert.True(TranscodeGuardRules.IsMotdClientAllowed("Jellyfin Web", config));
+        Assert.True(TranscodeGuardRules.IsMotdClientAllowed(null, config));
     }
 
     [Fact]
@@ -128,24 +128,24 @@ public class TranscodeNagRulesTests
     {
         var userId = Guid.NewGuid();
 
-        Assert.True(TranscodeNagRules.IsUserExcluded(userId, new[] { userId.ToString("N") }));
-        Assert.True(TranscodeNagRules.IsUserExcluded(userId, new[] { userId.ToString("D") }));
-        Assert.True(TranscodeNagRules.IsUserExcluded(userId, new[] { " ", userId.ToString("N").ToUpperInvariant() }));
-        Assert.False(TranscodeNagRules.IsUserExcluded(userId, new[] { Guid.NewGuid().ToString("N") }));
-        Assert.False(TranscodeNagRules.IsUserExcluded(userId, Array.Empty<string>()));
-        Assert.False(TranscodeNagRules.IsUserExcluded(userId, null));
-        Assert.False(TranscodeNagRules.IsUserExcluded(Guid.Empty, new[] { Guid.Empty.ToString("N") }));
+        Assert.True(TranscodeGuardRules.IsUserExcluded(userId, new[] { userId.ToString("N") }));
+        Assert.True(TranscodeGuardRules.IsUserExcluded(userId, new[] { userId.ToString("D") }));
+        Assert.True(TranscodeGuardRules.IsUserExcluded(userId, new[] { " ", userId.ToString("N").ToUpperInvariant() }));
+        Assert.False(TranscodeGuardRules.IsUserExcluded(userId, new[] { Guid.NewGuid().ToString("N") }));
+        Assert.False(TranscodeGuardRules.IsUserExcluded(userId, Array.Empty<string>()));
+        Assert.False(TranscodeGuardRules.IsUserExcluded(userId, null));
+        Assert.False(TranscodeGuardRules.IsUserExcluded(Guid.Empty, new[] { Guid.Empty.ToString("N") }));
     }
 
     [Fact]
     public void IsLiveTvItem_DetectsLiveAndLiveTvItemTypes()
     {
-        Assert.True(TranscodeNagRules.IsLiveTvItem(new BaseItemDto { IsLive = true, Type = BaseItemKind.Movie }));
-        Assert.True(TranscodeNagRules.IsLiveTvItem(new BaseItemDto { Type = BaseItemKind.TvChannel }));
-        Assert.True(TranscodeNagRules.IsLiveTvItem(new BaseItemDto { Type = BaseItemKind.LiveTvProgram }));
-        Assert.True(TranscodeNagRules.IsLiveTvItem(new BaseItemDto { Type = BaseItemKind.TvProgram }));
-        Assert.False(TranscodeNagRules.IsLiveTvItem(new BaseItemDto { Type = BaseItemKind.Movie }));
-        Assert.False(TranscodeNagRules.IsLiveTvItem(null));
+        Assert.True(TranscodeGuardRules.IsLiveTvItem(new BaseItemDto { IsLive = true, Type = BaseItemKind.Movie }));
+        Assert.True(TranscodeGuardRules.IsLiveTvItem(new BaseItemDto { Type = BaseItemKind.TvChannel }));
+        Assert.True(TranscodeGuardRules.IsLiveTvItem(new BaseItemDto { Type = BaseItemKind.LiveTvProgram }));
+        Assert.True(TranscodeGuardRules.IsLiveTvItem(new BaseItemDto { Type = BaseItemKind.TvProgram }));
+        Assert.False(TranscodeGuardRules.IsLiveTvItem(new BaseItemDto { Type = BaseItemKind.Movie }));
+        Assert.False(TranscodeGuardRules.IsLiveTvItem(null));
     }
 
     [Fact]
@@ -153,11 +153,11 @@ public class TranscodeNagRulesTests
     {
         var liveTvItem = new BaseItemDto { Type = BaseItemKind.TvChannel };
 
-        Assert.True(TranscodeNagRules.IsItemAllowed(liveTvItem, new PluginConfiguration()));
-        Assert.False(TranscodeNagRules.IsItemAllowed(
+        Assert.True(TranscodeGuardRules.IsItemAllowed(liveTvItem, new PluginConfiguration()));
+        Assert.False(TranscodeGuardRules.IsItemAllowed(
             liveTvItem,
             new PluginConfiguration { ExcludeLiveTv = true }));
-        Assert.True(TranscodeNagRules.IsItemAllowed(
+        Assert.True(TranscodeGuardRules.IsItemAllowed(
             new BaseItemDto { Type = BaseItemKind.Movie },
             new PluginConfiguration { ExcludeLiveTv = true }));
     }
@@ -171,13 +171,13 @@ public class TranscodeNagRulesTests
             ExcludedClientPatterns = new[] { "android tv" }
         };
 
-        Assert.True(TranscodeNagRules.IsStoredEventAllowed(
+        Assert.True(TranscodeGuardRules.IsStoredEventAllowed(
             new TranscodeEvent { Client = "Jellyfin Web" },
             config));
-        Assert.False(TranscodeNagRules.IsStoredEventAllowed(
+        Assert.False(TranscodeGuardRules.IsStoredEventAllowed(
             new TranscodeEvent { Client = "Jellyfin Web", IsLiveTv = true },
             config));
-        Assert.False(TranscodeNagRules.IsStoredEventAllowed(
+        Assert.False(TranscodeGuardRules.IsStoredEventAllowed(
             new TranscodeEvent { Client = "Jellyfin Android TV" },
             config));
     }
@@ -185,15 +185,15 @@ public class TranscodeNagRulesTests
     [Fact]
     public void ResolveLoginNagWindow_MapsMonthAndFallsBackToWeek()
     {
-        Assert.Equal((30, "month"), TranscodeNagRules.ResolveLoginNagWindow("Month"));
-        Assert.Equal((7, "week"), TranscodeNagRules.ResolveLoginNagWindow("Week"));
-        Assert.Equal((7, "week"), TranscodeNagRules.ResolveLoginNagWindow("anything-else"));
+        Assert.Equal((30, "month"), TranscodeGuardRules.ResolveLoginNagWindow("Month"));
+        Assert.Equal((7, "week"), TranscodeGuardRules.ResolveLoginNagWindow("Week"));
+        Assert.Equal((7, "week"), TranscodeGuardRules.ResolveLoginNagWindow("anything-else"));
     }
 
     [Fact]
     public void FormatLoginNagMessage_ReplacesBothPlaceholders()
     {
-        var message = TranscodeNagRules.FormatLoginNagMessage(
+        var message = TranscodeGuardRules.FormatLoginNagMessage(
             "Bad transcodes: {{transcodes}} this {{timewindow}}.",
             4,
             "month");

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/UnixFactAttribute.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/UnixFactAttribute.cs
@@ -1,4 +1,4 @@
-namespace Jellyfin.Plugin.TranscodeNag.Tests;
+namespace Jellyfin.Plugin.TranscodeGuard.Tests;
 
 /// <summary>
 /// A fact that is reported as skipped on Windows, for tests that need a POSIX shell to stand in


### PR DESCRIPTION
Makes Transcode Guard a **new plugin** rather than a new version of Transcode Nag.

## Why the cheaper renames don't work

Jellyfin derives two paths from names that look like labels:

| Name | What it actually controls |
|---|---|
| assembly name | the config file, `plugins/configurations/<assembly>.xml` |
| manifest `name` | the install directory, `plugins/<name>_<version>` |

Changing the manifest name alone is what broke 1.0.1.41: it installed to `plugins/Transcode Guard_1.0.1.41` beside the existing `plugins/Transcode Nag_1.0.1.40`, and because both directories held the same assembly name and GUID, the server loaded both into separate contexts and crashed casting configuration between them.

## What this does instead

- New GUID `2ce6b237-…`, new assembly `Jellyfin.Plugin.TranscodeGuard`, new namespace, new package/install names.
- Existing installs are **never offered this** — they stay on Transcode Nag 1.0.1.40 until the user opts in.
- Different assembly names mean the two cannot collide if both are installed.
- Separate config files, so neither disturbs the other.

## Manifest

`manifest.json` now carries both entries. Transcode Nag keeps its GUID, its name and all 39 versions untouched — the name is the install directory of every existing deployment — with only its prose changed to say it is retired. Its version list is frozen permanently.

To make that structural rather than conventional, the release workflow now selects its entry **by GUID** via a new `PLUGIN_GUID` constant instead of writing `.[0]`, and fails if that GUID doesn't match exactly one entry.

## Verification

Booted a real Jellyfin 10.11.11 with both plugins installed side by side, in the same layout that crashed:

```
Loaded assembly Jellyfin.Plugin.TranscodeGuard ... from plugins/Transcode Guard_1.0.1.43/...
Loaded assembly Jellyfin.Plugin.TranscodeNag   ... from plugins/Transcode Nag_1.0.1.40/...
Loaded plugin: Transcode Guard 1.0.1.43
Loaded plugin: Transcode Nag 1.0.1.40
```

Both `PlaybackMonitor`s ran, two separate config files were written (`Jellyfin.Plugin.TranscodeGuard.xml`, `Jellyfin.Plugin.TranscodeNag.xml`), and the boot log contained zero errors.

## Left alone deliberately

Config properties are still `NagMessage`, `EnableLoginNag`, etc., and the config page still says "Login Nag". Renaming them is free now (the new identity starts with no config to preserve) but it changes what the plugin calls its *features* rather than what it *is* — separate decision.

## Note on merging

Merging this pushes to `main` and cuts **1.0.1.43** as the first Transcode Guard release.