### PR TITLE
feat(limits): refuse transcodes once a user passes a configurable limit

### DIFF
--- a/Configuration/PluginConfiguration.cs
+++ b/Configuration/PluginConfiguration.cs
@@ -55,6 +55,35 @@ public class PluginConfiguration : BasePluginConfiguration
 
     public bool UseStickyLoginNagMessages { get; set; } = false;
 
+    /// <summary>
+    /// Gets or sets a value indicating whether a user who is over
+    /// <see cref="TranscodeLimitThreshold"/> has further transcodes refused instead of only being
+    /// nagged. Defaults to off so upgrading the plugin cannot start failing anyone's playback.
+    /// </summary>
+    public bool EnableTranscodeLimit { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets how many counted transcodes a user may accumulate in
+    /// <see cref="LoginNagTimeWindow"/> before the next one is refused. Counted the same way the
+    /// login nag counts, so this is normally set higher than <see cref="LoginNagThreshold"/>.
+    /// A value below 1 disables the refusal rather than blocking everything.
+    /// </summary>
+    public int TranscodeLimitThreshold { get; set; } = 10;
+
+    /// <summary>
+    /// Gets or sets the popup title shown to a client whose transcode was refused for being
+    /// over the limit.
+    /// </summary>
+    public string TranscodeLimitHeader { get; set; } = "Transcode limit reached";
+
+    /// <summary>
+    /// Gets or sets the popup body shown to a client whose transcode was refused for being over
+    /// the limit. Supports <c>{{transcodes}}</c>, <c>{{timewindow}}</c>, and <c>{{limit}}</c>.
+    /// </summary>
+    public string TranscodeLimitMessage { get; set; } = "You've transcoded {{transcodes}} videos in the last {{timewindow}} due to unsupported formats, which is over this server's limit of {{limit}}. Switch to a client that can direct play (mpv, VLC, or Jellyfin Media Player) to keep watching.";
+
+    public bool UseStickyTranscodeLimitMessages { get; set; } = false;
+
     public string[] AlertTranscodeReasons { get; set; } = GetDefaultAlertTranscodeReasons();
 
     public ReasonMessageOverride[] ReasonMessageOverrides { get; set; } = Array.Empty<ReasonMessageOverride>();

--- a/Configuration/configPage.html
+++ b/Configuration/configPage.html
@@ -124,6 +124,53 @@
                         <div class="fieldDescription checkboxFieldDescription">Sends each login warning three times, 3 seconds apart, with a 4-second timeout to improve visibility on clients that dismiss Jellyfin messages quickly.</div>
                     </div>
 
+                    <h2>Transcode Limit</h2>
+                    <div class="fieldDescription" style="margin-bottom: 12px;">
+                        Turns the login nag's count into a hard stop. A user at or over this limit has their
+                        next transcode refused before FFmpeg starts, and is shown the message below. Set it
+                        higher than the Login Nag Threshold so users are warned before they are stopped.
+                        Counted exactly like the login nag: same time window, same trigger reasons, same user
+                        and client exclusions. Bitrate-only transcodes, audio-only streams, and direct play
+                        are never refused, so a user who is over the limit can still watch anything their
+                        client can play without transcoding.
+                    </div>
+
+                    <div class="checkboxContainer checkboxContainer-withDescription">
+                        <label>
+                            <input type="checkbox" is="emby-checkbox" id="chkEnableTranscodeLimit" name="chkEnableTranscodeLimit" />
+                            <span>Block transcodes once the limit is reached</span>
+                        </label>
+                        <div class="fieldDescription checkboxFieldDescription">Off by default. Playback fails for the user with the message below instead of only nagging them.</div>
+                    </div>
+
+                    <div id="transcodeLimitOptions" style="display: none;">
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtTranscodeLimitThreshold">Transcode Limit:</label>
+                            <input type="number" id="txtTranscodeLimitThreshold" name="txtTranscodeLimitThreshold" min="1" max="1000" class="emby-input" />
+                            <div class="fieldDescription">Refuse a transcode once the user has this many in the Login Nag Time Window.</div>
+                        </div>
+
+                        <div class="inputContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtTranscodeLimitHeader">Blocked Title:</label>
+                            <input type="text" id="txtTranscodeLimitHeader" name="txtTranscodeLimitHeader" class="emby-input" />
+                            <div class="fieldDescription">Title of the popup shown to the client whose transcode was refused.</div>
+                        </div>
+
+                        <div class="selectContainer">
+                            <label class="inputLabel inputLabelUnfocused" for="txtTranscodeLimitMessage">Blocked Message:</label>
+                            <textarea id="txtTranscodeLimitMessage" name="txtTranscodeLimitMessage" rows="3" class="emby-input"></textarea>
+                            <div class="fieldDescription">Shown when a transcode is refused. Use {{transcodes}} for their count, {{timewindow}} for the time window, and {{limit}} for the limit.</div>
+                        </div>
+
+                        <div class="checkboxContainer checkboxContainer-withDescription">
+                            <label>
+                                <input type="checkbox" is="emby-checkbox" id="chkUseStickyTranscodeLimitMessages" name="chkUseStickyTranscodeLimitMessages" />
+                                <span>Sticky Messages</span>
+                            </label>
+                            <div class="fieldDescription checkboxFieldDescription">Sends each refusal notice three times, 3 seconds apart, with a 4-second timeout to improve visibility on clients that dismiss Jellyfin messages quickly.</div>
+                        </div>
+                    </div>
+
                     <h2>User Exclusions</h2>
 
                     <div class="fieldDescription" style="margin-bottom: 10px;">
@@ -755,6 +802,32 @@
                 }
             };
 
+            // Keeps the transcode limit block collapsed unless the feature is switched on.
+            var TranscodeLimitSection = {
+                initialized: false,
+
+                init: function() {
+                    if (this.initialized) {
+                        return;
+                    }
+
+                    document.getElementById('chkEnableTranscodeLimit').addEventListener('change', this.updateVisibility);
+                    this.initialized = true;
+                },
+
+                updateVisibility: function() {
+                    var enabled = document.getElementById('chkEnableTranscodeLimit').checked;
+                    document.getElementById('transcodeLimitOptions').style.display = enabled ? 'block' : 'none';
+                },
+
+                // A blank or non-numeric field must not be saved as NaN, and a limit below 1 would
+                // refuse everything, so it falls back to the default rather than being stored.
+                readNumber: function(elementId, fallback) {
+                    var parsed = parseInt(document.getElementById(elementId).value, 10);
+                    return isNaN(parsed) || parsed < 1 ? fallback : parsed;
+                }
+            };
+
             // Keeps the paused transcode reaper block collapsed unless the feature is switched on.
             var PausedReaperSection = {
                 initialized: false,
@@ -1092,6 +1165,7 @@
                 UserExclusionManager.init();
                 MotdUserExclusionManager.init();
                 MotdSection.init();
+                TranscodeLimitSection.init();
                 GpuGuardSection.init();
                 PausedTranscodeUserExclusionManager.init();
                 PausedReaperSection.init();
@@ -1109,6 +1183,11 @@
                     document.getElementById('selectLoginNagTimeWindow').value = config.LoginNagTimeWindow || 'Week';
                     document.getElementById('txtLoginNagMessage').value = config.LoginNagMessage || '';
                     document.getElementById('chkUseStickyLoginNagMessages').checked = config.UseStickyLoginNagMessages === true;
+                    document.getElementById('chkEnableTranscodeLimit').checked = config.EnableTranscodeLimit === true;
+                    document.getElementById('txtTranscodeLimitThreshold').value = config.TranscodeLimitThreshold || 10;
+                    document.getElementById('txtTranscodeLimitHeader').value = config.TranscodeLimitHeader || '';
+                    document.getElementById('txtTranscodeLimitMessage').value = config.TranscodeLimitMessage || '';
+                    document.getElementById('chkUseStickyTranscodeLimitMessages').checked = config.UseStickyTranscodeLimitMessages === true;
                     document.getElementById('chkEnableMotd').checked = config.EnableMotd === true;
                     document.getElementById('txtMotdMessage').value = config.MotdMessage || '';
                     document.getElementById('chkUseStickyMotdMessages').checked = config.UseStickyMotdMessages === true;
@@ -1128,6 +1207,7 @@
                     document.getElementById('txtPausedTranscodeWarningMessage').value = config.PausedTranscodeWarningMessage || '';
                     document.getElementById('chkUseStickyPausedTranscodeMessages').checked = config.UseStickyPausedTranscodeMessages === true;
                     document.getElementById('chkReapPausedDirectPlay').checked = config.ReapPausedDirectPlay === true;
+                    TranscodeLimitSection.updateVisibility();
                     MotdSection.updateVisibility();
                     GpuGuardSection.updateVisibility();
                     PausedReaperSection.updateVisibility();
@@ -1156,6 +1236,11 @@
                     config.LoginNagTimeWindow = document.getElementById('selectLoginNagTimeWindow').value;
                     config.LoginNagMessage = document.getElementById('txtLoginNagMessage').value;
                     config.UseStickyLoginNagMessages = document.getElementById('chkUseStickyLoginNagMessages').checked;
+                    config.EnableTranscodeLimit = document.getElementById('chkEnableTranscodeLimit').checked;
+                    config.TranscodeLimitThreshold = TranscodeLimitSection.readNumber('txtTranscodeLimitThreshold', 10);
+                    config.TranscodeLimitHeader = document.getElementById('txtTranscodeLimitHeader').value;
+                    config.TranscodeLimitMessage = document.getElementById('txtTranscodeLimitMessage').value;
+                    config.UseStickyTranscodeLimitMessages = document.getElementById('chkUseStickyTranscodeLimitMessages').checked;
                     config.EnableMotd = document.getElementById('chkEnableMotd').checked;
                     config.MotdMessage = document.getElementById('txtMotdMessage').value;
                     config.UseStickyMotdMessages = document.getElementById('chkUseStickyMotdMessages').checked;

--- a/Gpu/GuardedTranscodeManager.cs
+++ b/Gpu/GuardedTranscodeManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Plugin.TranscodeGuard.Limits;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Net;
 using MediaBrowser.Controller.Streaming;
@@ -9,8 +10,8 @@ using Microsoft.Extensions.Logging;
 namespace Jellyfin.Plugin.TranscodeGuard.Gpu;
 
 /// <summary>
-/// Wraps Jellyfin's <see cref="ITranscodeManager"/> so the GPU guard runs immediately before
-/// FFmpeg is launched.
+/// Wraps Jellyfin's <see cref="ITranscodeManager"/> so the transcode limit and the GPU guard run
+/// immediately before FFmpeg is launched.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -30,16 +31,19 @@ public sealed class GuardedTranscodeManager : ITranscodeManager, IDisposable
 {
     private readonly ITranscodeManager _inner;
     private readonly GpuResourceGuard _guard;
+    private readonly TranscodeLimitGuard _limitGuard;
     private readonly ILogger<GuardedTranscodeManager> _logger;
     private bool _disposed;
 
     public GuardedTranscodeManager(
         ITranscodeManager inner,
         GpuResourceGuard guard,
+        TranscodeLimitGuard limitGuard,
         ILogger<GuardedTranscodeManager> logger)
     {
         _inner = inner;
         _guard = guard;
+        _limitGuard = limitGuard;
         _logger = logger;
     }
 
@@ -55,6 +59,30 @@ public sealed class GuardedTranscodeManager : ITranscodeManager, IDisposable
     {
         ArgumentNullException.ThrowIfNull(state);
         ArgumentNullException.ThrowIfNull(cancellationTokenSource);
+
+        // The per-user limit is settled first: it is a policy decision that does not depend on the
+        // GPU's state, and refusing here means no VRAM reservation is spent on a job that is not
+        // allowed to run anyway.
+        var limitDecision = TranscodeLimitDecision.Allowed;
+
+        try
+        {
+            limitDecision = await _limitGuard.AssessAsync(
+                BuildLimitRequest(state, userId),
+                cancellationTokenSource.Token).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException && ex is not OperationCanceledException)
+        {
+            // A broken guard must never break playback.
+            BestEffort(() => _logger.LogError(ex, "Transcode limit guard failed; allowing the transcode to proceed"));
+        }
+
+        if (!limitDecision.IsAdmitted)
+        {
+            // See the note below on SecurityException: this is Jellyfin's type, mapping to a clean
+            // HTTP 403 rather than a 500 with a stack trace.
+            throw new SecurityException(limitDecision.BuildRefusalReason());
+        }
 
         var admitted = true;
         GpuTranscodeRequest? request = null;
@@ -138,6 +166,26 @@ public sealed class GuardedTranscodeManager : ITranscodeManager, IDisposable
             }
             throw;
         }
+    }
+
+    private static TranscodeLimitRequest BuildLimitRequest(StreamState state, Guid userId)
+    {
+        var request = state.Request;
+
+        return new TranscodeLimitRequest
+        {
+            IsVideoRequest = state.VideoRequest != null,
+            // EncodingJobInfo reads TranscodeReasons off Request, so a partially constructed state
+            // has none. No reasons reads as a bitrate-driven transcode, which is never refused.
+            TranscodeReasons = request == null ? 0 : state.TranscodeReasons,
+            // Both signals, because either alone is narrower than the Live TV the counter skips.
+            IsLiveStream = state.MediaSource?.IsInfiniteStream == true
+                || !string.IsNullOrEmpty(state.MediaSource?.LiveStreamId),
+            DeviceId = request?.DeviceId,
+            UserId = userId,
+            ItemId = request?.Id ?? Guid.Empty,
+            ItemName = state.MediaSource?.Name
+        };
     }
 
     private static GpuTranscodeRequest BuildRequest(

--- a/Limits/TranscodeLimitDecision.cs
+++ b/Limits/TranscodeLimitDecision.cs
@@ -1,0 +1,69 @@
+using System.Globalization;
+
+namespace Jellyfin.Plugin.TranscodeGuard.Limits;
+
+/// <summary>
+/// The outcome of one transcode limit check, carrying the numbers behind a refusal so the caller
+/// does not have to read the event store a second time to explain it.
+/// </summary>
+public readonly struct TranscodeLimitDecision
+{
+    private TranscodeLimitDecision(bool isAdmitted, int transcodeCount, int threshold, string timeWindowLabel)
+    {
+        IsAdmitted = isAdmitted;
+        TranscodeCount = transcodeCount;
+        Threshold = threshold;
+        TimeWindowLabel = timeWindowLabel;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether Jellyfin may launch this transcode.
+    /// </summary>
+    public bool IsAdmitted { get; }
+
+    /// <summary>
+    /// Gets the user's counted transcodes in the configured window.
+    /// </summary>
+    public int TranscodeCount { get; }
+
+    /// <summary>
+    /// Gets the configured limit the count was measured against.
+    /// </summary>
+    public int Threshold { get; }
+
+    /// <summary>
+    /// Gets the human-readable window the count covers, for example "week".
+    /// </summary>
+    public string TimeWindowLabel { get; }
+
+    /// <summary>
+    /// Gets a decision that lets the transcode through. Every path that is not a refusal returns
+    /// this, so a guard that cannot reach an answer always fails open.
+    /// </summary>
+    public static TranscodeLimitDecision Allowed { get; } = new(true, 0, 0, "week");
+
+    /// <summary>
+    /// Builds a refusal for a user who is at or over the limit.
+    /// </summary>
+    /// <param name="transcodeCount">The user's counted transcodes.</param>
+    /// <param name="threshold">The configured limit.</param>
+    /// <param name="timeWindowLabel">The window the count covers.</param>
+    /// <returns>The refusal.</returns>
+    public static TranscodeLimitDecision Denied(int transcodeCount, int threshold, string timeWindowLabel)
+        => new(false, transcodeCount, threshold, timeWindowLabel);
+
+    /// <summary>
+    /// Builds the server-side refusal text. This travels in the exception, not to the client:
+    /// Jellyfin only returns exception messages to callers in a Development environment.
+    /// </summary>
+    /// <returns>The server-side refusal reason.</returns>
+    public string BuildRefusalReason()
+    {
+        return string.Format(
+            CultureInfo.InvariantCulture,
+            "Transcode Guard refused this transcode: the user has {0} counted transcodes in the last {1}, at or over the configured limit of {2}.",
+            TranscodeCount,
+            TimeWindowLabel,
+            Threshold);
+    }
+}

--- a/Limits/TranscodeLimitGuard.cs
+++ b/Limits/TranscodeLimitGuard.cs
@@ -1,0 +1,430 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.TranscodeGuard.Configuration;
+using Jellyfin.Plugin.TranscodeGuard.Data;
+using Jellyfin.Plugin.TranscodeGuard.Messaging;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Session;
+using Microsoft.Extensions.Logging;
+
+namespace Jellyfin.Plugin.TranscodeGuard.Limits;
+
+/// <summary>
+/// Turns the login nag's transcode count into an enforceable limit: once a user is at or over
+/// <see cref="PluginConfiguration.TranscodeLimitThreshold"/>, their next transcode is refused
+/// before FFmpeg is launched.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The count, the window, and which transcodes count are all the login nag's, so an admin sets
+/// one policy and picks two points on it: nag here, stop there. Anything the nag would ignore -
+/// a bitrate-only transcode, an excluded user, a filtered client, Live TV when it is excluded -
+/// is never refused either.
+/// </para>
+/// <para>
+/// Every failure path allows the transcode. A limit that cannot be evaluated must not become an
+/// outage.
+/// </para>
+/// </remarks>
+public sealed class TranscodeLimitGuard
+{
+    // A refused client retries: jellyfin-web's playbackmanager falls back through progressively
+    // stricter transcode options, and each hop is another StartFfMpeg, so answering from a few
+    // seconds of memory keeps a retry storm off the event store's lock. A refusal records
+    // nothing, so a refusing burst reads a count that genuinely cannot move. An admitted one can:
+    // starts within the same window share a count that a preceding start is still on its way to
+    // incrementing, so a user at the boundary can slip a small, bounded number of extra
+    // transcodes through. That is the right trade for a limit whose input is a rolling weekly
+    // count - it is not a licence check - and the same staleness is why an edited client filter
+    // or time window takes effect within a window rather than instantly.
+    private static readonly TimeSpan DefaultCountCacheLifetime = TimeSpan.FromSeconds(5);
+
+    // Same burst, one popup. See GpuResourceGuard for the timing this is derived from.
+    private static readonly TimeSpan DefaultNotificationQuietPeriod = TimeSpan.FromSeconds(3);
+
+    private const string DefaultDeniedHeader = "Transcode limit reached";
+    private const string DefaultDeniedMessage = "You have reached this server's transcoding limit. Switch to a client that can direct play to keep watching.";
+
+    private readonly TranscodeEventStore _eventStore;
+    private readonly IClientMessageService _clientMessageService;
+    private readonly ILogger<TranscodeLimitGuard> _logger;
+    private readonly Func<PluginConfiguration?> _configurationAccessor;
+    private readonly TimeSpan _countCacheLifetime;
+    private readonly TimeSpan _notificationQuietPeriod;
+    private readonly Func<DateTimeOffset> _clock;
+
+    private readonly Dictionary<string, CachedCount> _countCache = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, DateTimeOffset> _lastRefusalUtc = new(StringComparer.Ordinal);
+    private readonly object _countCacheLock = new();
+    private readonly object _suppressionLock = new();
+
+    public TranscodeLimitGuard(
+        TranscodeEventStore eventStore,
+        IClientMessageService clientMessageService,
+        ILogger<TranscodeLimitGuard> logger)
+        : this(eventStore, clientMessageService, logger, () => Plugin.Instance?.Configuration)
+    {
+    }
+
+    internal TranscodeLimitGuard(
+        TranscodeEventStore eventStore,
+        IClientMessageService clientMessageService,
+        ILogger<TranscodeLimitGuard> logger,
+        Func<PluginConfiguration?> configurationAccessor)
+        : this(
+            eventStore,
+            clientMessageService,
+            logger,
+            configurationAccessor,
+            DefaultCountCacheLifetime,
+            DefaultNotificationQuietPeriod,
+            () => DateTimeOffset.UtcNow)
+    {
+    }
+
+    internal TranscodeLimitGuard(
+        TranscodeEventStore eventStore,
+        IClientMessageService clientMessageService,
+        ILogger<TranscodeLimitGuard> logger,
+        Func<PluginConfiguration?> configurationAccessor,
+        TimeSpan countCacheLifetime,
+        TimeSpan notificationQuietPeriod,
+        Func<DateTimeOffset> clock)
+    {
+        _eventStore = eventStore;
+        _clientMessageService = clientMessageService;
+        _logger = logger;
+        _configurationAccessor = configurationAccessor;
+        _countCacheLifetime = countCacheLifetime;
+        _notificationQuietPeriod = notificationQuietPeriod;
+        _clock = clock;
+    }
+
+    /// <summary>
+    /// Decides whether Jellyfin may launch this transcode, notifying the requesting client on refusal.
+    /// </summary>
+    /// <param name="request">The transcode Jellyfin is about to launch.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The decision, which carries the numbers behind a refusal.</returns>
+    public async Task<TranscodeLimitDecision> AssessAsync(
+        TranscodeLimitRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var config = _configurationAccessor();
+        if (config == null)
+        {
+            // The plugin is not fully loaded; never stand between Jellyfin and playback.
+            return TranscodeLimitDecision.Allowed;
+        }
+
+        if (!config.EnableTranscodeLimit)
+        {
+            return TranscodeLimitDecision.Allowed;
+        }
+
+        // A limit of zero or less would refuse every transcode the moment the feature is switched
+        // on, which is never what an admin means by a limit. Treat it as unconfigured.
+        if (config.TranscodeLimitThreshold < 1)
+        {
+            if (ShouldNotify("invalid-threshold"))
+            {
+                _logger.LogWarning(
+                    "Transcode limit is enabled but its threshold is {Threshold}; no transcode will be refused until it is set to 1 or more",
+                    config.TranscodeLimitThreshold);
+            }
+
+            return TranscodeLimitDecision.Allowed;
+        }
+
+        // An unauthenticated request cannot be attributed to anyone's history.
+        if (request.UserId == Guid.Empty)
+        {
+            return TranscodeLimitDecision.Allowed;
+        }
+
+        // Only what the login nag counts is refused: audio-only streams and bitrate-driven
+        // transcodes never counted toward the limit, so they must not be stopped by it.
+        if (!request.IsVideoRequest
+            || !TranscodeGuardRules.MatchesConfiguredNagReasons(request.TranscodeReasons, config))
+        {
+            return TranscodeLimitDecision.Allowed;
+        }
+
+        if (TranscodeGuardRules.IsUserExcluded(request.UserId, config.ExcludedUserIds))
+        {
+            return TranscodeLimitDecision.Allowed;
+        }
+
+        // Live TV excluded from the nag means excluded from the limit: a channel that never
+        // counted toward the total must not be the stream that gets refused because of it.
+        if (config.ExcludeLiveTv && request.IsLiveStream)
+        {
+            return TranscodeLimitDecision.Allowed;
+        }
+
+        var session = TryResolveSession(request);
+
+        // A filtered client's history never counted toward the total, so it must not be the
+        // stream refused because of one. Only a positively identified filtered client is spared:
+        // a request whose session cannot be correlated is still refused, or the limit would be
+        // trivially avoidable.
+        if (session != null && !TranscodeGuardRules.IsClientAllowed(session.Client, config))
+        {
+            return TranscodeLimitDecision.Allowed;
+        }
+
+        // A stream the user is already watching is a continuation, not a new transcode. Jellyfin
+        // starts a fresh FFmpeg job for a seek, and the event recorded for this very playback is
+        // what can push its owner over the limit - so without this, the movie that reached the
+        // limit is the one cut off, mid-scene, and it cannot be resumed for the rest of the
+        // window. The limit stops the next thing a user starts, never the thing they are watching.
+        // The session only carries a now-playing item once playback has been reported, which is
+        // exactly the case this must spare: a first launch has not reported one yet.
+        if (request.ItemId != Guid.Empty && session?.NowPlayingItem?.Id == request.ItemId)
+        {
+            return TranscodeLimitDecision.Allowed;
+        }
+
+        var (days, timeWindowLabel) = TranscodeGuardRules.ResolveLoginNagWindow(config.LoginNagTimeWindow);
+        var transcodeCount = await GetTranscodeCountAsync(request.UserId, days, config).ConfigureAwait(false);
+
+        if (transcodeCount < config.TranscodeLimitThreshold)
+        {
+            return TranscodeLimitDecision.Allowed;
+        }
+
+        var decision = TranscodeLimitDecision.Denied(transcodeCount, config.TranscodeLimitThreshold, timeWindowLabel);
+
+        // The decision is made. Everything past this point is notification and logging, and none
+        // of it may reverse the refusal: an exception escaping here would reach the decorator's
+        // fail-open catch and admit the very transcode we just refused. ClientMessageService does
+        // not catch every failure Jellyfin's WebSocket send path can raise.
+        try
+        {
+            await DenyAsync(request, session, config, decision, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            BestEffort(() => _logger.LogError(
+                ex,
+                "Failed to notify the client about the blocked transcode of {ItemName}; the refusal still stands",
+                request.ItemName ?? "Unknown"));
+        }
+
+        return decision;
+    }
+
+    /// <summary>
+    /// Resolves the session behind a streaming request, treating a failure as "unknown session"
+    /// rather than letting it escape. Session lookup is an input to the decision, so it must not
+    /// be able to throw the decision away.
+    /// </summary>
+    /// <param name="request">The transcode being judged.</param>
+    /// <returns>The session, or null when it cannot be identified.</returns>
+    private SessionInfo? TryResolveSession(TranscodeLimitRequest request)
+    {
+        try
+        {
+            return _clientMessageService.ResolveSession(request.DeviceId, request.UserId, request.ItemId);
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            BestEffort(() => _logger.LogDebug(
+                ex,
+                "Could not resolve the session behind the transcode of {ItemName}; judging it without one",
+                request.ItemName ?? "Unknown"));
+            return null;
+        }
+    }
+
+    private async Task<int> GetTranscodeCountAsync(Guid userId, int days, PluginConfiguration config)
+    {
+        var cacheKey = string.Join(
+            '|',
+            userId.ToString("N", CultureInfo.InvariantCulture),
+            days.ToString(CultureInfo.InvariantCulture));
+        var now = _clock();
+
+        lock (_countCacheLock)
+        {
+            if (_countCache.TryGetValue(cacheKey, out var cached) && cached.ExpiresUtc > now)
+            {
+                return cached.Count;
+            }
+        }
+
+        var status = await _eventStore.GetUserNagStatusAsync(
+            userId.ToString(),
+            days,
+            storedEvent => TranscodeGuardRules.IsStoredEventAllowed(storedEvent, config)).ConfigureAwait(false);
+
+        lock (_countCacheLock)
+        {
+            PruneExpiredCounts(now);
+            _countCache[cacheKey] = new CachedCount(status.BadTranscodeCount, now + _countCacheLifetime);
+        }
+
+        return status.BadTranscodeCount;
+    }
+
+    private async Task DenyAsync(
+        TranscodeLimitRequest request,
+        SessionInfo? session,
+        PluginConfiguration config,
+        TranscodeLimitDecision decision,
+        CancellationToken cancellationToken)
+    {
+        var notify = ShouldNotify(BuildSuppressionKey(request));
+
+        if (!notify)
+        {
+            // Still refused - only the popup and the warning are de-duplicated.
+            BestEffort(() => _logger.LogDebug(
+                "Transcode blocked again for item {ItemName} within the notification suppression window",
+                request.ItemName ?? "Unknown"));
+            return;
+        }
+
+        BestEffort(() => _logger.LogWarning(
+            "Transcode blocked for session {SessionId}, user {UserName}, item {ItemName}: {TranscodeCount} counted transcodes in the last {TimeWindow} is at or over the limit of {Threshold}; reasons {TranscodeReasons}",
+            session?.Id ?? "Unknown",
+            session?.UserName ?? request.UserId.ToString(),
+            request.ItemName ?? "Unknown",
+            decision.TranscodeCount,
+            decision.TimeWindowLabel,
+            decision.Threshold,
+            request.TranscodeReasons));
+
+        if (session == null)
+        {
+            BestEffort(() => _logger.LogDebug(
+                "No session could be correlated to the blocked transcode of {ItemName}; the refusal still stands",
+                request.ItemName ?? "Unknown"));
+            return;
+        }
+
+        // Delivery is best effort. A client that cannot show a popup is still refused.
+        await _clientMessageService.SendMessageAsync(
+            session,
+            new MessageCommand
+            {
+                // An admin who blanks these fields should still get a usable popup.
+                Header = Fallback(config.TranscodeLimitHeader, DefaultDeniedHeader),
+                Text = TranscodeGuardRules.FormatTranscodeLimitMessage(
+                    Fallback(config.TranscodeLimitMessage, DefaultDeniedMessage),
+                    decision.TranscodeCount,
+                    decision.TimeWindowLabel,
+                    decision.Threshold),
+                TimeoutMs = config.MessageTimeoutMs
+            },
+            config.UseStickyTranscodeLimitMessages,
+            "transcode limit block",
+            $"{decision.TranscodeCount} counted transcodes against a limit of {decision.Threshold}",
+            config.EnableLogging,
+            _logger,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static string Fallback(string? configured, string defaultText)
+        => string.IsNullOrWhiteSpace(configured) ? defaultText : configured;
+
+    /// <summary>
+    /// Identifies "this client, this item" across renegotiation, matching the GPU guard so one
+    /// press of play produces one popup however many times Jellyfin retries it.
+    /// </summary>
+    /// <param name="request">The refused transcode.</param>
+    /// <returns>The suppression key.</returns>
+    private static string BuildSuppressionKey(TranscodeLimitRequest request)
+    {
+        return string.Join(
+            '|',
+            request.DeviceId ?? string.Empty,
+            request.ItemId.ToString("N", CultureInfo.InvariantCulture));
+    }
+
+    private bool ShouldNotify(string key)
+    {
+        var now = _clock();
+
+        lock (_suppressionLock)
+        {
+            var notify = !_lastRefusalUtc.TryGetValue(key, out var previousRefusal)
+                || now - previousRefusal >= _notificationQuietPeriod;
+
+            // Recorded on every refusal, not just the announced ones: this measures the gap since
+            // the last attempt, so an ongoing burst keeps extending and a lull always resets.
+            PruneExpiredRefusals(now);
+            _lastRefusalUtc[key] = now;
+
+            return notify;
+        }
+    }
+
+    private void PruneExpiredRefusals(DateTimeOffset now)
+    {
+        if (_lastRefusalUtc.Count == 0)
+        {
+            return;
+        }
+
+        var expired = _lastRefusalUtc
+            .Where(entry => now - entry.Value >= _notificationQuietPeriod)
+            .Select(entry => entry.Key)
+            .ToList();
+
+        foreach (var key in expired)
+        {
+            _lastRefusalUtc.Remove(key);
+        }
+    }
+
+    private void PruneExpiredCounts(DateTimeOffset now)
+    {
+        if (_countCache.Count == 0)
+        {
+            return;
+        }
+
+        var expired = _countCache
+            .Where(entry => entry.Value.ExpiresUtc <= now)
+            .Select(entry => entry.Key)
+            .ToList();
+
+        foreach (var key in expired)
+        {
+            _countCache.Remove(key);
+        }
+    }
+
+    private static void BestEffort(Action action)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception ex) when (ex is not OutOfMemoryException)
+        {
+            // A logger is diagnostic infrastructure. It must not change a refusal into an
+            // allowance if a custom provider throws from ILogger.Log.
+        }
+    }
+
+    private readonly struct CachedCount
+    {
+        internal CachedCount(int count, DateTimeOffset expiresUtc)
+        {
+            Count = count;
+            ExpiresUtc = expiresUtc;
+        }
+
+        internal int Count { get; }
+
+        internal DateTimeOffset ExpiresUtc { get; }
+    }
+}

--- a/Limits/TranscodeLimitRequest.cs
+++ b/Limits/TranscodeLimitRequest.cs
@@ -1,0 +1,55 @@
+using System;
+using MediaBrowser.Model.Session;
+
+namespace Jellyfin.Plugin.TranscodeGuard.Limits;
+
+/// <summary>
+/// Everything <see cref="TranscodeLimitGuard"/> needs about a transcode Jellyfin is about to
+/// launch, lifted out of <c>StreamState</c> so the policy can be exercised without a live server.
+/// </summary>
+public sealed class TranscodeLimitRequest
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the streaming request asked for video.
+    /// False for audio-only streams, which the login nag never counts.
+    /// </summary>
+    public bool IsVideoRequest { get; set; }
+
+    /// <summary>
+    /// Gets or sets Jellyfin's reasons for this transcode. Zero when the client sent none, which
+    /// reads as a bitrate-only transcode and is never refused.
+    /// </summary>
+    public TranscodeReason TranscodeReasons { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this is a live stream, which is the request-side
+    /// stand-in for the Live TV test the stored count uses.
+    /// </summary>
+    /// <remarks>
+    /// A streaming request carries a media source, not the <c>BaseItemDto</c> the counter checks
+    /// with <c>IsLiveTvItem</c>, so the two cannot be the same test. This one is deliberately the
+    /// wider of the two: over-including a live stream only means not refusing something, while
+    /// under-including it would refuse a channel against a count it never contributed to.
+    /// </remarks>
+    public bool IsLiveStream { get; set; }
+
+    /// <summary>
+    /// Gets or sets the requesting device ID. The correlation key for the client message.
+    /// </summary>
+    public string? DeviceId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the authenticated user, or <see cref="Guid.Empty"/> when unknown.
+    /// </summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the item being played.
+    /// </summary>
+    public Guid ItemId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the item name, for logging only.
+    /// </summary>
+    public string? ItemName { get; set; }
+}

--- a/PlaybackMonitor.cs
+++ b/PlaybackMonitor.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using Jellyfin.Plugin.TranscodeGuard.Data;
 using Jellyfin.Plugin.TranscodeGuard.Messaging;
 using Jellyfin.Plugin.TranscodeGuard.Models;
-using MediaBrowser.Common.Configuration;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Session;
@@ -49,14 +48,13 @@ public class PlaybackMonitor : IHostedService
     public PlaybackMonitor(
         ISessionManager sessionManager,
         IClientMessageService clientMessageService,
-        IApplicationPaths applicationPaths,
-        ILogger<PlaybackMonitor> logger,
-        ILogger<TranscodeEventStore> eventStoreLogger)
+        TranscodeEventStore eventStore,
+        ILogger<PlaybackMonitor> logger)
     {
         _sessionManager = sessionManager;
         _clientMessageService = clientMessageService;
         _logger = logger;
-        _eventStore = new TranscodeEventStore(applicationPaths, eventStoreLogger);
+        _eventStore = eventStore;
     }
 
     public Task StartAsync(CancellationToken cancellationToken)

--- a/PluginServiceRegistrator.cs
+++ b/PluginServiceRegistrator.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using Jellyfin.Plugin.TranscodeGuard.Data;
 using Jellyfin.Plugin.TranscodeGuard.Gpu;
+using Jellyfin.Plugin.TranscodeGuard.Limits;
 using Jellyfin.Plugin.TranscodeGuard.Messaging;
 using Jellyfin.Plugin.TranscodeGuard.Sessions;
 using MediaBrowser.Controller;
@@ -25,6 +27,11 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
         serviceCollection.AddSingleton<IClientMessageService, ClientMessageService>();
         serviceCollection.AddSingleton<IGpuMemoryProvider, NvidiaSmiGpuMemoryProvider>();
         serviceCollection.AddSingleton<GpuResourceGuard>();
+
+        // One store instance, so the reader in front of FFmpeg and the writer behind playback
+        // events share its lock rather than racing each other over the same file.
+        serviceCollection.AddSingleton<TranscodeEventStore>();
+        serviceCollection.AddSingleton<TranscodeLimitGuard>();
         serviceCollection.AddHostedService<PlaybackMonitor>();
         serviceCollection.AddHostedService<PausedTranscodeReaper>();
 
@@ -32,8 +39,8 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
     }
 
     /// <summary>
-    /// Wraps Jellyfin's <c>ITranscodeManager</c> so the GPU guard can refuse a hardware transcode
-    /// before FFmpeg is launched.
+    /// Wraps Jellyfin's <c>ITranscodeManager</c> so the transcode limit and the GPU guard can
+    /// refuse a transcode before FFmpeg is launched.
     /// </summary>
     /// <remarks>
     /// Jellyfin calls plugin service registrators after its own <c>RegisterServices</c>, so the core
@@ -86,6 +93,7 @@ public class PluginServiceRegistrator : IPluginServiceRegistrator
             provider => new GuardedTranscodeManager(
                 (ITranscodeManager)ActivatorUtilities.CreateInstance(provider, implementationType),
                 provider.GetRequiredService<GpuResourceGuard>(),
+                provider.GetRequiredService<TranscodeLimitGuard>(),
                 provider.GetRequiredService<ILogger<GuardedTranscodeManager>>()),
             lifetime);
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
     <img src="https://img.shields.io/github/v/release/voc0der/jellyfin-plugin-transcode-guard?label=stable%20release" alt="Stable release version" />
   </a>
   <a href="https://github.com/voc0der/jellyfin-plugin-transcode-guard/tree/main/tests">
-    <img src="https://img.shields.io/badge/coverage-69%25-yellowgreen" alt="Code coverage percentage" />
+    <img src="https://img.shields.io/badge/coverage-71%25-yellowgreen" alt="Code coverage percentage" />
   </a>
   <a href="https://github.com/voc0der/jellyfin-plugin-transcode-guard/issues">
     <img src="https://img.shields.io/github/issues/voc0der/jellyfin-plugin-transcode-guard?color=DAA520" alt="Open issues" />
@@ -51,6 +51,7 @@ A Jellyfin plugin that intelligently nags users when they're transcoding due to 
 - Ignores bitrate-only transcodes, so users lowering quality for bandwidth do not get warned.
 - Can exclude Live TV channel streams from playback nags and login nag history.
 - Can send a login nag when a user keeps hitting bad transcodes over the last week or month.
+- Can refuse a user's next transcode outright once that same count passes a second, higher limit, so heavy transcoders are warned before they are stopped.
 - Lets you exclude users from all nags.
 - Includes a live session monitor in the plugin settings page.
 - Can broadcast an optional Message of the Day to users at login, with its own user exclusions and client filters.
@@ -99,6 +100,7 @@ Open **Dashboard** → **Plugins** → **Transcode Guard**.
 - Enable **Exclude Live TV** if Live TV channel streams should not trigger playback nags or count toward login nags.
 - Optionally add client include/exclude filters using case-insensitive text matching. If the include list is empty, all clients are eligible; exclude matches always win.
 - If you want login nags, enable them and set the threshold, time window, and message. The login message supports `{{transcodes}}` and `{{timewindow}}`.
+- Enable **Block transcodes once the limit is reached** (off by default) to make the login nag's count enforceable. Its options stay collapsed until the toggle is on. Set the limit above the login nag threshold so a user is warned before being stopped; the count, time window, trigger reasons, and user/client exclusions are all the login nag's, so there is one policy with two points on it. The blocked message supports `{{transcodes}}`, `{{timewindow}}`, and `{{limit}}`.
 - Use **Manage Excluded Users** to opt users out of both playback and login nags.
 - Use the built-in live session monitor to see which active sessions currently match your rules.
 - Enable the **Paused Transcode Reaper** (off by default) to stop transcodes left paused past a timeout, 25 minutes by default. The client is asked to stop first, which leaves the resume point the last progress report saved; a client that ignores that has its FFmpeg job ended server-side. Neither path signs the user out or removes their device. It applies to every paused transcode, including Live TV and CPU transcodes, and never touches direct play. Optionally warn the viewer first with a popup supporting `{{minutes}}`, and use **Manage Excluded Users (Paused Transcodes)** to leave chosen users' paused streams alone. **Also stop paused direct play** (off by default) widens it to every paused session; direct play is stop-only, since there is no FFmpeg process to end if the client ignores the stop.
@@ -113,6 +115,9 @@ Open **Dashboard** → **Plugins** → **Transcode Guard**.
 - The MOTD is sent once per session at login and is unrelated to transcode history. Sessions that were already signed in when you enabled it receive nothing until they sign in again.
 - If a user qualifies for both the MOTD and a login nag, the nag waits for the MOTD to time out first, so clients that show one message at a time still display both.
 - A sticky message is sent three times, 3 seconds apart, with a 4-second timeout per send. Non-sticky messages continue to use the configured message timeout.
+- The transcode limit only refuses what the login nag counts. Direct Play, bitrate-only transcodes, audio-only streams, excluded users, filtered clients, and Live TV when it is excluded are never refused, so a user who is over the limit can still watch anything their client plays without a bad transcode. A refused stream returns HTTP 403 and starts no FFmpeg process, and a refusal records nothing, so it cannot push a user further over the limit.
+- The limit stops what a user starts next, never what they are already watching. Crossing the limit part-way through a video does not interrupt it, and seeking within it still works; the next thing they start is refused.
+- The count is read fresh but held for a few seconds, so a user right at the limit may get one or two more transcodes through, and an edited threshold, time window, or client filter takes effect within seconds rather than instantly.
 - The GPU guard only refuses NVIDIA video transcodes. Direct Play, Direct Stream, remux, audio-only, and CPU transcodes are never refused, and playback is allowed whenever free VRAM cannot be read.
 - After launch, the guard samples `nvidia-smi`'s per-process memory for the FFmpeg PID. Successful samples are logged with the job shape and budget for MiB-level calibration; if container PID namespaces prevent attribution, admission still works and the temporary reservation simply expires on its timer.
 - A refused stream returns HTTP 403 and starts no FFmpeg process. Freeing GPU memory restores playback on the next attempt, with no setting change or restart.

--- a/TranscodeGuardRules.cs
+++ b/TranscodeGuardRules.cs
@@ -151,8 +151,23 @@ internal static class TranscodeGuardRules
         ArgumentNullException.ThrowIfNull(transcodeInfo);
         ArgumentNullException.ThrowIfNull(config);
 
+        return MatchesConfiguredNagReasons(transcodeInfo.TranscodeReasons, config);
+    }
+
+    /// <summary>
+    /// Decides whether a transcode counts as one of the failures this plugin cares about. The one
+    /// place that answer is defined, so what the login nag counts and what the transcode limit
+    /// refuses can never drift apart.
+    /// </summary>
+    /// <param name="transcodeReasons">Jellyfin's reasons for the transcode.</param>
+    /// <param name="config">Plugin configuration.</param>
+    /// <returns>True when at least one configured reason is active.</returns>
+    internal static bool MatchesConfiguredNagReasons(TranscodeReason transcodeReasons, PluginConfiguration config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
         // If no transcode reasons specified, it's likely bitrate limiting - don't nag.
-        if (transcodeInfo.TranscodeReasons == (TranscodeReason)0)
+        if (transcodeReasons == (TranscodeReason)0)
         {
             return false;
         }
@@ -163,7 +178,7 @@ internal static class TranscodeGuardRules
             return false;
         }
 
-        return (transcodeInfo.TranscodeReasons & enabledNagReasons) != 0;
+        return (transcodeReasons & enabledNagReasons) != 0;
     }
 
     internal static (int Days, string Label) ResolveLoginNagWindow(string? configuredTimeWindow)
@@ -176,5 +191,11 @@ internal static class TranscodeGuardRules
         return template
             .Replace("{{transcodes}}", badTranscodeCount.ToString(), StringComparison.Ordinal)
             .Replace("{{timewindow}}", timeWindowLabel, StringComparison.Ordinal);
+    }
+
+    internal static string FormatTranscodeLimitMessage(string template, int badTranscodeCount, string timeWindowLabel, int limit)
+    {
+        return FormatLoginNagMessage(template, badTranscodeCount, timeWindowLabel)
+            .Replace("{{limit}}", limit.ToString(), StringComparison.Ordinal);
     }
 }

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/GuardedTranscodeManagerTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/GuardedTranscodeManagerTests.cs
@@ -1,11 +1,14 @@
 using Jellyfin.Plugin.TranscodeGuard.Configuration;
+using Jellyfin.Plugin.TranscodeGuard.Data;
 using Jellyfin.Plugin.TranscodeGuard.Gpu;
+using Jellyfin.Plugin.TranscodeGuard.Limits;
 using Jellyfin.Plugin.TranscodeGuard.Messaging;
 using MediaBrowser.Controller.MediaEncoding;
 using MediaBrowser.Controller.Net;
 using MediaBrowser.Controller.Streaming;
 using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Session;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -126,6 +129,31 @@ public class GuardedTranscodeManagerTests
         return state;
     }
 
+    /// <summary>
+    /// A limit guard that is switched off, for the tests that are about the GPU guard. Its store
+    /// is never read, so it needs no seeding and no cleanup.
+    /// </summary>
+    /// <returns>The guard.</returns>
+    private static TranscodeLimitGuard DisabledLimitGuard()
+    {
+        return CreateLimitGuard(
+            new PluginConfiguration { EnableTranscodeLimit = false },
+            new TestEventStore().Store,
+            new RecordingClientMessageService());
+    }
+
+    private static TranscodeLimitGuard CreateLimitGuard(
+        PluginConfiguration config,
+        TranscodeEventStore store,
+        RecordingClientMessageService messages)
+    {
+        return new TranscodeLimitGuard(
+            store,
+            messages,
+            NullLogger<TranscodeLimitGuard>.Instance,
+            () => config);
+    }
+
     private static (GuardedTranscodeManager Decorator, SpyTranscodeManager Inner, RecordingClientMessageService Messages)
         CreateDecorator(int freeMiB, bool guardEnabled = true)
     {
@@ -145,7 +173,7 @@ public class GuardedTranscodeManagerTests
             () => config);
 
         var inner = new SpyTranscodeManager();
-        var decorator = new GuardedTranscodeManager(inner, guard, NullLogger<GuardedTranscodeManager>.Instance);
+        var decorator = new GuardedTranscodeManager(inner, guard, DisabledLimitGuard(), NullLogger<GuardedTranscodeManager>.Instance);
 
         return (decorator, inner, messages);
     }
@@ -239,7 +267,7 @@ public class GuardedTranscodeManagerTests
             () => new PluginConfiguration { EnableGpuResourceGuard = true });
 
         var inner = new SpyTranscodeManager();
-        var decorator = new GuardedTranscodeManager(inner, guard, NullLogger<GuardedTranscodeManager>.Instance);
+        var decorator = new GuardedTranscodeManager(inner, guard, DisabledLimitGuard(), NullLogger<GuardedTranscodeManager>.Instance);
         using var cts = new CancellationTokenSource();
 
         await decorator.StartFfMpeg(
@@ -294,6 +322,7 @@ public class GuardedTranscodeManagerTests
         var decorator = new GuardedTranscodeManager(
             inner,
             guard,
+            DisabledLimitGuard(),
             new ThrowingLogger<GuardedTranscodeManager>());
         using var cts = new CancellationTokenSource();
 
@@ -307,6 +336,91 @@ public class GuardedTranscodeManagerTests
 
         Assert.Equal("MediaBrowser.Controller.Net.SecurityException", exception.GetType().FullName);
         Assert.Equal(0, inner.StartFfMpegCallCount);
+    }
+
+    [Fact]
+    public async Task StartFfMpeg_RefusesAUserOverTheTranscodeLimitBeforeFfmpegStarts()
+    {
+        using var store = new TestEventStore();
+        await store.SeedBadTranscodesAsync(AliceId, 3);
+
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+        var config = new PluginConfiguration
+        {
+            EnableTranscodeLimit = true,
+            TranscodeLimitThreshold = 3,
+            EnableGpuResourceGuard = false
+        };
+
+        var inner = new SpyTranscodeManager();
+        var decorator = new GuardedTranscodeManager(
+            inner,
+            new GpuResourceGuard(
+                FakeGpuMemoryProvider.WithFreeMiB(100000),
+                messages,
+                NullLogger<GpuResourceGuard>.Instance,
+                () => config),
+            CreateLimitGuard(config, store.Store, messages),
+            NullLogger<GuardedTranscodeManager>.Instance);
+
+        var state = CreateHardwareVideoState();
+        state.Request.TranscodeReasons = nameof(TranscodeReason.VideoCodecNotSupported);
+        using var cts = new CancellationTokenSource();
+
+        var exception = await Assert.ThrowsAsync<SecurityException>(() => decorator.StartFfMpeg(
+            state,
+            "/config/transcodes/abc.m3u8",
+            CudaNvencArguments,
+            AliceId,
+            TranscodingJobType.Hls,
+            cts));
+
+        Assert.Equal("MediaBrowser.Controller.Net.SecurityException", exception.GetType().FullName);
+        Assert.Equal(0, inner.StartFfMpegCallCount);
+        Assert.Single(messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task StartFfMpeg_LetsABitrateOnlyTranscodeThroughForTheSameOverLimitUser()
+    {
+        using var store = new TestEventStore();
+        await store.SeedBadTranscodesAsync(AliceId, 3);
+
+        var messages = new RecordingClientMessageService();
+        messages.AddSession(TestSessions.Create("session-2", "device-2", AliceId));
+        var config = new PluginConfiguration
+        {
+            EnableTranscodeLimit = true,
+            TranscodeLimitThreshold = 3,
+            EnableGpuResourceGuard = false
+        };
+
+        var inner = new SpyTranscodeManager();
+        var decorator = new GuardedTranscodeManager(
+            inner,
+            new GpuResourceGuard(
+                FakeGpuMemoryProvider.WithFreeMiB(100000),
+                messages,
+                NullLogger<GpuResourceGuard>.Instance,
+                () => config),
+            CreateLimitGuard(config, store.Store, messages),
+            NullLogger<GuardedTranscodeManager>.Instance);
+
+        // Jellyfin reports no reason when the client is simply capping bitrate.
+        var state = CreateHardwareVideoState();
+        using var cts = new CancellationTokenSource();
+
+        await decorator.StartFfMpeg(
+            state,
+            "/config/transcodes/abc.m3u8",
+            CudaNvencArguments,
+            AliceId,
+            TranscodingJobType.Hls,
+            cts);
+
+        Assert.Equal(1, inner.StartFfMpegCallCount);
+        Assert.Empty(messages.SentMessages);
     }
 
     [Fact]
@@ -369,6 +483,7 @@ public class GuardedTranscodeManagerTests
             new RecordingClientMessageService(),
             NullLogger<GpuResourceGuard>.Instance,
             () => new PluginConfiguration()));
+        services.AddSingleton(DisabledLimitGuard());
         services.AddSingleton<ILogger<GuardedTranscodeManager>>(NullLogger<GuardedTranscodeManager>.Instance);
         return services;
     }

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/PluginConfigurationCompatibilityTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/PluginConfigurationCompatibilityTests.cs
@@ -73,6 +73,63 @@ public class PluginConfigurationCompatibilityTests
     }
 
     [Fact]
+    public void TranscodeLimitIsOptInAndSitsAboveTheDefaultLoginNagThreshold()
+    {
+        var config = new PluginConfiguration();
+
+        // Upgrading the plugin must not start failing anyone's playback, and out of the box the
+        // limit must leave room for the nag to warn first.
+        Assert.False(config.EnableTranscodeLimit);
+        Assert.False(config.UseStickyTranscodeLimitMessages);
+        Assert.True(config.TranscodeLimitThreshold > config.LoginNagThreshold);
+    }
+
+    [Fact]
+    public void TranscodeLimitSettingsRoundTripThroughXml()
+    {
+        var serializer = new XmlSerializer(typeof(PluginConfiguration));
+        var config = new PluginConfiguration
+        {
+            EnableTranscodeLimit = true,
+            TranscodeLimitThreshold = 12,
+            TranscodeLimitHeader = "Blocked",
+            TranscodeLimitMessage = "{{transcodes}} of {{limit}}",
+            UseStickyTranscodeLimitMessages = true
+        };
+
+        using var writer = new StringWriter();
+        serializer.Serialize(writer, config);
+
+        using var reader = new StringReader(writer.ToString());
+        var roundTripped = Assert.IsType<PluginConfiguration>(serializer.Deserialize(reader));
+
+        Assert.True(roundTripped.EnableTranscodeLimit);
+        Assert.Equal(12, roundTripped.TranscodeLimitThreshold);
+        Assert.Equal("Blocked", roundTripped.TranscodeLimitHeader);
+        Assert.Equal("{{transcodes}} of {{limit}}", roundTripped.TranscodeLimitMessage);
+        Assert.True(roundTripped.UseStickyTranscodeLimitMessages);
+    }
+
+    [Fact]
+    public void ConfigurationSavedBeforeTheTranscodeLimitExistedLoadsWithItSwitchedOff()
+    {
+        const string LegacyXml = """
+            <?xml version="1.0" encoding="utf-8"?>
+            <PluginConfiguration>
+              <EnableLoginNag>true</EnableLoginNag>
+              <LoginNagThreshold>5</LoginNagThreshold>
+            </PluginConfiguration>
+            """;
+        var serializer = new XmlSerializer(typeof(PluginConfiguration));
+
+        using var reader = new StringReader(LegacyXml);
+        var config = Assert.IsType<PluginConfiguration>(serializer.Deserialize(reader));
+
+        Assert.False(config.EnableTranscodeLimit);
+        Assert.Equal(10, config.TranscodeLimitThreshold);
+    }
+
+    [Fact]
     public void PausedTranscodeReaperIsOptInAndDefaultsTo25Minutes()
     {
         var config = new PluginConfiguration();

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/TestDoubles.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/TestDoubles.cs
@@ -1,6 +1,8 @@
 using System.Linq;
+using Jellyfin.Plugin.TranscodeGuard.Data;
 using Jellyfin.Plugin.TranscodeGuard.Gpu;
 using Jellyfin.Plugin.TranscodeGuard.Messaging;
+using Jellyfin.Plugin.TranscodeGuard.Models;
 using MediaBrowser.Controller.Session;
 using MediaBrowser.Model.Session;
 using Microsoft.Extensions.Logging;
@@ -313,5 +315,86 @@ internal static class TestSessions
             UserName = userName,
             Client = "Jellyfin Web"
         };
+    }
+}
+
+/// <summary>
+/// A real <see cref="TranscodeEventStore"/> over a throwaway directory, with a seeder that waits
+/// for each fire-and-forget write to land before adding the next.
+/// </summary>
+internal sealed class TestEventStore : IDisposable
+{
+    private readonly string _rootPath = Path.Combine(
+        Path.GetTempPath(),
+        "transcode-guard-store",
+        Guid.NewGuid().ToString("N"));
+
+    public TestEventStore()
+    {
+        Directory.CreateDirectory(_rootPath);
+        Store = new TranscodeEventStore(new TestApplicationPaths(_rootPath), NullLogger<TranscodeEventStore>.Instance);
+    }
+
+    public TranscodeEventStore Store { get; }
+
+    public async Task SeedBadTranscodesAsync(
+        Guid userId,
+        int count,
+        DateTime? timestamp = null,
+        string client = "Jellyfin Web",
+        bool isLiveTv = false)
+    {
+        for (var index = 0; index < count; index++)
+        {
+            var itemId = Guid.NewGuid().ToString("N");
+            Store.AddEvent(new TranscodeEvent
+            {
+                UserId = userId.ToString(),
+                UserName = "tester",
+                ItemId = itemId,
+                ItemName = "Movie",
+                Timestamp = timestamp ?? DateTime.UtcNow.AddHours(-1),
+                Reasons = TranscodeReason.VideoCodecNotSupported,
+                Client = client,
+                IsLiveTv = isLiveTv,
+                Kind = NagEventKind.BadTranscode
+            });
+
+            await WaitForAsync(async () =>
+            {
+                var events = await Store.GetUserEventsAsync(userId.ToString(), 365);
+                return events.Any(storedEvent => storedEvent.ItemId == itemId);
+            });
+        }
+    }
+
+    private static async Task WaitForAsync(Func<Task<bool>> condition)
+    {
+        for (var attempt = 0; attempt < 200; attempt++)
+        {
+            if (await condition())
+            {
+                return;
+            }
+
+            await Task.Delay(10);
+        }
+
+        throw new TimeoutException("The event store did not reach the expected state.");
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_rootPath))
+            {
+                Directory.Delete(_rootPath, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // A leftover temp directory is not a test failure.
+        }
     }
 }

--- a/tests/Jellyfin.Plugin.TranscodeGuard.Tests/TranscodeLimitGuardTests.cs
+++ b/tests/Jellyfin.Plugin.TranscodeGuard.Tests/TranscodeLimitGuardTests.cs
@@ -1,0 +1,322 @@
+using Jellyfin.Plugin.TranscodeGuard.Configuration;
+using Jellyfin.Plugin.TranscodeGuard.Limits;
+using Jellyfin.Plugin.TranscodeGuard.Messaging;
+using MediaBrowser.Controller.Session;
+using MediaBrowser.Model.Dto;
+using MediaBrowser.Model.Session;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Jellyfin.Plugin.TranscodeGuard.Tests;
+
+public class TranscodeLimitGuardTests
+{
+    private static readonly Guid AliceId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid MovieId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+    private const string DeviceId = "device-1";
+
+    [Fact]
+    public async Task AllowsEverythingWhileTheLimitIsSwitchedOff()
+    {
+        using var harness = new LimitHarness(new PluginConfiguration { EnableTranscodeLimit = false, TranscodeLimitThreshold = 1 });
+        await harness.RecordBadTranscodesAsync(AliceId, 9);
+
+        var decision = await harness.AssessAsync(Request());
+
+        Assert.True(decision.IsAdmitted);
+        Assert.Empty(harness.Messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task AllowsAUserBelowTheLimit()
+    {
+        using var harness = new LimitHarness(EnabledConfig(threshold: 10));
+        await harness.RecordBadTranscodesAsync(AliceId, 9);
+
+        var decision = await harness.AssessAsync(Request());
+
+        Assert.True(decision.IsAdmitted);
+        Assert.Empty(harness.Messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task RefusesAtTheLimitAndTellsTheClientWithTheConfiguredNumbers()
+    {
+        var config = EnabledConfig(threshold: 10);
+        config.TranscodeLimitHeader = "Stop";
+        config.TranscodeLimitMessage = "{{transcodes}} of {{limit}} this {{timewindow}}.";
+        using var harness = new LimitHarness(config);
+        await harness.RecordBadTranscodesAsync(AliceId, 10);
+
+        var decision = await harness.AssessAsync(Request());
+
+        Assert.False(decision.IsAdmitted);
+        Assert.Equal(10, decision.TranscodeCount);
+        Assert.Equal(10, decision.Threshold);
+        Assert.Equal("week", decision.TimeWindowLabel);
+        Assert.Contains("10 counted transcodes", decision.BuildRefusalReason(), StringComparison.Ordinal);
+
+        var sent = Assert.Single(harness.Messages.SentMessages);
+        Assert.Equal("Stop", sent.Command.Header);
+        Assert.Equal("10 of 10 this week.", sent.Command.Text);
+    }
+
+    [Fact]
+    public async Task CountsTheSameMonthLongWindowTheLoginNagUses()
+    {
+        var config = EnabledConfig(threshold: 3);
+        config.LoginNagTimeWindow = "Month";
+        using var harness = new LimitHarness(config);
+
+        // Older than a week, inside a month: only the month-long window sees these.
+        await harness.RecordBadTranscodesAsync(AliceId, 3, DateTime.UtcNow.AddDays(-20));
+
+        var decision = await harness.AssessAsync(Request());
+
+        Assert.False(decision.IsAdmitted);
+        Assert.Equal("month", decision.TimeWindowLabel);
+    }
+
+    [Fact]
+    public async Task NeverRefusesABitrateOnlyTranscode()
+    {
+        using var harness = new LimitHarness(EnabledConfig(threshold: 1));
+        await harness.RecordBadTranscodesAsync(AliceId, 5);
+
+        var decision = await harness.AssessAsync(Request(reasons: 0));
+
+        Assert.True(decision.IsAdmitted);
+        Assert.Empty(harness.Messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task NeverRefusesATranscodeForAReasonTheAdminDidNotSelect()
+    {
+        var config = EnabledConfig(threshold: 1);
+        config.AlertTranscodeReasons = new[] { nameof(TranscodeReason.VideoCodecNotSupported) };
+        using var harness = new LimitHarness(config);
+        await harness.RecordBadTranscodesAsync(AliceId, 5);
+
+        var decision = await harness.AssessAsync(Request(reasons: TranscodeReason.ContainerBitrateExceedsLimit));
+
+        Assert.True(decision.IsAdmitted);
+    }
+
+    [Fact]
+    public async Task NeverRefusesAnAudioOnlyStream()
+    {
+        using var harness = new LimitHarness(EnabledConfig(threshold: 1));
+        await harness.RecordBadTranscodesAsync(AliceId, 5);
+
+        var decision = await harness.AssessAsync(Request(isVideoRequest: false));
+
+        Assert.True(decision.IsAdmitted);
+    }
+
+    [Fact]
+    public async Task NeverRefusesAnExcludedUser()
+    {
+        var config = EnabledConfig(threshold: 1);
+        config.ExcludedUserIds = new[] { AliceId.ToString() };
+        using var harness = new LimitHarness(config);
+        await harness.RecordBadTranscodesAsync(AliceId, 5);
+
+        var decision = await harness.AssessAsync(Request());
+
+        Assert.True(decision.IsAdmitted);
+    }
+
+    [Fact]
+    public async Task NeverRefusesAClientWhoseHistoryIsFilteredOut()
+    {
+        var config = EnabledConfig(threshold: 1);
+        config.ExcludedClientPatterns = new[] { "Jellyfin Web" };
+        using var harness = new LimitHarness(config);
+        await harness.RecordBadTranscodesAsync(AliceId, 5, client: "Kodi");
+
+        var decision = await harness.AssessAsync(Request());
+
+        Assert.True(decision.IsAdmitted);
+        Assert.Empty(harness.Messages.SentMessages);
+    }
+
+    [Fact]
+    public async Task NeverRefusesLiveTvWhileLiveTvIsExcluded()
+    {
+        var config = EnabledConfig(threshold: 1);
+        config.ExcludeLiveTv = true;
+        using var harness = new LimitHarness(config);
+        await harness.RecordBadTranscodesAsync(AliceId, 5);
+
+        Assert.True((await harness.AssessAsync(Request(isLiveStream: true))).IsAdmitted);
+        Assert.False((await harness.AssessAsync(Request())).IsAdmitted);
+    }
+
+    [Fact]
+    public async Task RefusesNothingWhileTheThresholdIsBelowOne()
+    {
+        using var harness = new LimitHarness(EnabledConfig(threshold: 0));
+
+        var decision = await harness.AssessAsync(Request());
+
+        Assert.True(decision.IsAdmitted);
+    }
+
+    [Fact]
+    public async Task RefusesAnUnknownUserNever()
+    {
+        using var harness = new LimitHarness(EnabledConfig(threshold: 1));
+        await harness.RecordBadTranscodesAsync(AliceId, 5);
+
+        var decision = await harness.AssessAsync(Request(userId: Guid.Empty));
+
+        Assert.True(decision.IsAdmitted);
+    }
+
+    [Fact]
+    public async Task LetsAnAlreadyPlayingStreamKeepGoingWhenItsOwnPlaybackCrossedTheLimit()
+    {
+        // The event recorded for the current movie is what puts its owner over. Seeking starts a
+        // fresh FFmpeg job, and refusing that would cut off the very film that reached the limit.
+        using var harness = new LimitHarness(EnabledConfig(threshold: 5));
+        await harness.RecordBadTranscodesAsync(AliceId, 5);
+        harness.SetNowPlaying(MovieId);
+
+        Assert.True((await harness.AssessAsync(Request())).IsAdmitted);
+        Assert.Empty(harness.Messages.SentMessages);
+
+        // Anything else they start is still refused.
+        Assert.False((await harness.AssessAsync(Request(itemId: Guid.NewGuid()))).IsAdmitted);
+    }
+
+    [Fact]
+    public async Task RefusesAFirstLaunchThatHasNotReportedPlaybackYet()
+    {
+        using var harness = new LimitHarness(EnabledConfig(threshold: 5));
+        await harness.RecordBadTranscodesAsync(AliceId, 5);
+
+        // No now-playing item: the client has requested the stream but not started it.
+        Assert.False((await harness.AssessAsync(Request())).IsAdmitted);
+    }
+
+    [Fact]
+    public async Task KeepsTheRefusalWhenTheClientPopupCannotBeDelivered()
+    {
+        // ClientMessageService does not catch every failure Jellyfin's WebSocket send can raise.
+        // One escaping here would reach the decorator's fail-open catch and admit the transcode.
+        using var harness = new LimitHarness(
+            EnabledConfig(threshold: 1),
+            messages: new ThrowingClientMessageService(TestSessions.Create("session-1", DeviceId, AliceId)));
+        await harness.RecordBadTranscodesAsync(AliceId, 5);
+
+        var decision = await harness.AssessAsync(Request());
+
+        Assert.False(decision.IsAdmitted);
+    }
+
+    [Fact]
+    public async Task CollapsesARetryBurstToOnePopupWithoutSofteningAnyRefusal()
+    {
+        var now = DateTimeOffset.UtcNow;
+        using var harness = new LimitHarness(EnabledConfig(threshold: 1), () => now);
+        await harness.RecordBadTranscodesAsync(AliceId, 5);
+
+        Assert.False((await harness.AssessAsync(Request())).IsAdmitted);
+        now = now.AddSeconds(1);
+        Assert.False((await harness.AssessAsync(Request())).IsAdmitted);
+        Assert.Single(harness.Messages.SentMessages);
+
+        // A lull, then a deliberate retry, gets its own popup.
+        now = now.AddSeconds(30);
+        Assert.False((await harness.AssessAsync(Request())).IsAdmitted);
+        Assert.Equal(2, harness.Messages.SentMessages.Count);
+    }
+
+    [Fact]
+    public async Task ReReadsTheCountOnceItsShortLivedCacheExpires()
+    {
+        var now = DateTimeOffset.UtcNow;
+        using var harness = new LimitHarness(EnabledConfig(threshold: 5), () => now);
+        await harness.RecordBadTranscodesAsync(AliceId, 4);
+
+        Assert.True((await harness.AssessAsync(Request())).IsAdmitted);
+
+        await harness.RecordBadTranscodesAsync(AliceId, 1);
+
+        // Still answering from the cached count.
+        Assert.True((await harness.AssessAsync(Request())).IsAdmitted);
+
+        now = now.AddSeconds(30);
+        Assert.False((await harness.AssessAsync(Request())).IsAdmitted);
+    }
+
+    private static PluginConfiguration EnabledConfig(int threshold) => new()
+    {
+        EnableTranscodeLimit = true,
+        TranscodeLimitThreshold = threshold,
+        LoginNagTimeWindow = "Week"
+    };
+
+    private static TranscodeLimitRequest Request(
+        Guid? userId = null,
+        TranscodeReason reasons = TranscodeReason.VideoCodecNotSupported,
+        bool isVideoRequest = true,
+        bool isLiveStream = false,
+        Guid? itemId = null)
+    {
+        return new TranscodeLimitRequest
+        {
+            IsVideoRequest = isVideoRequest,
+            TranscodeReasons = reasons,
+            IsLiveStream = isLiveStream,
+            DeviceId = DeviceId,
+            UserId = userId ?? AliceId,
+            ItemId = itemId ?? MovieId,
+            ItemName = "Movie"
+        };
+    }
+
+    private sealed class LimitHarness : IDisposable
+    {
+        private readonly TestEventStore _store = new();
+        private readonly SessionInfo _session = TestSessions.Create("session-1", DeviceId, AliceId);
+
+        public LimitHarness(
+            PluginConfiguration config,
+            Func<DateTimeOffset>? clock = null,
+            IClientMessageService? messages = null)
+        {
+            Messages = new RecordingClientMessageService();
+            Messages.AddSession(_session);
+
+            Guard = new TranscodeLimitGuard(
+                _store.Store,
+                messages ?? Messages,
+                NullLogger<TranscodeLimitGuard>.Instance,
+                () => config,
+                TimeSpan.FromSeconds(5),
+                TimeSpan.FromSeconds(3),
+                clock ?? (() => DateTimeOffset.UtcNow));
+        }
+
+        public RecordingClientMessageService Messages { get; }
+
+        public TranscodeLimitGuard Guard { get; }
+
+        public Task<TranscodeLimitDecision> AssessAsync(TranscodeLimitRequest request)
+            => Guard.AssessAsync(request, CancellationToken.None);
+
+        public Task RecordBadTranscodesAsync(Guid userId, int count, DateTime? timestamp = null, string client = "Jellyfin Web")
+            => _store.SeedBadTranscodesAsync(userId, count, timestamp, client);
+
+        /// <summary>
+        /// Puts the session into the state Jellyfin leaves it in once playback has been reported.
+        /// </summary>
+        /// <param name="itemId">The item the session is playing.</param>
+        public void SetNowPlaying(Guid itemId)
+        {
+            _session.NowPlayingItem = new BaseItemDto { Id = itemId, Name = "Movie" };
+        }
+
+        public void Dispose() => _store.Dispose();
+    }
+}


### PR DESCRIPTION
## What

Adds a second, higher threshold next to the login nag that makes its count enforceable. Nag at 5, stop at 10: once a user passes the limit, their next counted transcode is refused before FFmpeg starts and they get a configurable popup.

New **Transcode Limit** section on the config page, directly under Login Nag Settings, collapsed until enabled:

- **Block transcodes once the limit is reached** — off by default
- **Transcode Limit** — default 10
- **Blocked Title** / **Blocked Message** — supports `{{transcodes}}`, `{{timewindow}}`, `{{limit}}`
- **Sticky Messages**

## Why

The login nag can count a heavy transcoder's history but can only ever ask them nicely. This makes the same count enforceable without introducing a second policy to configure: the window, trigger reasons, and user/client exclusions are all the nag's, so an admin sets one policy and picks two points on it.

## How

Enforcement lives in `GuardedTranscodeManager` alongside the GPU guard, so the FFmpeg process is never created and Jellyfin returns a clean 403. The limit is settled first, so a refused job never spends a VRAM reservation.

## What is never refused

Only what the login nag counts. Direct play, bitrate-only transcodes, audio-only streams, excluded users, filtered clients, and Live TV when it is excluded all pass — a user over the limit can still watch anything their client plays without a bad transcode. A refusal records nothing, so it cannot push someone further over.

**A stream already playing is exempt.** Jellyfin starts a fresh FFmpeg job for a seek, and the event recorded for the current playback is what can push its owner over — so without this, the film that reached the limit would be the one cut off mid-scene, unresumable for the rest of the window. The limit stops what a user starts next, never what they are watching.

## Safety

- Off by default, and a threshold below 1 disables it rather than blocking everything. Upgrading cannot start failing anyone's playback.
- Every failure path allows the transcode. A limit that cannot be evaluated must not become an outage.
- Notification failure cannot reverse a refusal — an exception escaping the deny path would reach the decorator's fail-open catch and admit the transcode just refused. Covered by a regression test.

## Known trade-offs

- The count is cached for 5s to keep a client's retry storm off the event store's lock, so a user at the boundary can slip a small bounded number of extra transcodes through, and an edited threshold or filter applies within seconds rather than instantly. Documented in the README.
- Live TV detection is request-side (`IsInfiniteStream` / `LiveStreamId`) while the counter is item-side (`IsLiveTvItem`). A streaming request carries a media source, not a `BaseItemDto`, so the two cannot be the same test; the request-side one is deliberately the wider, since over-including only means not refusing something.

## Incidental

`TranscodeEventStore` becomes a DI singleton. `PlaybackMonitor` previously constructed its own, and a second instance reading in front of FFmpeg would have raced it over the same file with a separate lock.

## Testing

- `dotnet build --configuration Release` — clean, 0 warnings
- **232 tests pass** (up from 210). 22 new: the guard's allow/refuse paths, the decorator wiring, and config XML round-trip / back-compat defaults.
- Both regression tests were mutation-checked: reverting each fix makes exactly its test fail.
- `dotnet format whitespace` and `dotnet format style --severity warn` clean on both projects.
- Line coverage 68.5% → 70.5%; badge updated 69% → 71%.

Not yet run against a live Jellyfin instance — worth a smoke test before merge.
