### PR TITLE
feat(reaper): stop transcodes left paused past a timeout

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -142,6 +142,13 @@ public class PluginConfiguration : BasePluginConfiguration
     public bool UseStickyPausedTranscodeMessages { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets a value indicating whether paused direct play is stopped on the same timeout.
+    /// Off by default: direct play holds an open file handle and a stream slot rather than VRAM or
+    /// an encoder session, and a client that ignores the stop cannot be ended server-side.
+    /// </summary>
+    public bool ReapPausedDirectPlay { get; set; } = false;
+
+    /// <summary>
     /// Gets or sets the users whose paused transcodes are left alone. Separate from every other
     /// exclusion list.
     /// </summary>

--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -110,6 +110,42 @@ public class PluginConfiguration : BasePluginConfiguration
     public string GpuGuardDeniedMessage { get; set; } = "GPU resources are currently busy. Please try again later or use Direct Play.";
 
     public bool UseStickyGpuGuardMessages { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether transcodes left paused past
+    /// <see cref="PausedTranscodeTimeoutMinutes"/> are stopped. Defaults to off so upgrading the
+    /// plugin cannot start ending anyone's playback on its own.
+    /// </summary>
+    public bool EnablePausedTranscodeReaper { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets how many minutes a transcode may stay paused before it is stopped.
+    /// </summary>
+    public int PausedTranscodeTimeoutMinutes { get; set; } = 25;
+
+    /// <summary>
+    /// Gets or sets how many minutes before the deadline the warning is sent. 0 sends no warning.
+    /// </summary>
+    public int PausedTranscodeWarningMinutes { get; set; } = 2;
+
+    /// <summary>
+    /// Gets or sets the popup title shown before a paused transcode is stopped.
+    /// </summary>
+    public string PausedTranscodeWarningHeader { get; set; } = "Still there?";
+
+    /// <summary>
+    /// Gets or sets the popup body shown before a paused transcode is stopped.
+    /// Supports <c>{{minutes}}</c>.
+    /// </summary>
+    public string PausedTranscodeWarningMessage { get; set; } = "Your paused video will be stopped in {{minutes}} minute(s) to free up server resources. Press play to keep watching.";
+
+    public bool UseStickyPausedTranscodeMessages { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets the users whose paused transcodes are left alone. Separate from every other
+    /// exclusion list.
+    /// </summary>
+    public string[] PausedTranscodeExcludedUserIds { get; set; } = Array.Empty<string>();
 }
 
 public class ReasonMessageOverride

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -310,8 +310,16 @@
                             <div class="fieldDescription checkboxFieldDescription">Sends each warning three times, 3 seconds apart, with a 4-second timeout to improve visibility on clients that dismiss Jellyfin messages quickly.</div>
                         </div>
 
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label>
+                                <input type="checkbox" is="emby-checkbox" id="chkReapPausedDirectPlay" name="chkReapPausedDirectPlay" />
+                                <span>Also stop paused direct play</span>
+                            </label>
+                            <div class="fieldDescription checkboxFieldDescription">Off by default. Direct play holds an open file handle and a stream slot rather than VRAM or an encoder session, so this frees far less than stopping a transcode. It is also stop-only: a direct play client that ignores the stop cannot be ended server-side, because there is no FFmpeg process to end.</div>
+                        </div>
+
                         <div class="fieldDescription" style="margin-bottom: 10px;">
-                            Exclude specific users from the reaper. Their paused transcodes are left running. This list is separate from every other exclusion list.
+                            Exclude specific users from the reaper. Their paused playback is left running. This list is separate from every other exclusion list.
                         </div>
 
                         <div style="margin-bottom: 20px;">
@@ -1119,6 +1127,7 @@
                     document.getElementById('txtPausedTranscodeWarningHeader').value = config.PausedTranscodeWarningHeader || '';
                     document.getElementById('txtPausedTranscodeWarningMessage').value = config.PausedTranscodeWarningMessage || '';
                     document.getElementById('chkUseStickyPausedTranscodeMessages').checked = config.UseStickyPausedTranscodeMessages === true;
+                    document.getElementById('chkReapPausedDirectPlay').checked = config.ReapPausedDirectPlay === true;
                     MotdSection.updateVisibility();
                     GpuGuardSection.updateVisibility();
                     PausedReaperSection.updateVisibility();
@@ -1165,6 +1174,7 @@
                     config.PausedTranscodeWarningHeader = document.getElementById('txtPausedTranscodeWarningHeader').value;
                     config.PausedTranscodeWarningMessage = document.getElementById('txtPausedTranscodeWarningMessage').value;
                     config.UseStickyPausedTranscodeMessages = document.getElementById('chkUseStickyPausedTranscodeMessages').checked;
+                    config.ReapPausedDirectPlay = document.getElementById('chkReapPausedDirectPlay').checked;
                     config.AlertTranscodeReasons = ReasonSelector.getSelectedReasonNames();
                     config.ReasonMessageOverrides = ReasonSelector.getReasonMessageOverrides();
 

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -259,6 +259,68 @@
                         </div>
                     </div>
 
+                    <h2>Paused Transcode Reaper</h2>
+                    <div class="fieldDescription" style="margin-bottom: 12px;">
+                        Jellyfin never evicts a paused transcode on its own: a paused client keeps checking in,
+                        so its FFmpeg process keeps holding VRAM, an encoder session, and its output files for
+                        as long as someone leaves the pause screen up. This stops a transcode that has been
+                        paused for too long. The client is asked to stop first, which leaves a resume point
+                        behind; a client that ignores that has its FFmpeg job ended server-side. Neither path
+                        signs the user out or removes their device.
+                    </div>
+
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input type="checkbox" is="emby-checkbox" id="chkEnablePausedTranscodeReaper" name="chkEnablePausedTranscodeReaper" />
+                            <span>Stop transcodes left paused</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">Off by default. Applies to every paused transcode, including Live TV and CPU transcodes. Direct play is never touched, because it holds nothing to reclaim.</div>
+                    </div>
+
+                    <div id="pausedReaperOptions" style="display: none;">
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtPausedTranscodeTimeoutMinutes">Stop after paused for (minutes):</label>
+                            <input type="number" id="txtPausedTranscodeTimeoutMinutes" name="txtPausedTranscodeTimeoutMinutes" min="1" max="1440" class="emby-input" />
+                            <div class="fieldDescription">How long a transcode may sit paused before it is stopped. The clock restarts whenever playback resumes or the viewer seeks.</div>
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtPausedTranscodeWarningMinutes">Warn this many minutes first:</label>
+                            <input type="number" id="txtPausedTranscodeWarningMinutes" name="txtPausedTranscodeWarningMinutes" min="0" max="60" class="emby-input" />
+                            <div class="fieldDescription">Sends one popup this long before the stop, giving the viewer a chance to press play. Set to 0 to stop without warning.</div>
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtPausedTranscodeWarningHeader">Warning Title:</label>
+                            <input type="text" id="txtPausedTranscodeWarningHeader" name="txtPausedTranscodeWarningHeader" class="emby-input" />
+                            <div class="fieldDescription">Title of the popup shown before the stop.</div>
+                        </div>
+
+                        <div class="selectContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtPausedTranscodeWarningMessage">Warning Message:</label>
+                            <textarea id="txtPausedTranscodeWarningMessage" name="txtPausedTranscodeWarningMessage" rows="3" class="emby-input"></textarea>
+                            <div class="fieldDescription">Supports <code>{{minutes}}</code>, replaced with the minutes left before the stop.</div>
+                        </div>
+
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label>
+                                <input type="checkbox" is="emby-checkbox" id="chkUseStickyPausedTranscodeMessages" name="chkUseStickyPausedTranscodeMessages" />
+                                <span>Sticky Messages</span>
+                            </label>
+                            <div class="fieldDescription checkboxFieldDescription">Sends each warning three times, 3 seconds apart, with a 4-second timeout to improve visibility on clients that dismiss Jellyfin messages quickly.</div>
+                        </div>
+
+                        <div class="fieldDescription" style="margin-bottom: 10px;">
+                            Exclude specific users from the reaper. Their paused transcodes are left running. This list is separate from every other exclusion list.
+                        </div>
+
+                        <div style="margin-bottom: 20px;">
+                            <button is="emby-button" type="button" id="btnManagePausedTranscodeExclusions" class="raised block emby-button">
+                                <span>Manage Excluded Users (Paused Transcodes)</span>
+                            </button>
+                        </div>
+                    </div>
+
                     <div>
                         <button is="emby-button" type="submit" class="raised button-submit block">
                             <span>Save</span>
@@ -325,6 +387,38 @@
                             <span>Save</span>
                         </button>
                         <button is="emby-button" type="button" id="btnCancelMotdExclusions" class="raised">
+                            <span>Cancel</span>
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Paused Transcode User Exclusion Modal -->
+            <div id="pausedTranscodeUserExclusionModal" style="display: none; position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.7); z-index: 1000; overflow-y: auto;">
+                <div style="background: var(--theme-background-content); margin: 50px auto; max-width: 600px; padding: 20px; border-radius: 4px;">
+                    <h2>Select Users to Exclude from the Paused Transcode Reaper</h2>
+                    <div class="fieldDescription" style="margin-bottom: 15px;">
+                        By default, every user's paused transcodes are stopped. Uncheck users to leave their paused transcodes running indefinitely.
+                    </div>
+                    <div style="display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 12px;">
+                        <button is="emby-button" type="button" id="btnPausedTranscodeUsersSelectAll" class="raised">
+                            <span>Select All</span>
+                        </button>
+                        <button is="emby-button" type="button" id="btnPausedTranscodeUsersResetDefaults" class="raised">
+                            <span>Reset Defaults</span>
+                        </button>
+                        <button is="emby-button" type="button" id="btnPausedTranscodeUsersClearAll" class="raised">
+                            <span>Clear All</span>
+                        </button>
+                    </div>
+                    <div id="pausedTranscodeUserExclusionList" style="max-height: 400px; overflow-y: auto; margin-bottom: 20px;">
+                        <!-- User checkboxes will be populated here -->
+                    </div>
+                    <div style="display: flex; gap: 10px;">
+                        <button is="emby-button" type="button" id="btnSavePausedTranscodeExclusions" class="raised button-submit">
+                            <span>Save</span>
+                        </button>
+                        <button is="emby-button" type="button" id="btnCancelPausedTranscodeExclusions" class="raised">
                             <span>Cancel</span>
                         </button>
                     </div>
@@ -653,6 +747,36 @@
                 }
             };
 
+            // Keeps the paused transcode reaper block collapsed unless the feature is switched on.
+            var PausedReaperSection = {
+                initialized: false,
+
+                init: function() {
+                    if (this.initialized) {
+                        return;
+                    }
+
+                    document.getElementById('chkEnablePausedTranscodeReaper').addEventListener('change', this.updateVisibility);
+                    this.initialized = true;
+                },
+
+                updateVisibility: function() {
+                    var enabled = document.getElementById('chkEnablePausedTranscodeReaper').checked;
+                    document.getElementById('pausedReaperOptions').style.display = enabled ? 'block' : 'none';
+                },
+
+                // A blank or non-numeric field must not be saved as NaN.
+                readNumber: function(elementId, fallback) {
+                    var parsed = parseInt(document.getElementById(elementId).value, 10);
+                    return isNaN(parsed) || parsed < 0 ? fallback : parsed;
+                },
+
+                // A saved 0 is a real value here, so it must not be treated as "unset".
+                numberOrDefault: function(value, fallback) {
+                    return typeof value === 'number' && isFinite(value) && value >= 0 ? value : fallback;
+                }
+            };
+
             var LiveSessionMonitor = {
                 initialized: false,
                 refreshTimer: null,
@@ -961,6 +1085,8 @@
                 MotdUserExclusionManager.init();
                 MotdSection.init();
                 GpuGuardSection.init();
+                PausedTranscodeUserExclusionManager.init();
+                PausedReaperSection.init();
                 ApiClient.getPluginConfiguration(TranscodeGuardConfig.pluginId).then(function (config) {
                     document.getElementById('txtNagMessage').value = config.NagMessage || '';
                     document.getElementById('chkUseStickyPlaybackMessages').checked = config.UseStickyPlaybackMessages === true;
@@ -987,8 +1113,15 @@
                     document.getElementById('txtGpuGuardDeniedHeader').value = config.GpuGuardDeniedHeader || '';
                     document.getElementById('txtGpuGuardDeniedMessage').value = config.GpuGuardDeniedMessage || '';
                     document.getElementById('chkUseStickyGpuGuardMessages').checked = config.UseStickyGpuGuardMessages === true;
+                    document.getElementById('chkEnablePausedTranscodeReaper').checked = config.EnablePausedTranscodeReaper === true;
+                    document.getElementById('txtPausedTranscodeTimeoutMinutes').value = PausedReaperSection.numberOrDefault(config.PausedTranscodeTimeoutMinutes, 25);
+                    document.getElementById('txtPausedTranscodeWarningMinutes').value = PausedReaperSection.numberOrDefault(config.PausedTranscodeWarningMinutes, 2);
+                    document.getElementById('txtPausedTranscodeWarningHeader').value = config.PausedTranscodeWarningHeader || '';
+                    document.getElementById('txtPausedTranscodeWarningMessage').value = config.PausedTranscodeWarningMessage || '';
+                    document.getElementById('chkUseStickyPausedTranscodeMessages').checked = config.UseStickyPausedTranscodeMessages === true;
                     MotdSection.updateVisibility();
                     GpuGuardSection.updateVisibility();
+                    PausedReaperSection.updateVisibility();
                     ReasonSelector.render(config.AlertTranscodeReasons, config.ReasonMessageOverrides);
                     LiveSessionMonitor.refresh(false, config);
                     LiveSessionMonitor.startRefreshTimer();
@@ -1026,6 +1159,12 @@
                     config.GpuGuardDeniedHeader = document.getElementById('txtGpuGuardDeniedHeader').value;
                     config.GpuGuardDeniedMessage = document.getElementById('txtGpuGuardDeniedMessage').value;
                     config.UseStickyGpuGuardMessages = document.getElementById('chkUseStickyGpuGuardMessages').checked;
+                    config.EnablePausedTranscodeReaper = document.getElementById('chkEnablePausedTranscodeReaper').checked;
+                    config.PausedTranscodeTimeoutMinutes = PausedReaperSection.readNumber('txtPausedTranscodeTimeoutMinutes', 25);
+                    config.PausedTranscodeWarningMinutes = PausedReaperSection.readNumber('txtPausedTranscodeWarningMinutes', 2);
+                    config.PausedTranscodeWarningHeader = document.getElementById('txtPausedTranscodeWarningHeader').value;
+                    config.PausedTranscodeWarningMessage = document.getElementById('txtPausedTranscodeWarningMessage').value;
+                    config.UseStickyPausedTranscodeMessages = document.getElementById('chkUseStickyPausedTranscodeMessages').checked;
                     config.AlertTranscodeReasons = ReasonSelector.getSelectedReasonNames();
                     config.ReasonMessageOverrides = ReasonSelector.getReasonMessageOverrides();
 
@@ -1196,6 +1335,20 @@
                 configProperty: 'MotdExcludedUserIds',
                 allIncludedMessage: 'All users will now receive the MOTD.',
                 excludedMessageSuffix: ' user(s) excluded from the MOTD.'
+            });
+
+            var PausedTranscodeUserExclusionManager = createUserExclusionManager({
+                modalId: 'pausedTranscodeUserExclusionModal',
+                listId: 'pausedTranscodeUserExclusionList',
+                openButtonId: 'btnManagePausedTranscodeExclusions',
+                saveButtonId: 'btnSavePausedTranscodeExclusions',
+                cancelButtonId: 'btnCancelPausedTranscodeExclusions',
+                selectAllButtonId: 'btnPausedTranscodeUsersSelectAll',
+                resetButtonId: 'btnPausedTranscodeUsersResetDefaults',
+                clearAllButtonId: 'btnPausedTranscodeUsersClearAll',
+                configProperty: 'PausedTranscodeExcludedUserIds',
+                allIncludedMessage: 'Paused transcodes will now be stopped for all users.',
+                excludedMessageSuffix: ' user(s) excluded from the paused transcode reaper.'
             });
 
             document.getElementById('TranscodeGuardConfigPage').addEventListener('pagehide', function() {

--- a/PluginServiceRegistrator.cs
+++ b/PluginServiceRegistrator.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Jellyfin.Plugin.TranscodeGuard.Gpu;
 using Jellyfin.Plugin.TranscodeGuard.Messaging;
+using Jellyfin.Plugin.TranscodeGuard.Sessions;
 using MediaBrowser.Controller;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Plugins;
@@ -25,6 +26,7 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
         serviceCollection.AddSingleton<IGpuMemoryProvider, NvidiaSmiGpuMemoryProvider>();
         serviceCollection.AddSingleton<GpuResourceGuard>();
         serviceCollection.AddHostedService<PlaybackMonitor>();
+        serviceCollection.AddHostedService<PausedTranscodeReaper>();
 
         TryDecorateTranscodeManager(serviceCollection);
     }

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ A Jellyfin plugin that intelligently nags users when they're transcoding due to 
 - Includes a live session monitor in the plugin settings page.
 - Can broadcast an optional Message of the Day to users at login, with its own user exclusions and client filters.
 - Can refuse an NVIDIA hardware transcode before FFmpeg starts when that job's conservative VRAM budget will not fit.
+- Can stop a transcode that has been left paused past a configurable timeout, so its FFmpeg process stops holding VRAM, an encoder session, and its output files for a viewer who is not coming back.
 
 ## Installation
 
@@ -97,6 +98,7 @@ Open **Dashboard** → **Plugins** → **Transcode Guard**.
 - If you want login nags, enable them and set the threshold, time window, and message. The login message supports `{{transcodes}}` and `{{timewindow}}`.
 - Use **Manage Excluded Users** to opt users out of both playback and login nags.
 - Use the built-in live session monitor to see which active sessions currently match your rules.
+- Enable the **Paused Transcode Reaper** (off by default) to stop transcodes left paused past a timeout, 25 minutes by default. The client is asked to stop first, which leaves the resume point the last progress report saved; a client that ignores that has its FFmpeg job ended server-side. Neither path signs the user out or removes their device. It applies to every paused transcode, including Live TV and CPU transcodes, and never touches direct play. Optionally warn the viewer first with a popup supporting `{{minutes}}`, and use **Manage Excluded Users (Paused Transcodes)** to leave chosen users' paused streams alone.
 - Enable **Message of the Day** (off by default) to send an announcement to everyone at login. Its options stay collapsed until the toggle is on, and it has its own message, its own **Manage Excluded Users (MOTD)** list, and its own client include/exclude filters, all independent of the nag settings.
 - Enable **GPU resource guard** (off by default) to set the fallback GPU index, nvidia-smi timeout and path, and the message a refused client sees. The guard reads current free memory immediately before launch and automatically budgets each job from its source, CUDA filters, and output instead of using a fixed free-VRAM threshold. An explicit GPU selected by FFmpeg overrides the fallback index. `nvidia-smi` must be runnable by the Jellyfin server process.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <img src="https://img.shields.io/github/v/release/voc0der/jellyfin-plugin-transcode-guard?label=stable%20release" alt="Stable release version" />
   </a>
   <a href="https://github.com/voc0der/jellyfin-plugin-transcode-guard/tree/main/tests">
-    <img src="https://img.shields.io/badge/coverage-65%25-yellowgreen" alt="Code coverage percentage" />
+    <img src="https://img.shields.io/badge/coverage-69%25-yellowgreen" alt="Code coverage percentage" />
   </a>
   <a href="https://github.com/voc0der/jellyfin-plugin-transcode-guard/issues">
     <img src="https://img.shields.io/github/issues/voc0der/jellyfin-plugin-transcode-guard?color=DAA520" alt="Open issues" />
@@ -98,7 +98,7 @@ Open **Dashboard** → **Plugins** → **Transcode Guard**.
 - If you want login nags, enable them and set the threshold, time window, and message. The login message supports `{{transcodes}}` and `{{timewindow}}`.
 - Use **Manage Excluded Users** to opt users out of both playback and login nags.
 - Use the built-in live session monitor to see which active sessions currently match your rules.
-- Enable the **Paused Transcode Reaper** (off by default) to stop transcodes left paused past a timeout, 25 minutes by default. The client is asked to stop first, which leaves the resume point the last progress report saved; a client that ignores that has its FFmpeg job ended server-side. Neither path signs the user out or removes their device. It applies to every paused transcode, including Live TV and CPU transcodes, and never touches direct play. Optionally warn the viewer first with a popup supporting `{{minutes}}`, and use **Manage Excluded Users (Paused Transcodes)** to leave chosen users' paused streams alone.
+- Enable the **Paused Transcode Reaper** (off by default) to stop transcodes left paused past a timeout, 25 minutes by default. The client is asked to stop first, which leaves the resume point the last progress report saved; a client that ignores that has its FFmpeg job ended server-side. Neither path signs the user out or removes their device. It applies to every paused transcode, including Live TV and CPU transcodes, and never touches direct play. Optionally warn the viewer first with a popup supporting `{{minutes}}`, and use **Manage Excluded Users (Paused Transcodes)** to leave chosen users' paused streams alone. **Also stop paused direct play** (off by default) widens it to every paused session; direct play is stop-only, since there is no FFmpeg process to end if the client ignores the stop.
 - Enable **Message of the Day** (off by default) to send an announcement to everyone at login. Its options stay collapsed until the toggle is on, and it has its own message, its own **Manage Excluded Users (MOTD)** list, and its own client include/exclude filters, all independent of the nag settings.
 - Enable **GPU resource guard** (off by default) to set the fallback GPU index, nvidia-smi timeout and path, and the message a refused client sees. The guard reads current free memory immediately before launch and automatically budgets each job from its source, CUDA filters, and output instead of using a fixed free-VRAM threshold. An explicit GPU selected by FFmpeg overrides the fallback index. `nvidia-smi` must be runnable by the Jellyfin server process.
 

--- a/Sessions/PausedTranscodeReaper.cs
+++ b/Sessions/PausedTranscodeReaper.cs
@@ -1,0 +1,326 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.TranscodeGuard.Configuration;
+using Jellyfin.Plugin.TranscodeGuard.Messaging;
+using MediaBrowser.Controller.MediaEncoding;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Session;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.TranscodeGuard.Sessions;
+
+/// <summary>
+/// Ends transcodes that have been sitting paused past the configured timeout, so their FFmpeg
+/// process stops holding VRAM, an encoder session, and its output files for a viewer who is not
+/// coming back.
+/// </summary>
+/// <remarks>
+/// The clean path is a Stop playstate command: the client stops, reports playback stopped, and
+/// Jellyfin tears the job down the same way it would for any other stop, leaving the resume point
+/// the last progress report saved. Killing the FFmpeg job is only the backstop for clients that
+/// ignore the command, and it ends the transcode alone - the session stays connected and the user
+/// stays signed in.
+/// </remarks>
+public sealed class PausedTranscodeReaper : IHostedService, IDisposable
+{
+    private const string WarningMessageContext = "paused transcode warning";
+    private const string DefaultWarningHeader = "Still there?";
+    private const string DefaultWarningMessage = "Your paused video will be stopped in {{minutes}} minute(s) to free up server resources. Press play to keep watching.";
+
+    private static readonly TimeSpan TickInterval = TimeSpan.FromSeconds(15);
+
+    private readonly Func<IEnumerable<SessionInfo>> _sessionsAccessor;
+    private readonly Func<SessionInfo, CancellationToken, Task> _stopSender;
+    private readonly IClientMessageService _clientMessageService;
+    private readonly IServiceProvider? _serviceProvider;
+    private readonly ILogger<PausedTranscodeReaper> _logger;
+    private readonly PausedTranscodeTracker _tracker = new();
+    private readonly CancellationTokenSource _stopping = new();
+
+    private Func<string, Task>? _transcodeKiller;
+    private bool _transcodeKillerResolved;
+    private Timer? _timer;
+    private int _tickInProgress;
+    private bool _disposed;
+
+    public PausedTranscodeReaper(
+        ISessionManager sessionManager,
+        IClientMessageService clientMessageService,
+        IServiceProvider serviceProvider,
+        ILogger<PausedTranscodeReaper> logger)
+    {
+        ArgumentNullException.ThrowIfNull(sessionManager);
+
+        _sessionsAccessor = () => sessionManager.Sessions;
+        _stopSender = (session, cancellationToken) => sessionManager.SendPlaystateCommand(
+            null,
+            session.Id,
+            new PlaystateRequest { Command = PlaystateCommand.Stop },
+            cancellationToken);
+        _clientMessageService = clientMessageService;
+        _serviceProvider = serviceProvider;
+        _logger = logger;
+    }
+
+    internal PausedTranscodeReaper(
+        Func<IEnumerable<SessionInfo>> sessionsAccessor,
+        Func<SessionInfo, CancellationToken, Task> stopSender,
+        Func<string, Task>? transcodeKiller,
+        IClientMessageService clientMessageService,
+        ILogger<PausedTranscodeReaper> logger)
+    {
+        _sessionsAccessor = sessionsAccessor ?? throw new ArgumentNullException(nameof(sessionsAccessor));
+        _stopSender = stopSender ?? throw new ArgumentNullException(nameof(stopSender));
+        _transcodeKiller = transcodeKiller;
+        _transcodeKillerResolved = true;
+        _clientMessageService = clientMessageService;
+        _logger = logger;
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _timer = new Timer(OnTick, null, TickInterval, TickInterval);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _timer?.Dispose();
+        _timer = null;
+        return Task.CompletedTask;
+    }
+
+    private void OnTick(object? state)
+    {
+        // A tick that outlives its interval must not overlap the next one: two passes over the
+        // same session would send the stop command twice.
+        if (Interlocked.CompareExchange(ref _tickInProgress, 1, 0) != 0)
+        {
+            return;
+        }
+
+        _ = RunTickAsync();
+    }
+
+    private async Task RunTickAsync()
+    {
+        try
+        {
+            var config = Plugin.Instance?.Configuration;
+            if (config == null)
+            {
+                return;
+            }
+
+            await RunOnceAsync(config, DateTime.UtcNow).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            _logger.LogError(ex, "Error reaping paused transcodes");
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _tickInProgress, 0);
+        }
+    }
+
+    /// <summary>
+    /// Runs one pass of the escalation. Separated from the timer so tests can drive it with their
+    /// own clock.
+    /// </summary>
+    /// <param name="config">The plugin configuration.</param>
+    /// <param name="utcNow">The current UTC time.</param>
+    /// <returns>A task that completes when every due action has been attempted.</returns>
+    internal async Task RunOnceAsync(PluginConfiguration config, DateTime utcNow)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (!config.EnablePausedTranscodeReaper)
+        {
+            // Nobody should inherit a part-run clock from the last time this was switched on.
+            _tracker.Reset();
+            return;
+        }
+
+        var verdicts = _tracker.Evaluate(_sessionsAccessor(), config, utcNow);
+
+        foreach (var verdict in verdicts)
+        {
+            // One session's failure is not the next session's problem.
+            try
+            {
+                await ApplyAsync(verdict, config).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OutOfMemoryException)
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to {Action} the paused transcode on session {SessionId}",
+                    verdict.Action,
+                    verdict.Session.Id ?? "Unknown");
+            }
+        }
+    }
+
+    private Task ApplyAsync(PausedTranscodeVerdict verdict, PluginConfiguration config)
+        => verdict.Action switch
+        {
+            PausedTranscodeAction.Warn => SendWarningAsync(verdict, config),
+            PausedTranscodeAction.Stop => SendStopAsync(verdict, config),
+            PausedTranscodeAction.Kill => KillAsync(verdict),
+            _ => Task.CompletedTask
+        };
+
+    private async Task SendWarningAsync(PausedTranscodeVerdict verdict, PluginConfiguration config)
+    {
+        var session = verdict.Session;
+
+        await _clientMessageService.SendMessageAsync(
+            session,
+            new MessageCommand
+            {
+                // An admin who blanks these fields should still get a usable popup.
+                Header = Fallback(config.PausedTranscodeWarningHeader, DefaultWarningHeader),
+                Text = PausedTranscodeTracker.FormatWarningMessage(
+                    Fallback(config.PausedTranscodeWarningMessage, DefaultWarningMessage),
+                    verdict.MinutesUntilStop),
+                TimeoutMs = config.MessageTimeoutMs
+            },
+            config.UseStickyPausedTranscodeMessages,
+            WarningMessageContext,
+            FormatPausedFor(verdict),
+            config.EnableLogging,
+            _logger,
+            _stopping.Token).ConfigureAwait(false);
+    }
+
+    private async Task SendStopAsync(PausedTranscodeVerdict verdict, PluginConfiguration config)
+    {
+        var session = verdict.Session;
+
+        _logger.LogInformation(
+            "Stopping the transcode for {ItemName} on session {SessionId} ({UserName} / {Client}): paused for {PausedMinutes} minute(s), limit is {TimeoutMinutes}",
+            session.NowPlayingItem?.Name ?? "Unknown",
+            session.Id ?? "Unknown",
+            session.UserName ?? "Unknown",
+            session.Client ?? "Unknown",
+            Math.Round(verdict.PausedFor.TotalMinutes),
+            PausedTranscodeTracker.ResolveTimeoutMinutes(config));
+
+        // The client is asked rather than told: stopping this way reports playback stopped, which
+        // is what tears the FFmpeg job down cleanly and keeps the resume point tidy.
+        await _stopSender(session, _stopping.Token).ConfigureAwait(false);
+    }
+
+    private async Task KillAsync(PausedTranscodeVerdict verdict)
+    {
+        var session = verdict.Session;
+        var deviceId = session.DeviceId;
+
+        if (string.IsNullOrWhiteSpace(deviceId))
+        {
+            _logger.LogWarning(
+                "Session {SessionId} ignored the stop command and has no device ID, so its transcode cannot be ended",
+                session.Id ?? "Unknown");
+            return;
+        }
+
+        var killer = ResolveTranscodeKiller();
+        if (killer == null)
+        {
+            return;
+        }
+
+        _logger.LogInformation(
+            "Session {SessionId} ({UserName} / {Client}) did not act on the stop command; ending its FFmpeg job. The session stays signed in.",
+            session.Id ?? "Unknown",
+            session.UserName ?? "Unknown",
+            session.Client ?? "Unknown");
+
+        await killer(deviceId).ConfigureAwait(false);
+    }
+
+    private Func<string, Task>? ResolveTranscodeKiller()
+    {
+        if (_transcodeKillerResolved)
+        {
+            return _transcodeKiller;
+        }
+
+        _transcodeKillerResolved = true;
+
+        try
+        {
+            _transcodeKiller = BuildTranscodeKiller();
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            _logger.LogWarning(
+                ex,
+                "Jellyfin's transcode manager is unavailable, so a client that ignores the stop command keeps its transcode");
+        }
+
+        if (_transcodeKiller == null)
+        {
+            _logger.LogWarning(
+                "Jellyfin's transcode manager could not be resolved; paused transcodes can only be stopped through the client, not ended server-side");
+        }
+
+        return _transcodeKiller;
+    }
+
+    /// <summary>
+    /// Builds the kill callback over strings only, so nothing outside this method mentions
+    /// <c>ITranscodeManager</c>.
+    /// </summary>
+    /// <remarks>
+    /// That type does not exist before Jellyfin 10.10. Isolating it behind a non-inlined method
+    /// keeps a type load failure on an older server inside the catch above, where it costs the
+    /// server-side kill and nothing else, rather than taking the whole hosted service down.
+    /// </remarks>
+    /// <returns>A callback that ends every transcode belonging to a device, or null.</returns>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private Func<string, Task>? BuildTranscodeKiller()
+    {
+        var transcodeManager = _serviceProvider?.GetService<ITranscodeManager>();
+        if (transcodeManager == null)
+        {
+            return null;
+        }
+
+        // A null play session ID means "every job on this device", which is the only handle a
+        // SessionInfo gives us. In practice a device has one transcode at a time, and this is the
+        // same call Jellyfin makes for itself when playback stops.
+        return deviceId => transcodeManager.KillTranscodingJobs(deviceId, null, _ => true);
+    }
+
+    private static string FormatPausedFor(PausedTranscodeVerdict verdict)
+        => string.Create(
+            CultureInfo.InvariantCulture,
+            $"Paused for {Math.Round(verdict.PausedFor.TotalMinutes)} minute(s)");
+
+    private static string Fallback(string? configured, string defaultText)
+        => string.IsNullOrWhiteSpace(configured) ? defaultText : configured;
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _timer?.Dispose();
+        _timer = null;
+
+        // Pending warning deliveries are cancelled rather than left running against a stopped server.
+        _stopping.Cancel();
+        _stopping.Dispose();
+    }
+}

--- a/Sessions/PausedTranscodeTracker.cs
+++ b/Sessions/PausedTranscodeTracker.cs
@@ -1,0 +1,276 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Jellyfin.Plugin.TranscodeGuard.Configuration;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Session;
+
+namespace Jellyfin.Plugin.TranscodeGuard.Sessions;
+
+/// <summary>
+/// What should happen to one paused transcoding session on this tick.
+/// </summary>
+internal enum PausedTranscodeAction
+{
+    /// <summary>
+    /// Tell the user their paused stream is about to be stopped.
+    /// </summary>
+    Warn,
+
+    /// <summary>
+    /// Ask the client to stop playback, which tears the FFmpeg job down through Jellyfin's
+    /// normal playback-stopped path and leaves a resume point behind.
+    /// </summary>
+    Stop,
+
+    /// <summary>
+    /// The client did not act on the stop command, so end the FFmpeg job server-side.
+    /// </summary>
+    Kill
+}
+
+/// <summary>
+/// One session's due action, with the timing detail its message and log line need.
+/// </summary>
+internal sealed class PausedTranscodeVerdict
+{
+    internal PausedTranscodeVerdict(
+        SessionInfo session,
+        PausedTranscodeAction action,
+        TimeSpan pausedFor,
+        int minutesUntilStop)
+    {
+        Session = session;
+        Action = action;
+        PausedFor = pausedFor;
+        MinutesUntilStop = minutesUntilStop;
+    }
+
+    internal SessionInfo Session { get; }
+
+    internal PausedTranscodeAction Action { get; }
+
+    internal TimeSpan PausedFor { get; }
+
+    /// <summary>
+    /// Gets whole minutes left before the stop, rounded up and never below 1. Only meaningful
+    /// for <see cref="PausedTranscodeAction.Warn"/>.
+    /// </summary>
+    internal int MinutesUntilStop { get; }
+}
+
+/// <summary>
+/// Decides which paused transcodes are due to be warned, stopped, and killed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Jellyfin never evicts a paused transcode on its own. Its kill timer is driven by client
+/// check-ins, and a paused client keeps checking in, so <c>IsUserPaused</c> is recorded on the job
+/// and then only consulted for throttling. The FFmpeg process therefore survives - holding its
+/// CUDA context, hardware frame pool, and NVENC session slot - for as long as the client is
+/// willing to sit on the pause screen.
+/// </para>
+/// <para>
+/// All timing lives here, with no Jellyfin service dependencies, so the escalation can be tested
+/// against a clock the test controls.
+/// </para>
+/// </remarks>
+internal sealed class PausedTranscodeTracker
+{
+    internal const int MinTimeoutMinutes = 1;
+    internal const int MaxTimeoutMinutes = 1440;
+
+    /// <summary>
+    /// How long a client gets to act on the stop command before the job is killed outright.
+    /// </summary>
+    internal static readonly TimeSpan StopGracePeriod = TimeSpan.FromSeconds(10);
+
+    // Keyed by SessionInfo instance rather than ID: Jellyfin derives session IDs from
+    // client/device identifiers, so a later session can reuse the ID of one that ended.
+    private readonly Dictionary<SessionInfo, TrackedSession> _tracked = new(ReferenceEqualityComparer.Instance);
+
+    /// <summary>
+    /// Applies the configured timeout, keeping a hand-edited configuration inside sane bounds.
+    /// </summary>
+    /// <param name="config">The plugin configuration.</param>
+    /// <returns>The effective timeout in minutes.</returns>
+    internal static int ResolveTimeoutMinutes(PluginConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        return Math.Clamp(config.PausedTranscodeTimeoutMinutes, MinTimeoutMinutes, MaxTimeoutMinutes);
+    }
+
+    /// <summary>
+    /// Applies the configured warning lead time. A lead that would reach back past the moment of
+    /// pausing is clamped away, because a warning nobody can act on is just noise.
+    /// </summary>
+    /// <param name="config">The plugin configuration.</param>
+    /// <returns>Minutes before the stop at which to warn, or 0 for no warning.</returns>
+    internal static int ResolveWarningMinutes(PluginConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        return Math.Clamp(config.PausedTranscodeWarningMinutes, 0, ResolveTimeoutMinutes(config) - 1);
+    }
+
+    internal static string FormatWarningMessage(string template, int minutesUntilStop)
+    {
+        ArgumentNullException.ThrowIfNull(template);
+
+        return template.Replace(
+            "{{minutes}}",
+            minutesUntilStop.ToString(CultureInfo.InvariantCulture),
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Identifies a session that is both paused and holding an FFmpeg process.
+    /// </summary>
+    /// <remarks>
+    /// Direct play costs nothing to leave paused and is never touched. A direct stream (remux)
+    /// still owns an FFmpeg process and its output files, so it counts. Live TV counts too: the
+    /// nag settings' Live TV exclusion is about who gets messaged, not about which processes are
+    /// allowed to sit idle.
+    /// </remarks>
+    /// <param name="session">The session to classify.</param>
+    /// <returns>True when the session is a paused transcode.</returns>
+    internal static bool IsPausedTranscode(SessionInfo session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+
+        var playState = session.PlayState;
+        if (playState == null || !playState.IsPaused)
+        {
+            return false;
+        }
+
+        return session.TranscodingInfo != null || playState.PlayMethod == PlayMethod.Transcode;
+    }
+
+    /// <summary>
+    /// Forgets every tracked session, so a disabled or reconfigured reaper starts from a clean clock.
+    /// </summary>
+    internal void Reset() => _tracked.Clear();
+
+    internal int TrackedCount => _tracked.Count;
+
+    /// <summary>
+    /// Advances the escalation for every live session and returns the actions now due.
+    /// </summary>
+    /// <param name="sessions">The current live sessions.</param>
+    /// <param name="config">The plugin configuration.</param>
+    /// <param name="utcNow">The current UTC time.</param>
+    /// <returns>The due actions, which may be empty.</returns>
+    internal IReadOnlyList<PausedTranscodeVerdict> Evaluate(
+        IEnumerable<SessionInfo>? sessions,
+        PluginConfiguration config,
+        DateTime utcNow)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        var timeout = TimeSpan.FromMinutes(ResolveTimeoutMinutes(config));
+        var warningLead = TimeSpan.FromMinutes(ResolveWarningMinutes(config));
+        var verdicts = new List<PausedTranscodeVerdict>();
+        var stillPaused = new HashSet<SessionInfo>(ReferenceEqualityComparer.Instance);
+
+        foreach (var session in sessions ?? Enumerable.Empty<SessionInfo>())
+        {
+            if (session?.Id == null
+                || !IsPausedTranscode(session)
+                || TranscodeGuardRules.IsUserExcluded(session.UserId, config.PausedTranscodeExcludedUserIds))
+            {
+                continue;
+            }
+
+            stillPaused.Add(session);
+
+            var itemId = session.NowPlayingItem?.Id ?? Guid.Empty;
+            var positionTicks = session.PlayState?.PositionTicks;
+
+            if (!_tracked.TryGetValue(session, out var state)
+                || state.ItemId != itemId
+                || state.PositionTicks != positionTicks)
+            {
+                // First sighting, a different item, or a seek while paused. All three say someone
+                // is still at the keyboard, so the clock starts now. A session that was already
+                // paused before the server started therefore gets a full grace period, which is
+                // the safe direction to be wrong in.
+                _tracked[session] = new TrackedSession(utcNow, itemId, positionTicks);
+                continue;
+            }
+
+            var pausedFor = utcNow - state.PausedSinceUtc;
+
+            if (state.StopSentUtc.HasValue)
+            {
+                if (utcNow - state.StopSentUtc.Value < StopGracePeriod)
+                {
+                    continue;
+                }
+
+                // Still paused and still transcoding after being asked to stop: the client is not
+                // going to cooperate. Forget it afterwards so a job that survives even the kill
+                // waits out another full timeout instead of being hammered every tick.
+                _tracked.Remove(session);
+                stillPaused.Remove(session);
+                verdicts.Add(new PausedTranscodeVerdict(session, PausedTranscodeAction.Kill, pausedFor, 0));
+                continue;
+            }
+
+            if (pausedFor >= timeout)
+            {
+                state.StopSentUtc = utcNow;
+                verdicts.Add(new PausedTranscodeVerdict(session, PausedTranscodeAction.Stop, pausedFor, 0));
+                continue;
+            }
+
+            if (warningLead > TimeSpan.Zero && !state.WarningSent && pausedFor >= timeout - warningLead)
+            {
+                state.WarningSent = true;
+                var remaining = timeout - pausedFor;
+                verdicts.Add(new PausedTranscodeVerdict(
+                    session,
+                    PausedTranscodeAction.Warn,
+                    pausedFor,
+                    Math.Max(1, (int)Math.Ceiling(remaining.TotalMinutes))));
+            }
+        }
+
+        // Sessions that resumed, ended, or stopped transcoding lose their clock - and must not be
+        // held alive by this dictionary.
+        if (_tracked.Count != stillPaused.Count)
+        {
+            foreach (var tracked in _tracked.Keys.ToList())
+            {
+                if (!stillPaused.Contains(tracked))
+                {
+                    _tracked.Remove(tracked);
+                }
+            }
+        }
+
+        return verdicts;
+    }
+
+    private sealed class TrackedSession
+    {
+        internal TrackedSession(DateTime pausedSinceUtc, Guid itemId, long? positionTicks)
+        {
+            PausedSinceUtc = pausedSinceUtc;
+            ItemId = itemId;
+            PositionTicks = positionTicks;
+        }
+
+        internal DateTime PausedSinceUtc { get; }
+
+        internal Guid ItemId { get; }
+
+        internal long? PositionTicks { get; }
+
+        internal bool WarningSent { get; set; }
+
+        internal DateTime? StopSentUtc { get; set; }
+    }
+}

--- a/Sessions/PausedTranscodeTracker.cs
+++ b/Sessions/PausedTranscodeTracker.cs
@@ -275,12 +275,9 @@ internal sealed class PausedTranscodeTracker
         // held alive by this dictionary.
         if (_tracked.Count != stillPaused.Count)
         {
-            foreach (var tracked in _tracked.Keys.ToList())
+            foreach (var stale in _tracked.Keys.Where(tracked => !stillPaused.Contains(tracked)).ToList())
             {
-                if (!stillPaused.Contains(tracked))
-                {
-                    _tracked.Remove(tracked);
-                }
+                _tracked.Remove(stale);
             }
         }
 

--- a/Sessions/PausedTranscodeTracker.cs
+++ b/Sessions/PausedTranscodeTracker.cs
@@ -126,19 +126,38 @@ internal sealed class PausedTranscodeTracker
     }
 
     /// <summary>
-    /// Identifies a session that is both paused and holding an FFmpeg process.
+    /// Identifies a session holding an FFmpeg process, which is the only thing the server can end
+    /// on its own.
     /// </summary>
     /// <remarks>
-    /// Direct play costs nothing to leave paused and is never touched. A direct stream (remux)
-    /// still owns an FFmpeg process and its output files, so it counts. Live TV counts too: the
-    /// nag settings' Live TV exclusion is about who gets messaged, not about which processes are
-    /// allowed to sit idle.
+    /// A direct stream (remux) counts: it still owns an FFmpeg process and its output files.
     /// </remarks>
     /// <param name="session">The session to classify.</param>
-    /// <returns>True when the session is a paused transcode.</returns>
-    internal static bool IsPausedTranscode(SessionInfo session)
+    /// <returns>True when an FFmpeg job belongs to this session.</returns>
+    internal static bool HasTranscodeJob(SessionInfo session)
     {
         ArgumentNullException.ThrowIfNull(session);
+
+        return session.TranscodingInfo != null || session.PlayState?.PlayMethod == PlayMethod.Transcode;
+    }
+
+    /// <summary>
+    /// Identifies a paused session the reaper is allowed to act on.
+    /// </summary>
+    /// <remarks>
+    /// Paused transcodes always qualify, Live TV included: the nag settings' Live TV exclusion is
+    /// about who gets messaged, not about which processes may sit idle. Direct play only qualifies
+    /// when the admin opts in, because it holds an open file handle and a stream slot rather than
+    /// VRAM or an encoder session, and there is nothing the server can take back from it if the
+    /// client ignores the stop.
+    /// </remarks>
+    /// <param name="session">The session to classify.</param>
+    /// <param name="config">The plugin configuration.</param>
+    /// <returns>True when the session is paused and in scope.</returns>
+    internal static bool IsReapable(SessionInfo session, PluginConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        ArgumentNullException.ThrowIfNull(config);
 
         var playState = session.PlayState;
         if (playState == null || !playState.IsPaused)
@@ -146,7 +165,14 @@ internal sealed class PausedTranscodeTracker
             return false;
         }
 
-        return session.TranscodingInfo != null || playState.PlayMethod == PlayMethod.Transcode;
+        if (HasTranscodeJob(session))
+        {
+            return true;
+        }
+
+        // NowPlayingItem guards against a session whose paused flag outlived whatever it was
+        // playing; there would be no playback left to stop.
+        return config.ReapPausedDirectPlay && session.NowPlayingItem != null;
     }
 
     /// <summary>
@@ -178,7 +204,7 @@ internal sealed class PausedTranscodeTracker
         foreach (var session in sessions ?? Enumerable.Empty<SessionInfo>())
         {
             if (session?.Id == null
-                || !IsPausedTranscode(session)
+                || !IsReapable(session, config)
                 || TranscodeGuardRules.IsUserExcluded(session.UserId, config.PausedTranscodeExcludedUserIds))
             {
                 continue;
@@ -210,12 +236,19 @@ internal sealed class PausedTranscodeTracker
                     continue;
                 }
 
-                // Still paused and still transcoding after being asked to stop: the client is not
-                // going to cooperate. Forget it afterwards so a job that survives even the kill
-                // waits out another full timeout instead of being hammered every tick.
+                // Still paused after being asked to stop: the client is not going to cooperate.
+                // Forget it afterwards so a job that survives even the kill waits out another full
+                // timeout instead of being hammered every tick.
                 _tracked.Remove(session);
                 stillPaused.Remove(session);
-                verdicts.Add(new PausedTranscodeVerdict(session, PausedTranscodeAction.Kill, pausedFor, 0));
+
+                // Direct play owns no FFmpeg process, so a client that ignores the stop simply
+                // keeps sitting there - the escalation has nothing left to escalate to.
+                if (HasTranscodeJob(session))
+                {
+                    verdicts.Add(new PausedTranscodeVerdict(session, PausedTranscodeAction.Kill, pausedFor, 0));
+                }
+
                 continue;
             }
 

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/PausedTranscodeReaperTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/PausedTranscodeReaperTests.cs
@@ -1,0 +1,425 @@
+using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.TranscodeGuard.Configuration;
+using Jellyfin.Plugin.TranscodeGuard.Sessions;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Session;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Jellyfin.Plugin.TranscodeGuard.Tests;
+
+public class PausedTranscodeTrackerTests
+{
+    private static readonly DateTime Start = new(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public void Evaluate_IgnoresATranscodeThatIsPlaying()
+    {
+        var tracker = new PausedTranscodeTracker();
+        var session = PausedTranscode();
+        session.PlayState.IsPaused = false;
+        var config = EnabledConfig();
+
+        tracker.Evaluate(new[] { session }, config, Start);
+
+        Assert.Empty(tracker.Evaluate(new[] { session }, config, Start.AddHours(3)));
+        Assert.Equal(0, tracker.TrackedCount);
+    }
+
+    [Fact]
+    public void Evaluate_IgnoresPausedDirectPlay()
+    {
+        var tracker = new PausedTranscodeTracker();
+        var session = PausedTranscode();
+
+        // Direct play holds no FFmpeg process, so there is nothing to reclaim by ending it.
+        session.TranscodingInfo = null;
+        session.PlayState.PlayMethod = PlayMethod.DirectPlay;
+        var config = EnabledConfig();
+
+        tracker.Evaluate(new[] { session }, config, Start);
+
+        Assert.Empty(tracker.Evaluate(new[] { session }, config, Start.AddHours(3)));
+    }
+
+    [Fact]
+    public void Evaluate_ReapsAPausedDirectStream()
+    {
+        var tracker = new PausedTranscodeTracker();
+        var session = PausedTranscode();
+
+        // A remux still owns an FFmpeg process and its output files.
+        session.TranscodingInfo!.IsVideoDirect = true;
+        var config = EnabledConfig();
+
+        tracker.Evaluate(new[] { session }, config, Start);
+        var verdicts = tracker.Evaluate(new[] { session }, config, Start.AddMinutes(25));
+
+        Assert.Equal(PausedTranscodeAction.Stop, Assert.Single(verdicts).Action);
+    }
+
+    [Fact]
+    public void Evaluate_ReapsPausedLiveTvEvenWhenNagsExcludeIt()
+    {
+        var tracker = new PausedTranscodeTracker();
+        var session = PausedTranscode();
+        session.NowPlayingItem = new BaseItemDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "BBC One",
+            Type = BaseItemKind.TvChannel,
+            IsLive = true
+        };
+
+        // The Live TV exclusion governs who gets messaged, not which processes may sit idle.
+        var config = EnabledConfig();
+        config.ExcludeLiveTv = true;
+
+        tracker.Evaluate(new[] { session }, config, Start);
+        var verdicts = tracker.Evaluate(new[] { session }, config, Start.AddMinutes(25));
+
+        Assert.Equal(PausedTranscodeAction.Stop, Assert.Single(verdicts).Action);
+    }
+
+    [Fact]
+    public void Evaluate_WarnsThenStopsThenKills()
+    {
+        var tracker = new PausedTranscodeTracker();
+        var session = PausedTranscode();
+        var config = EnabledConfig();
+
+        Assert.Empty(tracker.Evaluate(new[] { session }, config, Start));
+        Assert.Empty(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(22)));
+
+        var warning = Assert.Single(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(23)));
+        Assert.Equal(PausedTranscodeAction.Warn, warning.Action);
+        Assert.Equal(2, warning.MinutesUntilStop);
+
+        // Only one warning per pause, however many ticks fall inside the lead time.
+        Assert.Empty(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(24)));
+
+        var stop = Assert.Single(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(25)));
+        Assert.Equal(PausedTranscodeAction.Stop, stop.Action);
+
+        // The client is given the grace period to act on the stop before it is taken away.
+        Assert.Empty(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(25).AddSeconds(5)));
+
+        var kill = Assert.Single(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(25).AddSeconds(15)));
+        Assert.Equal(PausedTranscodeAction.Kill, kill.Action);
+    }
+
+    [Fact]
+    public void Evaluate_DoesNotKillAClientThatObeyedTheStop()
+    {
+        var tracker = new PausedTranscodeTracker();
+        var session = PausedTranscode();
+        var config = EnabledConfig();
+
+        tracker.Evaluate(new[] { session }, config, Start);
+        Assert.Single(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(25)));
+
+        // Playback stopped: Jellyfin has already torn the job down.
+        session.TranscodingInfo = null;
+        session.PlayState.PlayMethod = null;
+        session.NowPlayingItem = null;
+
+        Assert.Empty(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(26)));
+        Assert.Equal(0, tracker.TrackedCount);
+    }
+
+    [Fact]
+    public void Evaluate_RestartsTheClockWhenPlaybackResumes()
+    {
+        var tracker = new PausedTranscodeTracker();
+        var session = PausedTranscode();
+        var config = EnabledConfig();
+        config.PausedTranscodeWarningMinutes = 0;
+
+        tracker.Evaluate(new[] { session }, config, Start);
+
+        session.PlayState.IsPaused = false;
+        Assert.Empty(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(20)));
+
+        session.PlayState.IsPaused = true;
+        Assert.Empty(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(21)));
+
+        // 25 minutes after resuming, not 25 minutes after the first pause.
+        Assert.Empty(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(45)));
+        Assert.Equal(
+            PausedTranscodeAction.Stop,
+            Assert.Single(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(46))).Action);
+    }
+
+    [Fact]
+    public void Evaluate_RestartsTheClockWhenTheViewerSeeksWhilePaused()
+    {
+        var tracker = new PausedTranscodeTracker();
+        var session = PausedTranscode();
+        var config = EnabledConfig();
+        config.PausedTranscodeWarningMinutes = 0;
+
+        tracker.Evaluate(new[] { session }, config, Start);
+
+        // Someone scrubbing the timeline is still there, even without pressing play.
+        session.PlayState.PositionTicks = 90_000_000_000;
+        Assert.Empty(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(24)));
+        Assert.Empty(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(48)));
+        Assert.Equal(
+            PausedTranscodeAction.Stop,
+            Assert.Single(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(49))).Action);
+    }
+
+    [Fact]
+    public void Evaluate_SkipsExcludedUsers()
+    {
+        var tracker = new PausedTranscodeTracker();
+        var excluded = PausedTranscode();
+        var reaped = PausedTranscode();
+        var config = EnabledConfig();
+        config.PausedTranscodeExcludedUserIds = new[] { excluded.UserId.ToString("N") };
+
+        var sessions = new[] { excluded, reaped };
+        tracker.Evaluate(sessions, config, Start);
+        var verdicts = tracker.Evaluate(sessions, config, Start.AddMinutes(25));
+
+        Assert.Same(reaped, Assert.Single(verdicts).Session);
+    }
+
+    [Fact]
+    public void Evaluate_ForgetsSessionsThatWentAway()
+    {
+        var tracker = new PausedTranscodeTracker();
+        var first = PausedTranscode();
+        var second = PausedTranscode();
+        var config = EnabledConfig();
+
+        tracker.Evaluate(new[] { first, second }, config, Start);
+        Assert.Equal(2, tracker.TrackedCount);
+
+        tracker.Evaluate(new[] { second }, config, Start.AddMinutes(1));
+        Assert.Equal(1, tracker.TrackedCount);
+    }
+
+    [Fact]
+    public void Evaluate_ClampsAHandEditedTimeout()
+    {
+        var tracker = new PausedTranscodeTracker();
+        var session = PausedTranscode();
+        var config = EnabledConfig();
+
+        // The config page range-checks these fields; a hand-edited XML file does not.
+        config.PausedTranscodeTimeoutMinutes = 0;
+        config.PausedTranscodeWarningMinutes = 0;
+
+        tracker.Evaluate(new[] { session }, config, Start);
+
+        Assert.Empty(tracker.Evaluate(new[] { session }, config, Start.AddSeconds(30)));
+        Assert.Single(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(1)));
+    }
+
+    [Theory]
+    [InlineData(25, 2, 2)]
+    [InlineData(25, -5, 0)]
+    [InlineData(5, 90, 4)]
+    [InlineData(1, 1, 0)]
+    public void ResolveWarningMinutes_KeepsTheLeadInsideTheTimeout(int timeout, int warning, int expected)
+    {
+        var config = new PluginConfiguration
+        {
+            PausedTranscodeTimeoutMinutes = timeout,
+            PausedTranscodeWarningMinutes = warning
+        };
+
+        Assert.Equal(expected, PausedTranscodeTracker.ResolveWarningMinutes(config));
+    }
+
+    [Fact]
+    public void FormatWarningMessage_SubstitutesTheRemainingMinutes()
+    {
+        Assert.Equal(
+            "Stopping in 2 minute(s).",
+            PausedTranscodeTracker.FormatWarningMessage("Stopping in {{minutes}} minute(s).", 2));
+    }
+
+    internal static PluginConfiguration EnabledConfig()
+        => new()
+        {
+            EnablePausedTranscodeReaper = true,
+            PausedTranscodeTimeoutMinutes = 25,
+            PausedTranscodeWarningMinutes = 2
+        };
+
+    internal static SessionInfo PausedTranscode()
+    {
+        var session = TestSessions.Create(
+            "session-" + Guid.NewGuid().ToString("N"),
+            "device-" + Guid.NewGuid().ToString("N"),
+            Guid.NewGuid());
+
+        session.NowPlayingItem = new BaseItemDto
+        {
+            Id = Guid.NewGuid(),
+            Name = "Blade Runner 2049",
+            Type = BaseItemKind.Movie
+        };
+        session.TranscodingInfo = new TranscodingInfo
+        {
+            VideoCodec = "h264",
+            AudioCodec = "aac",
+            TranscodeReasons = TranscodeReason.VideoCodecNotSupported
+        };
+        session.PlayState.IsPaused = true;
+        session.PlayState.PlayMethod = PlayMethod.Transcode;
+        session.PlayState.PositionTicks = 12_000_000_000;
+
+        return session;
+    }
+}
+
+public class PausedTranscodeReaperTests
+{
+    private static readonly DateTime Start = new(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task RunOnceAsync_DoesNothingWhileTheFeatureIsOff()
+    {
+        var session = PausedTranscodeTrackerTests.PausedTranscode();
+        var harness = new Harness(session);
+        var config = PausedTranscodeTrackerTests.EnabledConfig();
+        config.EnablePausedTranscodeReaper = false;
+
+        await harness.Reaper.RunOnceAsync(config, Start);
+        await harness.Reaper.RunOnceAsync(config, Start.AddHours(4));
+
+        Assert.Empty(harness.Stopped);
+        Assert.Empty(harness.Killed);
+        Assert.Empty(harness.Messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_WarnsBeforeStopping()
+    {
+        var session = PausedTranscodeTrackerTests.PausedTranscode();
+        var harness = new Harness(session);
+        var config = PausedTranscodeTrackerTests.EnabledConfig();
+        config.PausedTranscodeWarningMessage = "Stopping in {{minutes}} minute(s).";
+
+        await harness.Reaper.RunOnceAsync(config, Start);
+        await harness.Reaper.RunOnceAsync(config, Start.AddMinutes(23));
+
+        var sent = Assert.Single(harness.Messages.SentMessages);
+        Assert.Equal("Stopping in 2 minute(s).", sent.Command.Text);
+        Assert.Empty(harness.Stopped);
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_AsksTheClientToStopBeforeEndingTheJob()
+    {
+        var session = PausedTranscodeTrackerTests.PausedTranscode();
+        var harness = new Harness(session);
+        var config = PausedTranscodeTrackerTests.EnabledConfig();
+        config.PausedTranscodeWarningMinutes = 0;
+
+        await harness.Reaper.RunOnceAsync(config, Start);
+        await harness.Reaper.RunOnceAsync(config, Start.AddMinutes(25));
+
+        Assert.Same(session, Assert.Single(harness.Stopped));
+        Assert.Empty(harness.Killed);
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_EndsTheJobOfAClientThatIgnoredTheStop()
+    {
+        var session = PausedTranscodeTrackerTests.PausedTranscode();
+        var harness = new Harness(session);
+        var config = PausedTranscodeTrackerTests.EnabledConfig();
+        config.PausedTranscodeWarningMinutes = 0;
+
+        await harness.Reaper.RunOnceAsync(config, Start);
+        await harness.Reaper.RunOnceAsync(config, Start.AddMinutes(25));
+        await harness.Reaper.RunOnceAsync(config, Start.AddMinutes(26));
+
+        Assert.Equal(session.DeviceId, Assert.Single(harness.Killed));
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_StillStopsClientsWhenTheTranscodeManagerIsUnavailable()
+    {
+        var session = PausedTranscodeTrackerTests.PausedTranscode();
+        var harness = new Harness(session, transcodeKillerAvailable: false);
+        var config = PausedTranscodeTrackerTests.EnabledConfig();
+        config.PausedTranscodeWarningMinutes = 0;
+
+        await harness.Reaper.RunOnceAsync(config, Start);
+        await harness.Reaper.RunOnceAsync(config, Start.AddMinutes(25));
+        await harness.Reaper.RunOnceAsync(config, Start.AddMinutes(26));
+
+        Assert.Single(harness.Stopped);
+    }
+
+    [Fact]
+    public async Task RunOnceAsync_KeepsGoingWhenOneSessionFails()
+    {
+        var failing = PausedTranscodeTrackerTests.PausedTranscode();
+        var healthy = PausedTranscodeTrackerTests.PausedTranscode();
+        var harness = new Harness(failing, healthy);
+        harness.FailStopFor = failing;
+        var config = PausedTranscodeTrackerTests.EnabledConfig();
+        config.PausedTranscodeWarningMinutes = 0;
+
+        await harness.Reaper.RunOnceAsync(config, Start);
+        await harness.Reaper.RunOnceAsync(config, Start.AddMinutes(25));
+
+        Assert.Same(healthy, Assert.Single(harness.Stopped));
+    }
+
+    private sealed class Harness
+    {
+        internal Harness(params SessionInfo[] sessions)
+            : this(true, sessions)
+        {
+        }
+
+        internal Harness(SessionInfo session, bool transcodeKillerAvailable)
+            : this(transcodeKillerAvailable, session)
+        {
+        }
+
+        private Harness(bool transcodeKillerAvailable, params SessionInfo[] sessions)
+        {
+            Messages = new RecordingClientMessageService();
+
+            Reaper = new PausedTranscodeReaper(
+                () => sessions,
+                (session, _) =>
+                {
+                    if (ReferenceEquals(session, FailStopFor))
+                    {
+                        throw new InvalidOperationException("session is gone");
+                    }
+
+                    Stopped.Add(session);
+                    return Task.CompletedTask;
+                },
+                transcodeKillerAvailable
+                    ? deviceId =>
+                    {
+                        Killed.Add(deviceId);
+                        return Task.CompletedTask;
+                    }
+                    : null,
+                Messages,
+                NullLogger<PausedTranscodeReaper>.Instance);
+        }
+
+        internal PausedTranscodeReaper Reaper { get; }
+
+        internal RecordingClientMessageService Messages { get; }
+
+        internal List<SessionInfo> Stopped { get; } = new();
+
+        internal List<string> Killed { get; } = new();
+
+        internal SessionInfo? FailStopFor { get; set; }
+    }
+}

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/PausedTranscodeReaperTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/PausedTranscodeReaperTests.cs
@@ -473,27 +473,34 @@ public class PausedTranscodeReaperTests
         {
             Messages = new RecordingClientMessageService();
 
+            // Null stands for a server whose ITranscodeManager could not be resolved.
+            Func<string, Task>? transcodeKiller = null;
+            if (transcodeKillerAvailable)
+            {
+                transcodeKiller = deviceId =>
+                {
+                    Killed.Add(deviceId);
+                    return Task.CompletedTask;
+                };
+            }
+
             Reaper = new PausedTranscodeReaper(
                 () => sessions,
-                (session, _) =>
-                {
-                    if (ReferenceEquals(session, FailStopFor))
-                    {
-                        throw new InvalidOperationException("session is gone");
-                    }
-
-                    Stopped.Add(session);
-                    return Task.CompletedTask;
-                },
-                transcodeKillerAvailable
-                    ? deviceId =>
-                    {
-                        Killed.Add(deviceId);
-                        return Task.CompletedTask;
-                    }
-                    : null,
+                RecordStop,
+                transcodeKiller,
                 Messages,
                 NullLogger<PausedTranscodeReaper>.Instance);
+        }
+
+        private Task RecordStop(SessionInfo session, CancellationToken cancellationToken)
+        {
+            if (ReferenceEquals(session, FailStopFor))
+            {
+                throw new InvalidOperationException("session is gone");
+            }
+
+            Stopped.Add(session);
+            return Task.CompletedTask;
         }
 
         internal PausedTranscodeReaper Reaper { get; }

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/PausedTranscodeReaperTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/PausedTranscodeReaperTests.cs
@@ -27,19 +27,79 @@ public class PausedTranscodeTrackerTests
     }
 
     [Fact]
-    public void Evaluate_IgnoresPausedDirectPlay()
+    public void Evaluate_IgnoresPausedDirectPlayByDefault()
     {
         var tracker = new PausedTranscodeTracker();
-        var session = PausedTranscode();
-
-        // Direct play holds no FFmpeg process, so there is nothing to reclaim by ending it.
-        session.TranscodingInfo = null;
-        session.PlayState.PlayMethod = PlayMethod.DirectPlay;
+        var session = PausedDirectPlay();
         var config = EnabledConfig();
 
         tracker.Evaluate(new[] { session }, config, Start);
 
         Assert.Empty(tracker.Evaluate(new[] { session }, config, Start.AddHours(3)));
+        Assert.Equal(0, tracker.TrackedCount);
+    }
+
+    [Fact]
+    public void Evaluate_StopsPausedDirectPlayWhenTheAdminOptsIn()
+    {
+        var tracker = new PausedTranscodeTracker();
+        var session = PausedDirectPlay();
+        var config = EnabledConfig();
+        config.ReapPausedDirectPlay = true;
+        config.PausedTranscodeWarningMinutes = 0;
+
+        tracker.Evaluate(new[] { session }, config, Start);
+        var verdicts = tracker.Evaluate(new[] { session }, config, Start.AddMinutes(25));
+
+        Assert.Equal(PausedTranscodeAction.Stop, Assert.Single(verdicts).Action);
+    }
+
+    [Fact]
+    public void Evaluate_NeverKillsDirectPlayBecauseThereIsNoJobToEnd()
+    {
+        var tracker = new PausedTranscodeTracker();
+        var session = PausedDirectPlay();
+        var config = EnabledConfig();
+        config.ReapPausedDirectPlay = true;
+        config.PausedTranscodeWarningMinutes = 0;
+
+        tracker.Evaluate(new[] { session }, config, Start);
+        Assert.Single(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(25)));
+
+        // The client ignored the stop, but there is no FFmpeg process to take away.
+        Assert.Empty(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(26)));
+    }
+
+    [Fact]
+    public void Evaluate_LeavesDirectPlayAloneWhenNothingIsPlaying()
+    {
+        var tracker = new PausedTranscodeTracker();
+        var session = PausedDirectPlay();
+
+        // A paused flag that outlived its playback is not something to stop.
+        session.NowPlayingItem = null;
+        var config = EnabledConfig();
+        config.ReapPausedDirectPlay = true;
+
+        tracker.Evaluate(new[] { session }, config, Start);
+
+        Assert.Empty(tracker.Evaluate(new[] { session }, config, Start.AddHours(3)));
+    }
+
+    [Fact]
+    public void Evaluate_StillKillsTranscodesWhenDirectPlayIsInScope()
+    {
+        var tracker = new PausedTranscodeTracker();
+        var session = PausedTranscode();
+        var config = EnabledConfig();
+        config.ReapPausedDirectPlay = true;
+        config.PausedTranscodeWarningMinutes = 0;
+
+        tracker.Evaluate(new[] { session }, config, Start);
+        Assert.Single(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(25)));
+
+        var kill = Assert.Single(tracker.Evaluate(new[] { session }, config, Start.AddMinutes(26)));
+        Assert.Equal(PausedTranscodeAction.Kill, kill.Action);
     }
 
     [Fact]
@@ -249,6 +309,15 @@ public class PausedTranscodeTrackerTests
             PausedTranscodeWarningMinutes = 2
         };
 
+    internal static SessionInfo PausedDirectPlay()
+    {
+        var session = PausedTranscode();
+        session.TranscodingInfo = null;
+        session.PlayState.PlayMethod = PlayMethod.DirectPlay;
+
+        return session;
+    }
+
     internal static SessionInfo PausedTranscode()
     {
         var session = TestSessions.Create(
@@ -371,6 +440,21 @@ public class PausedTranscodeReaperTests
         await harness.Reaper.RunOnceAsync(config, Start.AddMinutes(25));
 
         Assert.Same(healthy, Assert.Single(harness.Stopped));
+    }
+
+    [Fact]
+    public async Task HostedServiceLifecycleIsSafeToRepeat()
+    {
+        var harness = new Harness(PausedTranscodeTrackerTests.PausedTranscode());
+
+        await harness.Reaper.StartAsync(CancellationToken.None);
+        await harness.Reaper.StopAsync(CancellationToken.None);
+
+        // Jellyfin disposes hosted services after stopping them, and a plugin reload can repeat it.
+        harness.Reaper.Dispose();
+        harness.Reaper.Dispose();
+
+        Assert.Empty(harness.Stopped);
     }
 
     private sealed class Harness

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/PluginConfigurationCompatibilityTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/PluginConfigurationCompatibilityTests.cs
@@ -71,4 +71,67 @@ public class PluginConfigurationCompatibilityTests
         serializer.Serialize(writer, config);
         Assert.DoesNotContain("MinimumFreeGpuMemoryMiB", writer.ToString(), StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void PausedTranscodeReaperIsOptInAndDefaultsTo25Minutes()
+    {
+        var config = new PluginConfiguration();
+
+        Assert.False(config.EnablePausedTranscodeReaper);
+        Assert.Equal(25, config.PausedTranscodeTimeoutMinutes);
+        Assert.Equal(2, config.PausedTranscodeWarningMinutes);
+        Assert.False(config.UseStickyPausedTranscodeMessages);
+        Assert.Empty(config.PausedTranscodeExcludedUserIds);
+        Assert.Contains("{{minutes}}", config.PausedTranscodeWarningMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PausedTranscodeReaperSettingsRoundTripThroughXml()
+    {
+        var serializer = new XmlSerializer(typeof(PluginConfiguration));
+        var config = new PluginConfiguration
+        {
+            EnablePausedTranscodeReaper = true,
+            PausedTranscodeTimeoutMinutes = 40,
+            PausedTranscodeWarningMinutes = 5,
+            PausedTranscodeWarningHeader = "Wake up",
+            PausedTranscodeWarningMessage = "Stopping in {{minutes}}.",
+            UseStickyPausedTranscodeMessages = true,
+            PausedTranscodeExcludedUserIds = new[] { "abc" }
+        };
+
+        using var writer = new StringWriter();
+        serializer.Serialize(writer, config);
+
+        using var reader = new StringReader(writer.ToString());
+        var roundTripped = Assert.IsType<PluginConfiguration>(serializer.Deserialize(reader));
+
+        Assert.True(roundTripped.EnablePausedTranscodeReaper);
+        Assert.Equal(40, roundTripped.PausedTranscodeTimeoutMinutes);
+        Assert.Equal(5, roundTripped.PausedTranscodeWarningMinutes);
+        Assert.Equal("Wake up", roundTripped.PausedTranscodeWarningHeader);
+        Assert.Equal("Stopping in {{minutes}}.", roundTripped.PausedTranscodeWarningMessage);
+        Assert.True(roundTripped.UseStickyPausedTranscodeMessages);
+        Assert.Equal(new[] { "abc" }, roundTripped.PausedTranscodeExcludedUserIds);
+    }
+
+    [Fact]
+    public void ConfigurationSavedBeforeTheReaperExistedStaysOptedOut()
+    {
+        const string OlderXml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <PluginConfiguration>
+              <EnableLoginNag>true</EnableLoginNag>
+              <LoginNagThreshold>7</LoginNagThreshold>
+            </PluginConfiguration>
+            """;
+        var serializer = new XmlSerializer(typeof(PluginConfiguration));
+
+        using var reader = new StringReader(OlderXml);
+        var config = Assert.IsType<PluginConfiguration>(serializer.Deserialize(reader));
+
+        // An upgrade must never start ending anyone's playback on its own.
+        Assert.False(config.EnablePausedTranscodeReaper);
+        Assert.Equal(7, config.LoginNagThreshold);
+    }
 }

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/PluginConfigurationCompatibilityTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/PluginConfigurationCompatibilityTests.cs
@@ -81,6 +81,7 @@ public class PluginConfigurationCompatibilityTests
         Assert.Equal(25, config.PausedTranscodeTimeoutMinutes);
         Assert.Equal(2, config.PausedTranscodeWarningMinutes);
         Assert.False(config.UseStickyPausedTranscodeMessages);
+        Assert.False(config.ReapPausedDirectPlay);
         Assert.Empty(config.PausedTranscodeExcludedUserIds);
         Assert.Contains("{{minutes}}", config.PausedTranscodeWarningMessage, StringComparison.Ordinal);
     }
@@ -97,6 +98,7 @@ public class PluginConfigurationCompatibilityTests
             PausedTranscodeWarningHeader = "Wake up",
             PausedTranscodeWarningMessage = "Stopping in {{minutes}}.",
             UseStickyPausedTranscodeMessages = true,
+            ReapPausedDirectPlay = true,
             PausedTranscodeExcludedUserIds = new[] { "abc" }
         };
 
@@ -112,6 +114,7 @@ public class PluginConfigurationCompatibilityTests
         Assert.Equal("Wake up", roundTripped.PausedTranscodeWarningHeader);
         Assert.Equal("Stopping in {{minutes}}.", roundTripped.PausedTranscodeWarningMessage);
         Assert.True(roundTripped.UseStickyPausedTranscodeMessages);
+        Assert.True(roundTripped.ReapPausedDirectPlay);
         Assert.Equal(new[] { "abc" }, roundTripped.PausedTranscodeExcludedUserIds);
     }
 
@@ -132,6 +135,7 @@ public class PluginConfigurationCompatibilityTests
 
         // An upgrade must never start ending anyone's playback on its own.
         Assert.False(config.EnablePausedTranscodeReaper);
+        Assert.False(config.ReapPausedDirectPlay);
         Assert.Equal(7, config.LoginNagThreshold);
     }
 }


### PR DESCRIPTION
## What

Adds an opt-in **Paused Transcode Reaper**: transcodes left paused past a configurable timeout (25 minutes by default) are stopped, so their FFmpeg process stops holding VRAM, an encoder session, and its output files for a viewer who is not coming back.

## Why

Jellyfin never evicts a paused transcode on its own. Its kill timer is driven by client check-ins (`ITranscodeManager.PingTranscodingJob`), and a paused client keeps checking in roughly every 10 seconds, so `IsUserPaused` is recorded on the job and then only consulted for throttling decisions. Both stream types leak as a result:

- **HLS with throttling on** — `TranscodingThrottler` pauses FFmpeg, which keeps its CUDA context, hardware frame pool, and NVENC session slot allocated. Nothing is released short of process exit.
- **Progressive** — FFmpeg blocks writing to a socket the paused client has stopped draining, and the context stays allocated.

Nothing built-in covers this. `InactiveSessionThreshold` keys on inactivity, and a paused client that keeps checking in is not inactive. Throttling and segment deletion save disk, not VRAM.

This also compounds with the GPU resource guard: paused jobs are exactly what makes `GpuAdmissionPolicy` refuse new transcodes, so reaping them turns a refusal into an admission.

## How

Three steps per paused transcode:

1. **Warn** at `timeout − warningMinutes` — one popup per pause, through the existing `IClientMessageService`, so it inherits sticky-message support. Supports `{{minutes}}`.
2. **Stop** at the timeout — a `Stop` playstate command. The client stops, reports playback stopped, and Jellyfin tears the job down through its normal path, keeping the resume point the last progress report saved.
3. **Kill** 10 seconds later, and only if the session is still paused *and* still transcoding — `KillTranscodingJobs`, the same call Jellyfin makes for itself on playback stopped. It ends the FFmpeg job and deletes its partial files; the session stays connected and the user stays signed in. No logout, no device removal, nothing revoked.

The clock restarts on resume, item change, or a seek while paused. A session already paused when the server starts gets a full fresh grace period rather than being reaped immediately.

**Scope:** every paused transcode — Live TV included even when the nag settings exclude it, CPU transcodes included, and direct streams, which still own an FFmpeg process.

**Also stop paused direct play** (off by default) widens the timeout to every paused session. Worth knowing it is a different kind of win: direct play holds an open file handle and a stream slot rather than VRAM or an encoder session, so the reasons to enable it are freeing a concurrent stream slot or releasing read handles on network mounts, not GPU pressure. It is also stop-only — direct play owns no FFmpeg process, so a client that ignores the stop has nothing left to take away and no kill verdict is emitted. `HasTranscodeJob` answers what the server can actually end; `IsReapable` answers what is in scope.

## Design notes

- All timing lives in `PausedTranscodeTracker`, free of Jellyfin service dependencies, so the escalation is tested against a clock the tests control. `PausedTranscodeReaper` is a hosted service that ticks every 15 s and carries out the verdicts.
- `ITranscodeManager` is resolved lazily behind a `NoInlining` boundary and only ever referenced through a `Func<string, Task>`, matching the caution in `PluginServiceRegistrator`: the type does not exist before Jellyfin 10.10, and a type load failure there must cost the server-side kill and nothing else. The clean stop still works without it.
- The kill goes out as `KillTranscodingJobs(deviceId, null, …)` because `SessionInfo` exposes no play session id. A device running two transcodes at once with one paused would lose both; in practice a device has one.
- Hand-edited timeouts are clamped in code, since the config page is the only thing range-checking those fields.

## Configuration

New section on the plugin settings page, collapsed until enabled:

| Setting | Default |
| --- | --- |
| Stop transcodes left paused | **off** |
| Stop after paused for (minutes) | 25 |
| Warn this many minutes first (0 = no warning) | 2 |
| Warning title / message | supports `{{minutes}}` |
| Sticky messages | off |
| Also stop paused direct play | **off** |
| Manage Excluded Users (Paused Transcodes) | empty, separate from the nag and MOTD lists |

## Testing

- `dotnet build --configuration Release` — clean, 0 warnings.
- `dotnet format whitespace --verify-no-changes` and `dotnet format style --verify-no-changes --severity warn` — clean.
- 210 tests pass, 22 new: the full warn/stop/kill escalation, no kill for a client that obeyed the stop, clock restarts on resume and on seek-while-paused, excluded users skipped, paused Live TV still reaped with `ExcludeLiveTv` on, paused direct play ignored by default, stopped but never killed when opted in, ignored when nothing is playing, transcodes still killed while direct play is in scope, clamping of a hand-edited timeout, session pruning, repeated hosted-service disposal, one failing session not blocking the next, and config round-trip plus proof that a config file written before this feature loads with both switches off.
- Measured coverage is now 68.6% line / 62.2% branch on the plugin assembly, up from the 65% the badge carried; badge refreshed to 69%. `PausedTranscodeTracker` is at 100%.
- Not yet exercised against a running Jellyfin instance — worth a live check on a real paused HLS session before merge.

